### PR TITLE
Landing page enhancements

### DIFF
--- a/src/base/jstemplates/add-places.html
+++ b/src/base/jstemplates/add-places.html
@@ -1,6 +1,15 @@
 {{# adding_supported }}
-  <div id="add-place-btn-container" class="pos-top-right">
-    <a href="#" id="add-place" class="btn btn-block btn-primary btn-large"><span>{{ add_button_label }}</span></a>
-  </div>
+	<div id="main-btns-container" class="pos-top-right">
+		{{#if add_button_label}}
+		  <span id="add-place-btn-container">
+		    <a href="#" id="add-place" class="btn btn-block btn-primary btn-large"><span>{{ add_button_label }}</span></a>
+		  </span>
+		{{/if}}
+		{{#if story_button_label}}
+		  <span id="story-btn-container">
+		    <a href="/page/stories" rel="internal" id="nav-stories" class="btn btn-block btn-primary btn-large"><span>{{ story_button_label }}</span></a>
+		  </span>
+		{{/if}}
+	</div>
   <span id="centerpoint"><span class="shadow"></span><span class="x"></span><span class="marker"></span></span>
 {{/ adding_supported }}

--- a/src/base/jstemplates/add-places.html
+++ b/src/base/jstemplates/add-places.html
@@ -11,5 +11,4 @@
 		  </span>
 		{{/if}}
 	</div>
-  <span id="centerpoint"><span class="shadow"></span><span class="x"></span><span class="marker"></span></span>
 {{/ adding_supported }}

--- a/src/base/jstemplates/centerpoint.html
+++ b/src/base/jstemplates/centerpoint.html
@@ -1,0 +1,1 @@
+<span id="centerpoint"><span class="shadow"></span><span class="x"></span><span class="marker"></span></span>

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -129,6 +129,9 @@ var Shareabouts = Shareabouts || {};
         startPageConfig = S.Util.findPageConfig(options.pagesConfig, {start_page: true});
 
         if (startPageConfig && startPageConfig.slug) {
+          // if we route to a start page, add an additional body class
+          // so we can control start page height
+          $("body").addClass("start-page-visible");
           this.navigate('page/' + startPageConfig.slug, {trigger: true});
         }
       }

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -129,9 +129,6 @@ var Shareabouts = Shareabouts || {};
         startPageConfig = S.Util.findPageConfig(options.pagesConfig, {start_page: true});
 
         if (startPageConfig && startPageConfig.slug) {
-          // if we route to a start page, add an additional body class
-          // so we can control start page height
-          $("body").addClass("start-page-visible");
           this.navigate('page/' + startPageConfig.slug, {trigger: true});
         }
       }

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -79,6 +79,8 @@ var Shareabouts = Shareabouts || {};
             url,
             isLinkToPlace = false;
 
+        $("body").removeClass("start-page-visible");
+
         _.each(self.options.datasetConfigs.places, function(dataset) {
           if (href.indexOf('/' + dataset.slug) === 0) isLinkToPlace = true;
         });
@@ -458,7 +460,7 @@ var Shareabouts = Shareabouts || {};
         }
         $body.addClass(newBodyClasses[i]);
       }
-    },
+    }, 
     hasBodyClass: function(className) {
       return $('body').hasClass(className);
     },

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -448,7 +448,7 @@ var Shareabouts = Shareabouts || {};
 
     },
     onClickMaximizeBtn: function(evt) {
-      this.setBodyClass("content-expanded");
+      this.setBodyClass("content-expanded", "content-visible");
       $(".maximize-btn, .minimize-btn").toggle();
     },
     onClickMinimizeBtn: function(evt) {

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -111,7 +111,9 @@ var Shareabouts = Shareabouts || {};
       }, this);
 
       // Only append the tools to add places (if supported)
