### PR TITLE
fix($browser): CartoDB legend display (static/js/views/map-view.js)

### DIFF
--- a/src/sa_web/static/js/views/map-view.js
+++ b/src/sa_web/static/js/views/map-view.js
@@ -195,9 +195,6 @@ var legendToShow = '';
         var layer = self.layers[id];
         if (layer) {
           self.setLayerVisibility(layer, id, visible);
-            // .on('done', function(){
-            //   self.showLegend();
-            // });
         } else if (id === 'toggle-satellite') {
           // TODO: This is a hack! We should integrate this with the config
           // probably with a radio button in the legend!
@@ -258,13 +255,6 @@ var legendToShow = '';
             $('.cartodb-legend-stack').show();
           else
             $('.cartodb-legend-stack').hide();
-      }
-    },
-    showLegend: function() {
-      if(legendToShow.length > 0){
-        var layer = this.layers[legendToShow];
-        setLegendVisibility(layer, legendToShow, true);
-        legendToShow = '';
       }
     },
     reverseGeocodeMapCenter: _.debounce(function() {

--- a/src/sa_web/static/js/views/map-view.js
+++ b/src/sa_web/static/js/views/map-view.js
@@ -240,9 +240,8 @@ var legendToShow = '';
           if(visible)
           {
             visibleLegendIds.push(id);
-            /* Show only one legend at a time; remove any others */
-            $('.cartodb-legend, .wrapper').children().remove();
-            $('.cartodb-legend, .wrapper').append(layer.layers[0].legend.template);
+            /* Show only one legend at a time */
+            $('.cartodb-legend, .wrapper').html(layer.layers[0].legend.template);
           }
           else
           {
@@ -251,8 +250,7 @@ var legendToShow = '';
               //recursive call of setLegendVisibility would be better here
               legendToShow = visibleLegendIds[visibleLegendIds.length - 1];
               var lastLayer = this.layers[legendToShow];
-              $('.cartodb-legend, .wrapper').children().remove();
-              $('.cartodb-legend, .wrapper').append(lastLayer.layers[0].legend.template);
+              $('.cartodb-legend, .wrapper').html(lastLayer.layers[0].legend.template);
             }
           }
 


### PR DESCRIPTION
Add setLegendVisibility function

Works with any number of carto legends; only displays one legend at a time. Ultimately, no upfront prep in carto editor--nor additional config--was required.
