### PR TITLE
Add pboakland admin-only form fields

### DIFF
--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -334,6 +334,7 @@ place:
   common_form_elements:
     - name: venue
       type: dropdown
+      optional: true
       admin_only: true
       admin_msg: _((For administrator use only))
       prompt: _(Venue name:)

--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -209,6 +209,8 @@ activity:
   # Place Types
 
 place:
+  administrators:
+    - goldpbear
   adding_supported: true
   add_button_label: _(Share your idea!)
   # Labels for the buttons that toggle the map and list views
@@ -327,8 +329,22 @@ place:
           display_prompt: _( )
           placeholder: _( )
           optional: true
+
   # define form elements that appear on every form here
   common_form_elements:
+    - name: venue
+      type: dropdown
+      admin_only: true
+      admin_msg: _((For administrator use only))
+      prompt: _(Venue name:)
+      display_prompt: _(Submitted at:)
+      content:
+        - label: _(Asian Cultural Center)
+          value: asian_cultural_center
+        - label: _(Williams Chapel)
+          value: williams_chapel
+        - label: _(Other)
+          value: other
     - name: my_image
       type: file
       prompt: _(Image)

--- a/src/flavors/pboakland/jstemplates/place-detail.html
+++ b/src/flavors/pboakland/jstemplates/place-detail.html
@@ -1,0 +1,127 @@
+        {{> place-detail-story-bar }}
+
+        {{> place-detail-promotion-bar }}
+
+        <header class="place-header clearfix">
+          <h1 class="place-header-title {{#if story}}is-visuallyhidden{{/if}}">
+            {{>location-string location }}
+            {{#if fullTitle}}
+              {{fullTitle}}
+            {{else}}
+              {{#if title}}
+                {{title}}
+              {{else}}
+                {{name}}
+              {{/if}}
+            {{/if}}
+          </h1>
+          <span class="place-submission-details">
+            {{#_}}<strong class="point-submitter">
+              {{#if submitter.avatar_url }}
+                <img src="{{ submitter.avatar_url }}" class="avatar" />
+              {{^}}
+                <img src="{{ STATIC_URL }}css/images/user-50.png" class="avatar" />
+              {{/if}}
+              {{#if submitter.name }}
+                {{ submitter.name }}
+              {{^}}
+                {{#if submitter_name }}
+                  {{ submitter_name }}
+                {{^}}
+                  {{ anonymous_name }}
+                {{/if}}
+              {{/if}}
+            </strong> {{ action_text }} this {{ place_type_label location_type}}{{#if venueLabel}} at <strong>{{venueLabel}}</strong>{{/if}}
+
+            {{#if region}}
+              in {{ region }}
+            {{/if}}{{/_}}
+
+            <time datetime="{{ created_datetime }}" class="response-date"><a href="/{{ datasetSlug }}/{{ id }}">{{ fromnow created_datetime }}</a></time>
+
+            <span class="survey-count">{{ survey_count }} {{ survey_label_by_count }}</span>
+
+            {{^if survey_config}}
+              <a rel="internal" href="/{{ datasetSlug }}/{{ id }}" class="view-on-map-btn btn btn-small">{{#_}}View On Map{{/_}}</a>
+            {{/if}}
+
+          </span>
+        </header>
+
+        <section class="place-items">
+          {{# attachments }}
+            <div class="place-item place-item-attachment place-attachment-{{ name }}">
+              <img src="{{ file }}" class="place-value place-value-{{ name }}" alt="{{ name }}" />
+            </div>
+          {{/ attachments }}
+
+          {{#each_place_item "submitter_name" "name" "location_type" "fullTitle" "title" "name" "venue" "demographics-header" "demographics-description"}}
+            <div class="place-item place-item-{{ name }}">
+              <span class="place-label place-label-{{ name }}">{{ prompt }}</span>
+
+              {{#is type "datetime"}}
+                <p class="place-value place-value-{{ name }}">{{nlToBr content}}</p>
+              {{/is}}
+              
+              {{#is type "text"}}
+                <p class="place-value place-value-{{ name }}">{{nlToBr content}}</p>                
+              {{/is}}
+
+              {{#is type "textarea"}}
+                <p class="place-value place-value-{{ name }}">{{nlToBr content}}</p>
+              {{/is}}
+
+              {{#is type "radio_big_buttons"}}
+                <ul>
+                  {{#each content}}
+                    {{#if selected}}
+                      <li class="multi-select-response place-value">{{ label }} </li>
+                    {{/if}}
+                  {{/each}}
+                </ul>
+              {{/is}}
+
+              {{#is type "checkbox_big_buttons"}}
+                <ul>
+                  {{#each content}}
+                    {{#if selected}}
+                      <li class="multi-select-response place-value">{{ label }} </li>
+                    {{/if}}
+                  {{/each}}
+                </ul>
+              {{/is}}
+
+              {{#is type "binary_toggle"}}
+                <ul>
+                  <li class="place-value">
+                    {{#if content.selected}}
+                      {{ content.selectedLabel }}
+                    {{else}}
+                      {{ content.unselectedLabel }}
+                    {{/if}}
+                  </li>
+                </ul>
+              {{/is}}
+
+              {{#is type "dropdown"}}
+                {{#each content}}
+                  {{#if selected}}
+                    <ul>
+                      <li class="place-value">
+                        {{nlToBr label}}
+                      </li>
+                    </ul>
+                  {{/if}}
+                {{/each}}
+              {{/is}}
+            </div>
+          {{/each_place_item }}
+          <div class="clearfix"></div>
+        </section>
+
+        {{#if survey_config}}
+
+        <section class="survey" id="survey"></section>
+        {{/if}}
+
+        {{> place-detail-story-bar-tagline }}

--- a/src/flavors/pboakland/jstemplates/place-form.html
+++ b/src/flavors/pboakland/jstemplates/place-form.html
@@ -1,0 +1,125 @@
+<!-- <h4 class="">{{ placeConfig.title }}</h4> -->
+<div class="drag-marker-instructions">
+  <table>
+    <tr id="drag-marker-content">
+<!--       <td>
+        <div class="btn btn-inline btn-geolocate">
+          <img src="/static/css/images/locate-me.png" />
+          {{#_}}Set my location{{/_}}
+        </div> 
+      </td> -->
+      <td>
+        <p class="drag-text">{{#_}}First, drag the map to set your location{{/_}}</p>
+      </td>
+    </tr>
+    <tr id="geolocating-msg" class="is-visuallyhidden">
+      <td>{{#_}}Setting your location...{{/_}}</td>
+    </tr>
+  </table>
+</div>
+<p class="drag-marker-warning is-visuallyhidden">{{#_}}It looks like you didn't set your location yet. Please drag the map to your location.{{/_}}</p>
+
+<p class="form-field">{{ placeConfig.help_text }}</p>
+
+<form id="place-form" class="place-form clearfix">
+
+  <fieldset>
+    <input type="hidden" name="visible" value="on">
+    <input type="hidden" name="user_token" value="{{{ user_token }}}">
+
+    <!-- TODO We need user data in the template to know whether a user
+         is already logged in.
+       -->
+
+    <!-- container for selected category -->
+    {{#if isCategorySelected}}
+      {{#unless isSingleCategory}}
+        <div id="selected-category">
+          <input type="radio" id="selected-category-placeholder" class="category-btn" name={{ selectedCategoryConfig.name }} value={{ selectedCategoryConfig.value }} checked>
+          <table class="category-btn-container">
+            <tr>
+              <td class="category-icon"><img src={{ selectedCategoryConfig.icon_url }} /></td>
+              <td class="category-label">{{ selectedCategoryConfig.label }}</td>
+              <td class="category-menu-hamburger"></td>
+            </tr>
+          </table>
+        </div>
+      {{/unless}}
+    {{/if}}
+
+    <!-- place buttons for dynamic form categories -->
+    {{#unless isSingleCategory}}
+      <div id="category-btns">
+        {{#each placeConfig.place_detail}}
+          {{#if this.includeOnForm}}
+            <input type="radio" id={{ category }} class="category-btn clickable">
+            <table class="category-btn-container">
+              <tr>
+                <td class="category-icon"><img src={{icon_url}} /></td>
+                <td class="category-label">{{ label }}</td>
+              </tr>
+            </table>
+          {{/if}}
+        {{/each}}
+      </div>
+      <div style="clear:both"></div>
+      <br>
+    {{/unless}}
+
+    <!-- generate content for selected category -->
+    {{#each selectedCategoryConfig.fields}}
+      {{#if admin_only}}
+        {{#if ../../isAdmin}}
+          <div class="{{ type }} form-field is-admin-field">
+            {{#if horizontal_rule}}
+              <hr />
+            {{/if}}
+
+            {{#if prompt}}
+              <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }} {{admin_msg}}</label>
+            {{/if}}
+
+            {{> place-form-field-types }}
+          </div>
+        {{/if}}
+      {{else}}
+        <div class="{{ type }} form-field">
+          {{#if horizontal_rule}}
+            <hr />
+          {{/if}}
+
+          {{#if prompt}}
+            <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
+          {{/if}}
+
+          {{> place-form-field-types }}
+        </div>
+      {{/if}}
+    {{/each}}
+
+    <!-- begin fields that are included in every form type by default -->
+    {{#if isCategorySelected}}
+      <div id="common-form-elements">
+        {{#each placeConfig.common_form_elements }}
+          {{#if admin_only}}
+            {{#if ../../isAdmin}}
+              <div class="{{ this.type }} form-field is-admin-field">
+                <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }} {{admin_msg}}</label>
+                {{> place-form-field-types}}
+              </div>
+            {{/if}}
+          {{else}}
+            <div class="{{ this.type }} form-field">
+              <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>          
+              {{> place-form-field-types}}
+            </div>
+          {{/if}}
+          
+        {{/each}}
+      </div>
+    {{/if}}
+    <!-- end common field types -->
+
+    <div class="form-spinner"></div>
+</form>
+  

--- a/src/flavors/pboakland/static/css/custom.css
+++ b/src/flavors/pboakland/static/css/custom.css
@@ -171,3 +171,10 @@ label {
     }
 
 }
+
+/* admin-only form fields */
+.is-admin-field {
+    background-color: rgba(250, 128, 114, 0.48);
+    padding: 5px;
+    border-radius: 4px;
+}

--- a/src/flavors/pboakland/static/js/views/place-detail-view.js
+++ b/src/flavors/pboakland/static/js/views/place-detail-view.js
@@ -1,0 +1,113 @@
+/*globals Backbone _ jQuery Handlebars */
+
+var Shareabouts = Shareabouts || {};
+
+(function(S, $, console){
+  S.PlaceDetailView = Backbone.View.extend({
+    events: {
+      'click .place-story-bar .btn-previous-story-nav': 'onClickStoryPrevious',
+      'click .place-story-bar .btn-next-story-nav': 'onClickStoryNext'
+    },
+    initialize: function() {
+      var self = this;
+
+      this.surveyType = this.options.surveyConfig.submission_type;
+      this.supportType = this.options.supportConfig.submission_type;
+
+      this.model.on('change', this.onChange, this);
+
+      // Make sure the submission collections are set
+      this.model.submissionSets[this.surveyType] = this.model.submissionSets[this.surveyType] ||
+        new S.SubmissionCollection(null, {
+          submissionType: this.surveyType,
+          placeModel: this.model
+        });
+
+      this.model.submissionSets[this.supportType] = this.model.submissionSets[this.supportType] ||
+        new S.SubmissionCollection(null, {
+          submissionType: this.supportType,
+          placeModel: this.model
+        });
+
+      this.surveyView = new S.SurveyView({
+        collection: this.model.submissionSets[this.surveyType],
+        surveyConfig: this.options.surveyConfig,
+        userToken: this.options.userToken,
+        datasetId: self.options.datasetId
+      });
+
+      this.supportView = new S.SupportView({
+        collection: this.model.submissionSets[this.supportType],
+        supportConfig: this.options.supportConfig,
+        userToken: this.options.userToken,
+        datasetId: self.options.datasetId
+      });
+
+      this.$el.on('click', '.share-link a', function(evt){
+
+        // HACK! Each action should have its own view and bind its own events.
+        var shareTo = this.getAttribute('data-shareto');
+
+        S.Util.log('USER', 'place', shareTo, self.model.getLoggingDetails());
+      });
+    },
+
+    onClickStoryPrevious: function() {
+      this.options.router.navigate(this.model.attributes.story.previous, {trigger: true});
+    },
+
+    onClickStoryNext: function() {
+      this.options.router.navigate(this.model.attributes.story.next, {trigger: true});
+    },
+
+    render: function() {
+      var self = this,
+          data = _.extend({
+            place_config: this.options.placeConfig,
+            survey_config: this.options.surveyConfig,
+            url: this.options.url
+          }, this.model.toJSON());
+
+      // add venue label
+      if (data.venue) {
+        var venueContent = _.find(this.options.placeConfig.common_form_elements, function(item) {
+          return item.name === "venue"
+        }).content;
+        data.venueLabel = _.find(venueContent, function(item) {
+          return item.value = data.venue;
+        }).label;        
+      }
+      
+      data.submitter_name = this.model.get('submitter_name') ||
+        this.options.placeConfig.anonymous_name;
+
+      // Augment the template data with the attachments list
+      data.attachments = this.model.attachmentCollection.toJSON();
+
+      this.$el.html(Handlebars.templates['place-detail'](data));
+
+      // Render the view as-is (collection may have content already)
+      this.$('.survey').html(this.surveyView.render().$el);
+      // Fetch for submissions and automatically update the element
+      this.model.submissionSets[this.surveyType].fetchAllPages();
+
+      this.$('.support').html(this.supportView.render().$el);
+      // Fetch for submissions and automatically update the element
+      this.model.submissionSets[this.supportType].fetchAllPages();
+
+      this.delegateEvents();
+
+      $("#content article").animate({ scrollTop: 0 }, "fast");
+      
+      return this;
+    },
+
+    remove: function() {
+      // Nothing yet
+    },
+
+    onChange: function() {
+      this.render();
+    }
+  });
+}(Shareabouts, jQuery, Shareabouts.Util.console));

--- a/src/flavors/pboakland/static/js/views/place-form-view.js
+++ b/src/flavors/pboakland/static/js/views/place-form-view.js
@@ -1,0 +1,314 @@
+/*globals _ Spinner Handlebars Backbone jQuery Gatekeeper */
+
+var Shareabouts = Shareabouts || {};
+
+(function(S, $, console){
+  S.PlaceFormView = Backbone.View.extend({
+    events: {
+      'submit form': 'onSubmit',
+      'change input[type="file"]': 'onInputFileChange',
+      'click .category-btn.clickable': 'onCategoryChange',
+      'click .category-menu-hamburger': 'onExpandCategories',
+      'click input[data-input-type="binary_toggle"]': 'onBinaryToggle',
+      'click .btn-geolocate': 'onClickGeolocate'
+    },
+    initialize: function(){
+      var self = this;
+       
+      this.resetFormState();
+      this.placeDetail = this.options.placeConfig.place_detail;
+
+      S.TemplateHelpers.overridePlaceTypeConfig(this.options.placeConfig.items,
+        this.options.defaultPlaceTypeName);
+      S.TemplateHelpers.insertInputTypeFlags(this.options.placeConfig.items);
+    },
+    resetFormState: function() {
+      this.formState = {
+        selectedCategoryConfig: {
+          fields: []
+        },
+        isSingleCategory: false,
+        attachmentData: null,
+        commonFormElements: this.options.placeConfig.common_form_elements || {}
+      }
+    },
+    render: function(isCategorySelected) {
+      var isAdmin = false,
+      self = this,
+      placesToIncludeOnForm = _.filter(this.placeDetail, function(place) { 
+        return place.includeOnForm; 
+      });
+
+      if (S.bootstrapped.currentUser &&
+        _.contains(this.options.placeConfig.administrators, S.bootstrapped.currentUser.username)) {
+        isAdmin = true;
+      }
+
+      // if there is only one place to include on form, skip category selection page
+      if (placesToIncludeOnForm.length === 1) {
+        this.formState.isSingleCategory = true;
+        isCategorySelected = true;
+        this.formState.selectedCategoryConfig = placesToIncludeOnForm[0];
+      }
+
+      this.checkAutocomplete();
+
+      var data = _.extend({
+        isCategorySelected: isCategorySelected,
+        isAdmin: isAdmin,
+        placeConfig: this.options.placeConfig,
+        selectedCategoryConfig: this.formState.selectedCategoryConfig,
+        user_token: this.options.userToken,
+        current_user: S.currentUser,
+        isSingleCategory: this.formState.isSingleCategory
+      }, S.stickyFieldValues);
+
+      this.$el.html(Handlebars.templates['place-form'](data));
+
+      if (this.center) $(".drag-marker-instructions").addClass("is-visuallyhidden");
+
+      $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
+
+      return this;
+    },
+    // called from the app view
+    postRender: function() {
+      // NOTE: the extra call to initialize the date-time picker is necessary here,
+      // because on a single-category form the call to initialize in the render() method
+      // above will fail, since the form content will not yet have been inserted into
+      // the DOM by the app view
+      if (this.formState.isSingleCategory) {
+        $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
+      }
+
+      this.bindCategoryListeners();
+    },
+    bindCategoryListeners: function() {
+      $(".category-btn-container").off().on("click", function(evt) {
+        $(this).prev().trigger("click");
+      });
+    },
+    checkAutocomplete: function() {
+      var self = this,
+      storedValue;
+
+      this.formState.selectedCategoryConfig.fields.forEach(function(field, i) {
+        storedValue = S.Util.getAutocompleteValue(field.name);
+        self.formState.selectedCategoryConfig.fields[i].autocompleteValue = storedValue || null;
+      });
+      this.formState.commonFormElements.forEach(function(field, i) {
+        storedValue = S.Util.getAutocompleteValue(field.name);
+        self.formState.commonFormElements[i].autocompleteValue = storedValue || null;
+      });
+    },
+    remove: function() {
+      this.unbind();
+    },
+    onError: function(model, res) {
+      // TODO handle model errors!
+      console.log('oh no errors!!', model, res);
+    },
+    // This is called from the app view
+    setLatLng: function(latLng) {
+      this.center = latLng;
+      this.$('.drag-marker-instructions, .drag-marker-warning').addClass('is-visuallyhidden');
+    },
+    setLocation: function(location) {
+      this.location = location;
+    },
+    getAttrs: function() {
+      var self = this,
+          attrs = {},
+          locationAttr = this.options.placeConfig.location_item_name,
+          $form = this.$('form');
+
+      // Get values from the form
+      attrs = S.Util.getAttrs($form);
+
+      // get values off of binary toggle buttons that have not been toggled
+      $.each($("input[data-input-type='binary_toggle']:not(:checked)"), function() {
+        attrs[$(this).attr("name")] = $(this).val();
+      });
+
+      _.each(attrs, function(value, key) {
+        var itemConfig = _.find(
+          self.formState.selectedCategoryConfig.fields
+            .concat(self.formState.commonFormElements), function(field) { 
+              return field.name === key;
+            }) || {};
+        if (itemConfig.autocomplete) {
+          S.Util.saveAutocompleteValue(key, value, 30);
+        }
+      });
+
+      // Get the location attributes from the map
+      attrs.geometry = {
+        type: 'Point',
+        coordinates: [this.center.lng, this.center.lat]
+      };
+
+      if (this.location && locationAttr) {
+        attrs[locationAttr] = this.location;
+      }
+
+      return attrs;
+    },
+    onCategoryChange: function(evt) {
+      var self = this,
+          animationDelay = 200;
+
+      this.formState.selectedCategoryConfig = _.find(this.placeDetail, function(place) {
+        return place.category == $(evt.target).attr('id');
+      });
+
+      this.render(true);
+      $("#" + $(evt.target).attr("id"))
+        .prop("checked", true)
+        .next()
+        .addClass("category-btn-container-selected");
+      $("#selected-category").hide().show(animationDelay);
+      $("#category-btns").animate( { height: "hide" }, animationDelay );
+      if (this.center) {
+        this.$('.drag-marker-instructions, .drag-marker-warning').addClass('is-visuallyhidden');
+      }
+    },
+    onExpandCategories: function(evt) {
+      var animationDelay = 200;
+      $("#selected-category").hide(animationDelay);
+      $("#category-btns").animate( { height: "show" }, animationDelay ); 
+      this.bindCategoryListeners();
+    },
+    onClickGeolocate: function(evt) {
+      var self = this;
+      evt.preventDefault();
+      var ll = this.options.appView.mapView.map.getBounds().toBBoxString();
+      S.Util.log('USER', 'map', 'geolocate', ll, this.options.appView.mapView.map.getZoom());
+      $("#drag-marker-content").addClass("is-visuallyhidden");
+      $("#geolocating-msg").removeClass("is-visuallyhidden");
+
+      this.options.appView.mapView.map.locate()
+        .on("locationfound", function() { 
+          self.center = self.options.appView.mapView.map.getCenter();
+          $("#spotlight-place-mask").remove();
+          $("#drag-marker-content").addClass("is-visuallyhidden");
+        })
+        .on("locationerror", function() {
+          $("#drag-marker-content").removeClass("is-visuallyhidden");
+          $("#geolocating-msg").addClass("is-visuallyhidden");
+        });
+    },
+    onInputFileChange: function(evt) {
+      var self = this,
+          file,
+          attachment;
+
+      if(evt.target.files && evt.target.files.length) {
+        file = evt.target.files[0];
+
+        this.$('.fileinput-name').text(file.name);
+        S.Util.fileToCanvas(file, function(canvas) {
+          canvas.toBlob(function(blob) {
+            self.formState.attachmentData = {
+              name: $(evt.target).attr('name'),
+              blob: blob,
+              file: canvas.toDataURL('image/jpeg')
+            }
+          }, 'image/jpeg');
+        }, {
+          // TODO: make configurable
+          maxWidth: 800,
+          maxHeight: 800,
+          canvas: true
+        });
+      }
+    },
+    onBinaryToggle: function(evt) {
+      var self = this,
+      targetButton = $(evt.target).attr("id"),
+      oldValue = $(evt.target).val(),
+      altData = _.find(this.formState.selectedCategoryConfig.fields
+        .concat(self.formState.commonFormElements), function(item) { 
+          return item.name === targetButton; 
+        }),
+      altContent = _.find(altData.content, function(item) { return item.value != oldValue; });
+
+      // set new value and label
+      $(evt.target).val(altContent.value);
+      $(evt.target).next("label").html(altContent.label);
+    },
+    closePanel: function() {
+      this.center = null;
+      this.resetFormState();
+    },
+    onSubmit: Gatekeeper.onValidSubmit(function(evt) {
+      // Make sure that the center point has been set after the form was
+      // rendered. If not, this is a good indication that the user neglected
+      // to move the map to set it in the correct location.
+      if (!this.center) {
+        this.$('.drag-marker-instructions').addClass('is-visuallyhidden');
+        this.$('.drag-marker-warning').removeClass('is-visuallyhidden');
+
+        // Scroll to the top of the panel if desktop
+        this.$el.parent('article').scrollTop(0);
+        // Scroll to the top of the window, if mobile
+        window.scrollTo(0, 0);
+        return;
+      }
+
+      var self = this,
+          router = this.options.router,
+          collection = this.collection[self.formState.selectedCategoryConfig.dataset],
+          model,
+          // Should not include any files
+          attrs = this.getAttrs(),
+          $button = this.$('[name="save-place-btn"]'),
+          spinner, $fileInputs;
+      evt.preventDefault();
+
+      collection.add({"location_type": this.formState.selectedCategoryConfig.category});
+      model = collection.at(collection.length - 1);
+
+      model.set("datasetSlug", _.find(this.options.mapConfig.layers, function(layer) { 
+        return self.formState.selectedCategoryConfig.dataset == layer.id;
+      }).slug);
+      model.set("datasetId", self.formState.selectedCategoryConfig.dataset);
+      
+      // if an attachment has been added...
+      if (self.formState.attachmentData) {
+        var attachment = model.attachmentCollection.find(function(attachmentModel) {
+          return attachmentModel.get('name') === self.formState.attachmentData.name;
+        });
+
+        if (_.isUndefined(attachment)) {
+          model.attachmentCollection.add(self.formState.attachmentData);
+        } else {
+          attachment.set(self.formState.attachmentData);
+        }
+      }
+
+      $button.attr('disabled', 'disabled');
+      spinner = new Spinner(S.smallSpinnerOptions).spin(self.$('.form-spinner')[0]);
+
+      S.Util.log('USER', 'new-place', 'submit-place-btn-click');
+
+      S.Util.setStickyFields(attrs, S.Config.survey.items, S.Config.place.items);
+
+      // Save and redirect
+      model.save(attrs, {
+        success: function() {
+          S.Util.log('USER', 'new-place', 'successfully-add-place');
+          router.navigate('/'+ model.get('datasetSlug') + '/' + model.id, {trigger: true});
+        },
+        error: function() {
+          S.Util.log('USER', 'new-place', 'fail-to-add-place');
+        },
+        complete: function() {
+          $button.removeAttr('disabled');
+          spinner.stop();
+          self.resetFormState();
+        },
+        wait: true
+      });
+    })
+  });
+}(Shareabouts, jQuery, Shareabouts.Util.console));


### PR DESCRIPTION
Addresses: #576.

This PR makes it possible to declare form fields as admin-only. Admin-only fields will only be visible to logged-in users listed in the `administrators` section of the `place` section of the config. Note that all changes in this PR are contained inside `pboakland` flavor files. I thought this would be better for now, since we may add similar functionality to the base code via the editor/admin panel.

To add administrators, list their social media handles under the `administrators` key:

```
place:
  administrators:
    - goldpbear
    - etc.
  adding_supported: true
  add_button_label: _(Share your idea!)
  ...
```

To declare a form field as admin-only, add an `admin_only: true` flag in the form field's section in the config. You can also add an optional message that appears beside admin-only prompts, like so: `admin_msg: _((For administrator use only))`.

Full example:
```
- name: venue
  type: dropdown
  admin_only: true
  admin_msg: _((For administrator use only))
  prompt: _(Venue name:)
  ...
```

Change the `.is-admin-field` class in `custom.css` to alter the way admin-only form fields appear.