-      $('#map-container').append(Handlebars.templates['add-places'](this.options.placeConfig));
+      // NOTE: append after the #map-container div (rather than inside of it)
+      // in order to support bottom-clinging tools that are always visible
+      $('#map-container').after(Handlebars.templates['add-places'](this.options.placeConfig));
 
       this.pagesNavView = (new S.PagesNavView({
               el: '#pages-nav-container',
@@ -931,7 +933,7 @@ var Shareabouts = Shareabouts || {};
 
       $(S).trigger('panelshow', [this.options.router, Backbone.history.getFragment()]);
 
-      $("#add-place-btn-container").attr("class", "pos-top-left");
+      $("#main-btns-container").attr("class", "pos-top-left");
 
       S.Util.log('APP', 'panel-state', 'open');
     },
@@ -960,7 +962,7 @@ var Shareabouts = Shareabouts || {};
       this.setBodyClass();
       map.invalidateSize({ animate:true, pan:true });
 
-      $("#add-place-btn-container").attr("class", "pos-top-right");
+      $("#main-btns-container").attr("class", "pos-top-right");
 
       S.Util.log('APP', 'panel-state', 'closed');
       $("#spotlight-place-mask").remove();

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -21,7 +21,9 @@ var Shareabouts = Shareabouts || {};
   S.AppView = Backbone.View.extend({
     events: {
       'click #add-place': 'onClickAddPlaceBtn',
-      'click .close-btn': 'onClickClosePanelBtn'
+      'click .close-btn': 'onClickClosePanelBtn',
+      'click .maximize-btn': 'onClickMaximizeBtn',
+      'click .minimize-btn': 'onClickMinimizeBtn'
     },
     initialize: function(){
       var self = this,
@@ -79,8 +81,6 @@ var Shareabouts = Shareabouts || {};
             url,
             isLinkToPlace = false;
 
-        $("body").removeClass("start-page-visible");
-
         _.each(self.options.datasetConfigs.places, function(dataset) {
           if (href.indexOf('/' + dataset.slug) === 0) isLinkToPlace = true;
         });
@@ -113,8 +113,9 @@ var Shareabouts = Shareabouts || {};
       }, this);
 
       // Only append the tools to add places (if supported)
-      // NOTE: append after the #map-container div (rather than inside of it)
-      // in order to support bottom-clinging tools that are always visible
+      $('#map-container').append(Handlebars.templates['centerpoint']());
+      // NOTE: append add place/story buttons after the #map-container 
+      // div (rather than inside of it) in order to support bottom-clinging buttons
       $('#map-container').after(Handlebars.templates['add-places'](this.options.placeConfig));
 
       this.pagesNavView = (new S.PagesNavView({
@@ -388,7 +389,7 @@ var Shareabouts = Shareabouts || {};
     },
     onMapZoomEnd: function(evt) {
       if (this.hasBodyClass('content-visible') === true && !this.isProgrammaticZoom) {
-        $("#spotlight-place-mask").remove();
+        this.hideSpotlightMask();
       }
       this.isProgrammaticZoom = false;
     },
@@ -413,7 +414,7 @@ var Shareabouts = Shareabouts || {};
     },
     onMapDragEnd: function(evt) {
       if (this.hasBodyClass('content-visible') === true) {
-        $("#spotlight-place-mask").remove();
+        this.hideSpotlightMask();
       }
       this.setPlaceFormViewLatLng(this.mapView.map.getCenter());
     },
@@ -428,9 +429,12 @@ var Shareabouts = Shareabouts || {};
         this.placeFormView.closePanel();
       }
 
+      $(".maximize-btn").show();
+      $(".minimize-btn").hide();
+
       S.Util.log('USER', 'panel', 'close-btn-click');
       // remove map mask if the user closes the side panel
-      $("#spotlight-place-mask").remove();
+      this.hideSpotlightMask();
       if (this.mapView.locationTypeFilter) {
         this.options.router.navigate('filter/' + this.mapView.locationTypeFilter, {trigger: true});
       } else {
@@ -443,8 +447,16 @@ var Shareabouts = Shareabouts || {};
       }
 
     },
+    onClickMaximizeBtn: function(evt) {
+      this.setBodyClass("content-expanded");
+      $(".maximize-btn, .minimize-btn").toggle();
+    },
+    onClickMinimizeBtn: function(evt) {
+      this.setBodyClass("content-visible");
+      $(".maximize-btn, .minimize-btn").toggle();
+    },
     setBodyClass: function(/* newBodyClasses */) {
-      var bodyClasses = ['content-visible', 'place-form-visible'],
+      var bodyClasses = ['content-visible', 'place-form-visible', 'page-visible', 'content-expanded'],
           newBodyClasses = Array.prototype.slice.call(arguments, 0),
           i, $body = $('body');
 
@@ -570,6 +582,9 @@ var Shareabouts = Shareabouts || {};
         mapConfig: this.options.mapConfig
       })).render();
 
+      $(".maximize-btn").show();
+      $(".minimize-btn").hide();
+
       this.showNewPin();
       this.setBodyClass('content-visible', 'place-form-visible');
     },
@@ -626,6 +641,9 @@ var Shareabouts = Shareabouts || {};
           layout = S.Util.getPageLayout(),
           onLandmarkFound, onLandmarkNotFound, modelId;
 
+      $(".maximize-btn").show();
+      $(".minimize-btn").hide();
+
       onLandmarkFound = function(model, response, newOptions) {
         var map = self.mapView.map,
             layer, center, landmarkDetailView, $responseToScrollTo;
@@ -672,13 +690,13 @@ var Shareabouts = Shareabouts || {};
             }
           }
         }
-        self.addSpotlightMask();
+        self.showSpotlightMask();
 
         // Focus the one we're looking
         model.trigger('focus');
 
         if (model.get("story")) {
-          if (!model.get("story").spotlight) $("#spotlight-place-mask").remove();
+          if (!model.get("story").spotlight) self.hideSpotlightMask();
           self.isStoryActive = true;
           self.setStoryLayerVisibility(model);
         } else if (self.isStoryActive) {
@@ -776,6 +794,9 @@ var Shareabouts = Shareabouts || {};
           datasetId = _.find(self.options.mapConfig.layers, function(layer) { return layer.slug == datasetSlug }).id,
           onPlaceFound, onPlaceNotFound, modelId;
 
+      $(".maximize-btn").show();
+      $(".minimize-btn").hide();
+
       onPlaceFound = function(model) {
         var map = self.mapView.map,
             layer, center, placeDetailView, $responseToScrollTo;
@@ -832,7 +853,7 @@ var Shareabouts = Shareabouts || {};
             }
           }
         }
-        self.addSpotlightMask();
+        self.showSpotlightMask();
 
         if (responseId) {
           // get the element based on the id
@@ -854,7 +875,7 @@ var Shareabouts = Shareabouts || {};
         model.trigger('focus');
 
         if (model.get("story")) {
-          if (!model.get("story").spotlight) $("#spotlight-place-mask").remove();
+          if (!model.get("story").spotlight) self.hideSpotlightMask();
           self.isStoryActive = true;
           self.setStoryLayerVisibility(model);
         } else if (self.isStoryActive) {
@@ -901,13 +922,16 @@ var Shareabouts = Shareabouts || {};
           pageTemplateName = 'pages/' + (pageConfig.name || pageConfig.slug),
           pageHtml = Handlebars.templates[pageTemplateName]({config: this.options.config});
 
+      $(".maximize-btn").hide();
+      $(".minimize-btn").show();
+
       this.$panel.removeClass().addClass('page page-' + slug);
       this.showPanel(pageHtml);
 
       this.hideNewPin();
       this.destroyNewModels();
       this.hideCenterPoint();
-      this.setBodyClass('content-visible');
+      this.setBodyClass('content-visible', 'content-expanded');
     },
     showPanel: function(markup, preventScrollToTop) {
       var map = this.mapView.map;
@@ -942,7 +966,7 @@ var Shareabouts = Shareabouts || {};
     showNewPin: function() {
       this.$centerpoint.show().addClass('newpin');
 
-      this.addSpotlightMask();
+      this.showSpotlightMask();
     },
     showAddButton: function() {
       this.$addButton.show();
@@ -967,26 +991,16 @@ var Shareabouts = Shareabouts || {};
       $("#main-btns-container").attr("class", "pos-top-right");
 
       S.Util.log('APP', 'panel-state', 'closed');
-      $("#spotlight-place-mask").remove();
+      this.hideSpotlightMask();
     },
     hideNewPin: function() {
       this.showCenterPoint();
     },
-    addSpotlightMask: function() {
-      // remove an existing mask
-      $("#spotlight-place-mask").remove();
-
-      // add map mask and spotlight effect
-      var spotlightDiameter = 200,
-          xOffset = $("#map").width() / 2 - (spotlightDiameter / 2),
-          yOffset = $("#map").height() / 2 - (spotlightDiameter / 2);
-      $("#map").append("<div id='spotlight-place-mask'><div id='spotlight-place-mask-fill'></div></div>");
-      $("#spotlight-place-mask-fill").css("left", xOffset + "px")
-                               .css("top", yOffset + "px")
-                               .css("width", spotlightDiameter + "px")
-                               .css("height", spotlightDiameter + "px")
-                               // scale the box shadow to the largest screen dimension; an arbitrarily large box shadow won't get drawn in Safari
-                               .css("box-shadow", "0px 0px 0px " + Math.max((yOffset * 2), (xOffset * 2)) + "px rgba(0,0,0,0.4), inset 0px 0px 20px 30px rgba(0,0,0,0.4)");
+    showSpotlightMask: function() {
+      $("#spotlight-mask").show();
+    },
+    hideSpotlightMask: function() {
+      $("#spotlight-mask").hide();
     },
     unfocusAllPlaces: function() {
       // Unfocus all of the place markers

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -456,7 +456,7 @@ var Shareabouts = Shareabouts || {};
       $(".maximize-btn, .minimize-btn").toggle();
     },
     setBodyClass: function(/* newBodyClasses */) {
-      var bodyClasses = ['content-visible', 'place-form-visible', 'page-visible', 'content-expanded'],
+      var bodyClasses = ['content-visible', 'place-form-visible', 'page-visible', 'content-expanded', 'content-expanded-mid'],
           newBodyClasses = Array.prototype.slice.call(arguments, 0),
           i, $body = $('body');
 

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -112,6 +112,14 @@ var Shareabouts = Shareabouts || {};
     setLatLng: function(latLng) {
       this.center = latLng;
       this.$('.drag-marker-instructions, .drag-marker-warning').addClass('is-visuallyhidden');
+
+      // set the form to display full screen after initial map drag
+      if (!this.options.appView.hasBodyClass("content-expanded") &&
+        this.options.appView.hasBodyClass("place-form-visible")) {      
+        this.options.appView.setBodyClass("content-expanded");
+        $(".maximize-btn").hide();
+        $(".minimize-btn").show();
+      }
     },
     setLocation: function(location) {
       this.location = location;
@@ -189,7 +197,7 @@ var Shareabouts = Shareabouts || {};
       this.options.appView.mapView.map.locate()
         .on("locationfound", function() { 
           self.center = self.options.appView.mapView.map.getCenter();
-          $("#spotlight-place-mask").remove();
+          $("#spotlight-mask").hide();
           $("#drag-marker-content").addClass("is-visuallyhidden");
         })
         .on("locationerror", function() {

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -116,7 +116,7 @@ var Shareabouts = Shareabouts || {};
       // set the form to display at larger size after initial map drag
       if (!this.options.appView.hasBodyClass("content-expanded-mid") &&
           this.options.appView.hasBodyClass("place-form-visible")) {      
-        this.options.appView.setBodyClass("content-expanded-mid");
+        this.options.appView.setBodyClass("content-visible", "content-expanded-mid");
       }
     },
     setLocation: function(location) {

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -113,12 +113,10 @@ var Shareabouts = Shareabouts || {};
       this.center = latLng;
       this.$('.drag-marker-instructions, .drag-marker-warning').addClass('is-visuallyhidden');
 
-      // set the form to display full screen after initial map drag
-      if (!this.options.appView.hasBodyClass("content-expanded") &&
-        this.options.appView.hasBodyClass("place-form-visible")) {      
-        this.options.appView.setBodyClass("content-expanded");
-        $(".maximize-btn").hide();
-        $(".minimize-btn").show();
+      // set the form to display at larger size after initial map drag
+      if (!this.options.appView.hasBodyClass("content-expanded-mid") &&
+          this.options.appView.hasBodyClass("place-form-visible")) {      
+        this.options.appView.setBodyClass("content-expanded-mid");
       }
     },
     setLocation: function(location) {

--- a/src/base/static/scss/_content.scss
+++ b/src/base/static/scss/_content.scss
@@ -43,6 +43,52 @@ a.close-btn {
     }
 }
 
+a.maximize-btn, a.minimize-btn {
+    background: #fff;
+    color: #ff5e99;
+    font-size: 1.25em;
+    font-weight: bold;
+    text-decoration: none;
+    line-height: 1.125em;
+    display: block;
+    position: absolute;
+    top: -1.325em;
+    right: 0.5em;
+    padding: 0.325em 0.625em;
+    z-index: 2;
+    box-shadow: 0 -0.325em 0 rgba(0, 0, 0, 0.1);
+    border-radius: 0.325em 0.325em 0 0;
+
+    &:hover {
+        color: #cd2c67;
+    }
+
+    span {
+        font-size: 0.625em;
+        text-transform: uppercase;
+        margin-left: 0.625em;
+        position: relative;
+        top: -0.2em;
+    }
+}
+
+a.maximize-btn:after {
+    font-size: 1.0em;
+    font-family: FontAwesome;
+    content: "\f106";
+    padding-left: 7px;
+}
+
+a.minimize-btn {
+    display: none;
+    &:after {
+        font-size: 1.0em;
+        font-family: FontAwesome;
+        content: "\f107";
+        padding-left: 7px;
+    }
+}
+
 // Contains embeded video player size
 
 #content {
@@ -340,11 +386,13 @@ a.auth-inline {
     overflow: hidden;
     h1 {
         line-height: 1em;
+        font-size: 1.35em;
+        text-align: center;
     }
     .story-tagline {
         width: 100%;
-        padding-left: 10px;
-        padding-right: 10px;
+        padding-left: 5px;
+        padding-right: 5px;
         font-family: $default-font-family;
         margin-bottom: 0;
     }

--- a/src/base/static/scss/_map.scss
+++ b/src/base/static/scss/_map.scss
@@ -162,6 +162,19 @@
     }
 }
 
+// map spotlight effect
+
+#spotlight-mask {
+    display: none;
+    position: absolute;
+    left: calc(50% - 100px);
+    top: calc(50% - 100px);
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    box-shadow: 0px 0px 0px 800px rgba(0,0,0,0.4), inset 0px 0px 20px 30px rgba(0,0,0,0.4);
+}
+
 // Drag Marker Instructions (for adding a new place) - Selectors
 
 .drag-marker-instructions {

--- a/src/base/static/scss/_map.scss
+++ b/src/base/static/scss/_map.scss
@@ -45,23 +45,30 @@
 
 // Map Attribution - Selectors
 
-// Add Place Button - Selectors
+// Tool buttons - Selectors
 
-#add-place-btn-container {
-    background: url(images/lightpaperfibers.png);
+#main-btns-container {
+    display: table;
+    table-layout: fixed;
+    z-index: 12;
     padding: 0.5em 0.5em 0.75em;
-    position: relative;
-    z-index: 30;
-    box-shadow: 0 -0.325em 0 $opacity-very-low-black;
-    border-bottom: 1px solid #666;
 }
 
-#add-place {}
+#add-place-btn-container {
+    padding: 5px;
+    display: table-cell;
+}
 
-.content-visible #add-place-btn-container {
-    display: none;
+#story-btn-container {
+    padding: 5px;
+    display: table-cell;
+}
 
-    // hide the add button on mobile when the panel is open
+#add-place {
+}
+ 
+#nav-stories {
+    background-color: #007fbf;
 }
 
 // Center Point (new point icon) - Selectors
@@ -269,3 +276,7 @@
     display: none;
     font-size: 1.25em;
 }
+
+.leaflet-control-attribution {
+    display: none;
+} 

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -90,25 +90,26 @@
         width: 100%;
         display: block;
         left: 0;
-        top: calc(#{$map-height-smallscreen-when-sidebar-visible} + #{$footer-height-smallscreen});
+//        top: calc(#{$map-height-smallscreen-when-sidebar-visible} + #{$footer-height-smallscreen});
         height: 400px;
+        margin-top: 0;
     }
 
-    .content-expanded {
+    .content-visible.content-expanded {
         #map-container {
-            height: 10%;
+            height: 10% !important;
         }
         #content {
-            min-height: 90%;
+            min-height: 90% !important;
         }
     }
 
-    .content-expanded-mid {
+    .content-visible.content-expanded-mid {
         #map-container {
-            height: 50%;
+            height: 50% !important;
         }
         #content {
-            min-height: 90%;
+            min-height: 90% !important;
         }
     }
 
@@ -384,6 +385,12 @@
 
         .btn-primary:hover {
             background-color: #FF8B61;
+        }
+    }
+
+    .right-sidebar-visible #main-btns-container {
+        &.pos-top-right {
+            right: calc(#{$sidebar-width} + 10px);
         }
     }
 

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -103,6 +103,15 @@
         }
     }
 
+    .content-expanded-mid {
+        #map-container {
+            height: 50%;
+        }
+        #content {
+            min-height: 90%;
+        }
+    }
+
     .content-visible.right-sidebar-visible #right-sidebar {
         display: none;
     }

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -93,6 +93,32 @@
     .content-visible.right-sidebar-visible #right-sidebar {
         display: none;
     }
+
+    #main-btns-container {
+        position: fixed;
+        width: 98%;
+        background-color: white;
+        bottom: 0;
+        z-index: 12;
+        font-size: 0.75em;
+        -webkit-box-shadow: 0px -3px 3px 0px rgba(0,0,0,0.3);
+        -moz-box-shadow: 0px -3px 3px 0px rgba(0,0,0,0.3);
+        box-shadow: 0px -3px 3px 0px rgba(0,0,0,0.3);
+    }
+
+    #add-place:hover {
+        background-color: #FF8B61;
+    }
+
+    #nav-stories:hover {
+        background-color: #FF8B61;
+    }
+
+    #content {
+        // bump up the bottom margin here so content at the very bottom
+        // of a page is not obscured by bottom-clinging buttons
+        margin-bottom: $footer-height-smallscreen + 20px;
+    }
 }
 
 // default for other media
@@ -289,17 +315,17 @@
         height: 100%;
     }
 
-    #add-place-btn-container {
+    #main-btns-container {
         position: absolute;
 
         &.pos-top-left {
-            top: 1.5em;
+            top: $header-height-fullscreen + 10px;
             left: 3.5em;
         }
 
         &.pos-top-right {
-            top: 1.5em;
-            right: 1.5em;
+            top: $header-height-fullscreen + 10px;
+            right: 10px;
         }
 
         &.pos-bot-left {
@@ -328,14 +354,11 @@
         }
     }
 
-    .content-visible #add-place-btn-container {
-        display: block;
-
-        // override of the mobile style
-   
+    .content-visible #main-btns-container {
+        display: none;   
     }
 
-    .place-form-visible #add-place-btn-container {
+    .place-form-visible #main-btns-container {
         display: none;
     }
 
@@ -655,66 +678,66 @@
 
 
 /* Added temporarily for sidebar*/
-@media only screen and (max-width: 960px) {
+// @media only screen and (max-width: 960px) {
 
-    .sidebar.collapsed {
-        width: 100%;
-        box-sizing: border-box;
-        position: absolute;
-        bottom: 0;
-        height: 33px;
-        top: initial;
-    }
+//     .sidebar.collapsed {
+//         width: 100%;
+//         box-sizing: border-box;
+//         position: absolute;
+//         bottom: 0;
+//         height: 33px;
+//         top: initial;
+//     }
 
-    .sidebar {
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        overflow: hidden;
-        border-radius: 0px;
-        border: none;
-        z-index: 2000;
-        box-sizing: border-box;
-        box-shadow: none;
-    }
+//     .sidebar {
+//         top: 0;
+//         bottom: 0;
+//         left: 0;
+//         width: 100%;
+//         overflow: hidden;
+//         border-radius: 0px;
+//         border: none;
+//         z-index: 2000;
+//         box-sizing: border-box;
+//         box-shadow: none;
+//     }
 
-    .sidebar-left .sidebar-tabs {
-        bottom: 0px;
-        position: absolute;
-        height: 33px;
-        z-index: 99;
-        padding: 0 9px;
-        box-sizing: border-box;
-        box-shadow: 0px 0px 3px 1px rgba(0,0,0,.2);
-    }
-    .sidebar-tabs, .sidebar-tabs > ul {
-        width: 100%;
-        display: flex;
-    }
-    .sidebar-tabs li {
-        border-radius: 3px;
-    }
-    .sidebar-content {
-        padding-bottom: 33px;
-        left: 0 !important;
-        height: auto;
-    }
-    .sidebar-header .sidebar-close i {
-        padding: 5px 8px 6px 8px;
-    }
-    .sidebar-header .sidebar-close i::before {
-        content: "\f00d";
-    }
-    .sidebar-tabs .active {
-        border-radius: 3px;
-    }
+//     .sidebar-left .sidebar-tabs {
+//         bottom: 0px;
+//         position: absolute;
+//         height: 33px;
+//         z-index: 99;
+//         padding: 0 9px;
+//         box-sizing: border-box;
+//         box-shadow: 0px 0px 3px 1px rgba(0,0,0,.2);
+//     }
+//     .sidebar-tabs, .sidebar-tabs > ul {
+//         width: 100%;
+//         display: flex;
+//     }
+//     .sidebar-tabs li {
+//         border-radius: 3px;
+//     }
+//     .sidebar-content {
+//         padding-bottom: 33px;
+//         left: 0 !important;
+//         height: auto;
+//     }
+//     .sidebar-header .sidebar-close i {
+//         padding: 5px 8px 6px 8px;
+//     }
+//     .sidebar-header .sidebar-close i::before {
+//         content: "\f00d";
+//     }
+//     .sidebar-tabs .active {
+//         border-radius: 3px;
+//     }
 
-    /* Report button*/
-    #add-place-btn-container {
-        border-bottom: none;
-        box-shadow: none;
-    }
-}
+//     /* Report button*/
+//     #add-place-btn-container {
+//         border-bottom: none;
+//         box-shadow: none;
+//     }
+// }
 
 

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -64,6 +64,10 @@
         height: 100%;
     }
 
+    #site-header {
+        background: url(images/lightpaperfibers.png);
+    }
+
     #main {
         // calculated as 100% of viewport height, minus the height of the header
         height: calc(100% - #{$header-height-fullscreen});
@@ -78,12 +82,8 @@
         height: $map-height-smallscreen-when-sidebar-visible;
     }
 
-    .activity-enabled.content-visible #map-container {
-        height: 70%;
-    }
-
-    .content-visible.start-page-visible #map-container {
-        height: 5%;
+    .content-visible #map-container {
+        height: 60%
     }
 
     .right-sidebar-visible #right-sidebar {
@@ -94,8 +94,23 @@
         height: 400px;
     }
 
+    .content-expanded {
+        #map-container {
+            height: 10%;
+        }
+        #content {
+            min-height: 90%;
+        }
+    }
+
     .content-visible.right-sidebar-visible #right-sidebar {
         display: none;
+    }
+
+    .content-visible.place-form-visible {
+        #map-container {
+            height: 65%;
+        }
     }
 
     #main-btns-container {
@@ -122,6 +137,11 @@
         // bump up the bottom margin here so content at the very bottom
         // of a page is not obscured by bottom-clinging buttons
         margin-bottom: $footer-height-smallscreen + 20px;
+    }
+
+    #nav-stories, #add-place {
+        //font-size: 0.9em;
+        white-space: nowrap;
     }
 }
 

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -82,6 +82,10 @@
         height: 70%;
     }
 
+    .content-visible.start-page-visible #map-container {
+        height: 5%;
+    }
+
     .right-sidebar-visible #right-sidebar {
         width: 100%;
         display: block;

--- a/src/base/static/scss/_variables.scss
+++ b/src/base/static/scss/_variables.scss
@@ -106,7 +106,7 @@ $sidebar-width: 20%;
 // FOOTER - VARIABLES
 // ################################
 $footer-height-fullscreen: 0px;
-$footer-height-smallscreen: 72px;
+$footer-height-smallscreen: 39px;
 // Powered By - Variables
 // Mapquest Attribution - Variables
 

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -133,6 +133,7 @@
       <div id="ajax-error-msg">{% blocktrans %}We can't connect to the server at the moment. Hang tight while we re-establish communication.{% endblocktrans %}</div>
       <div id="map-progress" class="progress-bar"><strong>Loading Data&hellip;</strong><span class="current-progress"></span></div>
       <div id="map"></div>
+      <div id="spotlight-mask"></div>
 
       {% if config.sidebar.enabled %}
         <div id="sidebar-container"></div>
@@ -142,6 +143,8 @@
 
     <div id="content"><!-- .place or .page -->
       <a href="#" class="close-btn">&#10005;<span>{% blocktrans %}Close{% endblocktrans %}</span></a>
+      <a href="#" class="maximize-btn"><span>{% blocktrans %}Maximize{% endblocktrans %}</span></a>
+      <a href="#" class="minimize-btn"><span>{% blocktrans %}Minimize{% endblocktrans %}</span></a>
       <article></article>
     </div><!-- end #content -->
     <!-- right-panel sidebar -->

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -688,7 +688,8 @@ activity:
 
 place:
   adding_supported: true
-  add_button_label: _(Add a report to the map!)
+  add_button_label: _(Add Report)
+  story_button_label: _(Explore Stories)
   # Labels for the buttons that toggle the map and list views
   show_list_button_label: _(See All Reports)
   show_map_button_label: _(Show the Map)
@@ -1109,6 +1110,7 @@ pages:
     slug: stories
     name: stories
     start_page: true
+    hide_from_top_bar: true
 
   - title: _(Green Screen)
     slug: greenscreen

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -1095,7 +1095,7 @@ pages:
   - title: _(About)
     slug: about
     name: overview
-    start_page: false
+    start_page: true
 
   - title: _(Background)
     slug: background

--- a/src/flavors/pboakland/static/css/custom.css
+++ b/src/flavors/pboakland/static/css/custom.css
@@ -24,11 +24,15 @@ label {
   padding-bottom: 11px;
 }
 
+.recent-points {
+  background-color: white;
+}
+
 /* =Header
 -------------------------------------------------------------- */
 
 #site-header {
-  background-color: white;
+  background-color: white !important;
   background: none;
   padding-left: 1em;
   overflow: visible;


### PR DESCRIPTION
Addresses: #587

- Add bottom-clinging report and story buttons on devices with widths below 60em
  - Either or both buttons can be configured to display, by commenting out the `add_button_label` property or the `story_button_label` property in the `place` section of the config as appropriate
- Remove bottom-clinging leaflet controls
- After dragging a location with the form view open, adjust form height to nearly full screen
- Add minimize and maximize tabs to the content pane at small screen sizes to toggle content size
- ~~Configure start pages to occupy nearly fullscreen height on devices with widths below 60em~~
  - ~~Note that this configuration will be triggered only if there is a page with the `start_page` flag set to `true`, and if the site is accessed at the base url. (In other words, direct links to the start page will not trigger the expanded page height.)~~ All pages will be shown at nearly fullscreen height