### PR TITLE
Refactor place/landmark loading; support landmark-style urls

### DIFF
--- a/src/base/jstemplates/activity-list-item.html
+++ b/src/base/jstemplates/activity-list-item.html
@@ -1,6 +1,6 @@
       <li class="activity-item clearfix">
         {{!-- data attributes are not ideal, see comment in activity view --}}
-        <a href="/{{ place.datasetSlug }}/{{ place.id }}{{#is target_type 'comments'}}/response/{{ target.id }}{{/is}}" data-action-type="{{ target_type }}" data-place-id="{{ place.id }}">{{#_}}<strong>
+        <a href="/{{#if place.url-title}}{{ place.url-title }}{{else}}{{ place.datasetSlug }}/{{ place.id }}{{/if}}{{#is target_type 'comments'}}/response/{{ target.id }}{{/is}}" data-action-type="{{ target_type }}" data-place-id="{{ place.id }}">{{#_}}<strong>
 
         {{#if target.submitter.avatar_url}}
           <img src="{{ target.submitter.avatar_url }}" class="avatar" />

--- a/src/base/static/js/models/model-utils.js
+++ b/src/base/static/js/models/model-utils.js
@@ -17,8 +17,17 @@ var normalizeModelArguments = function(key, val, options) {
 var addStoryObj = function(response, type) {
   var storyObj = null,
   url;
-  if (type === "place") { url = response.properties.datasetSlug + "/" + response.properties.id; }
-  else if (type === "landmark") { url = response.title; }
+
+  if (type === "place") {
+    if (response.properties["url-title"]) {
+      url = response.properties["url-title"];
+    } else {
+      url = response.properties.datasetSlug + "/" + response.properties.id;
+    }
+  } else if (type === "landmark") {
+    url = response.title;
+  }
+
   _.each(Shareabouts.Config.story, function(story) {
     if (story.order[url]) {
       storyObj = {

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -20,6 +20,7 @@ Shareabouts.Util = Util;
       ':dataset/:id': 'viewPlace',
       'new': 'newPlace',
       ':dataset/:id/response/:response_id': 'viewPlace',
+      ':id/response/:response_id': 'viewLandmark',
       ':dataset/:id/edit': 'editPlace',
       'list': 'showList',
       ':id': 'viewLandmark',
@@ -165,12 +166,21 @@ Shareabouts.Util = Util;
       this.appView.newPlace();
     },
 
-    viewLandmark: function(id) {
-      this.appView.viewLandmark(id, { zoom: this.loading });
+    viewLandmark: function(modelId, responseId) {
+      this.appView.viewPlaceOrLandmark({
+        modelId: modelId,
+        responseId: responseId,
+        loading: this.loading
+      });
     },
 
-    viewPlace: function(datasetSlug, id, responseId) {
-      this.appView.viewPlace(datasetSlug, id, responseId, this.loading);
+    viewPlace: function(datasetSlug, modelId, responseId) {      
+      this.appView.viewPlaceOrLandmark({
+        datasetSlug: datasetSlug,
+        modelId: modelId,
+        responseId: responseId,
+        loading: this.loading
+      });
     },
 
     editPlace: function(){},

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -1,4 +1,4 @@
-  var self = module.exports = {
+var self = module.exports = {
     patch: function(obj, overrides, func) {
       var attr, originals = {};
 
@@ -27,6 +27,122 @@
       } else {
         return moment(datetime).fromNow();
       }
+    },
+
+    // Given the information provided in a url (that is, an id and possibly a slug),
+    // attempt to find the corresponding model within all collections on the page.
+    // Three conditions are possible:
+    // 1. A slug is provided, which means we have a Shareabouts place model
+    // 2. A landmark-style url (e.g. /xyz) is provided, which means we might
+    //    have an actual landmark loaded from a third-party source, or...
+    // 3. A landmark-style url is provided, but the url actually corresponds
+    //    to a Shareabouts place model with a url-title property set
+    // NOTE: We assume that all landmark-style urls (both those from third-party 
+    // data sources and those corresponding to Shareabouts place models) are unique.
+    getPlaceFromCollections: function(collectionsSet, args, mapConfig, callbacks) {
+
+      // If we have a slug, we definitely have a place model
+      if (args.datasetSlug) {
+        searchPlaceCollections();
+      } else {
+
+        // Otherwise, we have a landmark-style url, which may correspond
+        // to a place or a landmark.
+        // First, check if the model exists among collections already loaded
+        // on the page.
+        if (searchLoadedCollections(collectionsSet.places, "url-title", "place")) {
+          return;
+        };
+        if (searchLoadedCollections(collectionsSet.landmarks, "id", "landmark")) {
+          return;
+        };
+
+        // If the model is not found in the loaded collections, bind sync
+        // listeners for all collections.
+        bindCollectionsListeners(collectionsSet.places, "place", false);
+        bindCollectionsListeners(collectionsSet.landmarks, "landmark", true);
+      }
+        
+      function searchPlaceCollections() {
+        var datasetId = _.find(mapConfig.layers, function(layer) { 
+          return layer.slug === args.datasetSlug;
+        }).id,
+        model = collectionsSet.places[datasetId].get(args.modelId);
+        
+        if (model) {
+          callbacks.onFound(model, "place", datasetId);
+        } else {
+
+          // if the model has not already loaded, fetch it by id
+          // from the API
+          collectionsSet.places[datasetId].fetchById(args.modelId, {
+            validate: true,
+            success: function(model) {
+              callbacks.onFound(model, "place", datasetId);
+            },
+            error: function() {
+              callbacks.onNotFound();
+            },
+            data: {
+              include_submissions: Shareabouts.Config.flavor.app.list_enabled !== false
+            }
+          });
+        } 
+      }
+
+      function searchLoadedCollections(collections, property, type) {
+        var found = false,
+        searchTerm = {};
+        searchTerm[property] = args.modelId;
+        _.find(collections, function(collection, datasetId) {
+          var model = collection.where(searchTerm);
+          if (model.length === 1) {
+            found = true;
+            callbacks.onFound(model[0], type, datasetId);
+            return;
+          }
+        });
+
+        return found;
+      };
+
+      function bindCollectionsListeners(collections, type, isFinalCollection) {
+        var numCollections = _.keys(collections).length,
+            i = 0,
+            foundInCallback = false,
+            searchTerm = {};
+
+        if (type === "place") {
+          searchTerm["url-title"] = args.modelId;
+        } else if (type === "landmark") {
+          searchTerm["id"] = args.modelId;
+        }
+
+        _.each(collections, function(collection, datasetId) {
+          collection.on("sync", onSync);
+          function onSync(syncedCollection) {
+            i++;
+            var model = syncedCollection.where(searchTerm);
+
+            if (model.length === 1) {
+              foundInCallback = true;
+              collection.off("sync", onSync);
+              callbacks.onFound(model[0], type, datasetId);
+            } else if (numCollections === i && 
+                isFinalCollection && 
+                !foundInCallback) {
+
+              // if this is the last collection of the set and the final
+              // set of collections and no model has been found, it means the
+              // model doesn't exist.
+              collection.off("sync", onSync);
+              callbacks.onNotFound();
+            } else {
+              collection.off("sync", onSync);
+            }
+          };
+        });
+      };
     },
 
     getAttrs: function($form) {

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -507,6 +507,8 @@
         delete this.placeDetailViews[model.cid];
       }
     },
+
+    // TODO: clean up landmark/place distinction here
     getLandmarkDetailView: function(collectionId, model) {
       var landmarkDetailView;
       if (this.landmarkDetailViews[collectionId] && this.landmarkDetailViews[collectionId][model.id]) {
@@ -540,8 +542,9 @@
           userToken: this.options.userToken,
           mapView: this.mapView,
           router: this.options.router,
-          url: _.find(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug }).url,
-          datasetId: _.find(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug }).id
+          datasetId: _.find(this.options.mapConfig.layers, function(layer) { 
+            return layer.slug == model.attributes.datasetSlug 
+          }).id
         });
         this.placeDetailViews[model.cid] = placeDetailView;
       }
@@ -653,235 +656,79 @@
         });
       });
     },
-    // TODO: Refactor this into 'viewPlace'
-    viewLandmark: function(model, options) {
+    viewPlaceOrLandmark: function(args) {
       var self = this,
-          includeSubmissions = Shareabouts.Config.flavor.app.list_enabled !== false,
-          layout = Util.getPageLayout(),
-          onLandmarkFound, onLandmarkNotFound, modelId;
+        includeSubmissions = S.Config.flavor.app.list_enabled !== false,
+        layout = S.Util.getPageLayout(),
+        onFound, onNotFound, searchLoadedCollections, createCollectionsListeners,
+        foundInCallback = false;
 
-      $(".maximize-btn").show();
-      $(".minimize-btn").hide();
-
-      onLandmarkFound = function(model, response, newOptions) {
+      onFound = function(model, type, datasetId) {
         var map = self.mapView.map,
-            layer, center, landmarkDetailView, $responseToScrollTo;
-        options = newOptions ? newOptions : options;
+          layer, center, zoom, detailView, $responseToScrollTo;
 
-        layer = self.mapView.layerViews[options.collectionId][model.id].layer
-
-        if (layer) {
-          center = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
-        }
-        landmarkDetailView = self.getLandmarkDetailView(options.collectionId, model);
-
-        self.$panel.removeClass().addClass('place-detail place-detail-' + model);
-        self.showPanel(landmarkDetailView.render().$el, false);
-        landmarkDetailView.delegateEvents();
-        self.hideNewPin();
-        self.destroyNewModels();
-        self.hideCenterPoint();
-        self.setBodyClass('content-visible');
-
-        if (layer) {
-          if (options.zoom) {
-            if (layer.getLatLng) {
-              if (model.attributes.story) {
-                // TODO(Trevor): this needs to be cleaned up
-                self.setStoryLayerVisibility(model);
-                self.isProgrammaticZoom = true;
-                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
-              } else {
-                map.setView(center, map.getMaxZoom()-1, {reset: true});
-              }
-            } else {
-              map.fitBounds(layer.getBounds(), {reset: true});
-            }
-
-          } else {
-            if (model.attributes.story) {
-              // if this model is part of a story, set center and zoom level
-              self.isProgrammaticZoom = true;
-              self.setStoryLayerVisibility(model);
-              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true});
-            } else {
-              map.panTo(center, {animate: true, reset: true});
-            }
+        if (type === "place") {
+          // If this model is a duplicate of one that already exists in the
+          // places collection, it may not correspond to a layerView. For this
+          // case, get the model that's actually in the places collection.
+          if (_.isUndefined(self.mapView.layerViews[model.cid])) {
+            model = self.places[datasetId].get(model.id);
           }
-        }
-        self.showSpotlightMask();
 
-        // Focus the one we're looking
-        model.trigger('focus');
-
-        if (model.get("story")) {
-          if (!model.get("story").spotlight) self.hideSpotlightMask();
-          self.isStoryActive = true;
-          self.setStoryLayerVisibility(model);
-        } else if (self.isStoryActive) {
-          self.isStoryActive = false;
-          self.restoreDefaultLayerVisibility();
-        } else {
-          self.isStoryActive = false;
-        }
-      };
-
-      onLandmarkNotFound = function(model, response, newOptions) {
-        options.stillSearching[options.collectionId] = false;
-        var allCollectionsSearched = true;
-        _.each(_.values(options.stillSearching), function(stillSearching) {
-          if (stillSearching) {
-            allCollectionsSearched = false;
+          // TODO: We need to handle the non-deterministic case when
+          // 'self.mapView.layerViews[datasetId][model.cid]` is undefined -- ????
+          if (self.mapView.layerViews[datasetId] 
+            && self.mapView.layerViews[datasetId][model.cid]) {
+            layer = self.mapView.layerViews[datasetId][model.cid].layer;
           }
-        });
-        if (allCollectionsSearched) {
-          self.options.router.navigate('/');
+
+          detailView = self.getPlaceDetailView(model).delegateEvents();
+          self.showPanel(detailView.render().$el, !!args.responseId);
+        } else if (type === "landmark") {
+          layer = self.mapView.layerViews[datasetId][model.id].layer;
+          detailView = self.getLandmarkDetailView(datasetId, model).delegateEvents();
+          self.showPanel(detailView.render().$el, false);
         }
-      };
-
-      // If a collectionId is not specified, then we need to search all collections
-      if (options['collectionId'] === undefined) {
-        // First, let's check the caches of all of our collections for the
-        // model to avoid making unnecessary api calls for each collection:
-        var cachedModel;
-        var collectionId;
-
-        _.find(Object.keys(self.options.landmarks), function(landmarkConfigId) {
-          collectionId = landmarkConfigId;
-          cachedModel = self.landmarks[collectionId].get(model);
-          return cachedModel;
-        });
-        if (cachedModel) {
-          onLandmarkFound(cachedModel, {}, { collectionId: collectionId,
-                                          zoom: options.zoom });
-          return;
-        }
-
-        // If the model is not already in our collections, then we must fetch it
-        // by making a call to each collection:
-        var stillSearching = {};
-        _.each(self.options.datasetConfigs.landmarks, function(landmarkConfig) {
-          stillSearching[landmarkConfig.id] = true;
-        });
-        _.each(self.options.datasetConfigs.landmarks, function(landmarkConfig) {
-          self.viewLandmark(model, { collectionId: landmarkConfig.id,
-                                     zoom: options.zoom,
-                                     stillSearching: stillSearching });
-        });
-        return;
-      }
-
-      // If we are passed a LandmarkModel then show it immediately.
-      if (model instanceof LandmarkModel) {
-        onLandmarkFound(model)
-        return;
-      }
-
-      // Otherwise, assume we have a model ID.
-      modelId = model;
-      var landmarkCollection = this.landmarks[options.collectionId];
-      if (!landmarkCollection) {
-        onLandmarkNotFound();
-        return;
-      }
-      model = landmarkCollection.get(modelId);
-
-      // If the model was found in the landmarks, go ahead and use it.
-      if (model) {
-        onLandmarkFound(model);
-
-      // Otherwise, fetch and use the result.
-      } else {
-        landmarkCollection.fetch({
-          success: function(collection, response, options) {
-            var foundModel = collection.findWhere({ id: modelId });
-            if (foundModel) {
-              onLandmarkFound(foundModel);
-            } else {
-              onLandmarkNotFound();
-            }
-          },
-          error: onLandmarkNotFound
-        })
-      }
-    },
-    viewPlace: function(datasetSlug, model, responseId, zoom) {
-      var self = this,
-          includeSubmissions = Shareabouts.Config.flavor.app.list_enabled !== false,
-          layout = Util.getPageLayout(),
-          // get the dataset id from the map layers array for the given datasetSlug
-          datasetId = _.find(self.options.mapConfig.layers, function(layer) { return layer.slug == datasetSlug }).id,
-          onPlaceFound, onPlaceNotFound, modelId;
-
-      $(".maximize-btn").show();
-      $(".minimize-btn").hide();
-
-      onPlaceFound = function(model) {
-        var map = self.mapView.map,
-            layer, center, placeDetailView, $responseToScrollTo;
-
-        // If this model is a duplicate of one that already exists in the
-        // places collection, it may not correspond to a layerView. For this
-        // case, get the model that's actually in the places collection.
-        if (_.isUndefined(self.mapView.layerViews[model.cid])) {
-          model = self.places[datasetId].get(model.id);
-        }
-
-        // TODO: We need to handle the non-deterministic case when
-        // 'self.mapView.layerViews[model.cid]` is undefined
-        if (self.mapView.layerViews[datasetId] && self.mapView.layerViews[datasetId][model.cid]) {
-          layer = self.mapView.layerViews[datasetId][model.cid].layer;
-        }
-
-        placeDetailView = self.getPlaceDetailView(model);
-
-        if (layer) {
-          center = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
-        }
-
+     
         self.$panel.removeClass().addClass('place-detail place-detail-' + model.id);
-        self.showPanel(placeDetailView.render().$el, !!responseId);
-        placeDetailView.delegateEvents();
-
         self.hideNewPin();
         self.destroyNewModels();
         self.hideCenterPoint();
         self.setBodyClass('content-visible');
+        self.addSpotlightMask();
 
         if (layer) {
-          if (zoom) {
-            if (layer.getLatLng) {
-              if (model.attributes.story) {
-                // TODO(Trevor): this needs to be cleaned up
-                self.isProgrammaticZoom = true;
-                self.setStoryLayerVisibility(model);
-                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true});
-              } else {
-                map.setView(center, map.getMaxZoom()-1, {animate: true, reset: true});
-              }
-            } else {
-              map.fitBounds(layer.getBounds(), {reset: true});
+          center = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
+          zoom = map.getZoom();
+          
+          if (model.get("story")) {
+            if (!model.get("story").spotlight) {
+              $("#spotlight-place-mask").remove();
             }
+            self.isStoryActive = true;
+            self.isProgrammaticZoom = true;
+            self.setStoryLayerVisibility(model);
+            center = model.get("story").panTo || center;
+            zoom = model.get("story").zoom;
+          }
 
+          if (layer.getLatLng) {
+            map.setView(center, zoom, {
+              animate: true,
+              reset: (args.loading) ? true : false
+            });
           } else {
-            if (model.attributes.story) {
-              self.isProgrammaticZoom = true;
-              self.setStoryLayerVisibility(model);
-              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true});
-            } else {
-              map.panTo(center, {animate: true, reset: true});
-            }
+            map.fitBounds(layer.getBounds(), {
+              animate: true,
+              reset: (args.loading) ? true : false
+            });
           }
         }
-        self.showSpotlightMask();
 
-        if (responseId) {
-          // get the element based on the id
-          $responseToScrollTo = placeDetailView.$el.find('[data-response-id="'+ responseId +'"]');
-
-          // call scrollIntoView()
+        if (args.responseId) {
+          $responseToScrollTo = detailView.$el.find('[data-response-id="'+ args.responseId +'"]');
           if ($responseToScrollTo.length > 0) {
-            if (layout === 'desktop') {
+            if (layout === '"desktop"') {
               // For desktop, the panel content is scrollable
               self.$panelContent.scrollTo($responseToScrollTo, 500);
             } else {
@@ -891,52 +738,100 @@
           }
         }
 
-        // Focus the one we're looking
         model.trigger('focus');
-
-        if (model.get("story")) {
-          if (!model.get("story").spotlight) self.hideSpotlightMask();
-          self.isStoryActive = true;
-          self.setStoryLayerVisibility(model);
-        } else if (self.isStoryActive) {
+        
+        if (!model.get("story") && self.isStoryActive) {
           self.isStoryActive = false;
           self.restoreDefaultLayerVisibility();
-        } else {
-          self.isStoryActive = false;
         }
       };
 
-      onPlaceNotFound = function() {
+      onNotFound = function() {
         self.options.router.navigate('/');
+        return;
       };
 
-      // If we get a PlaceModel then show it immediately.
-      if (model instanceof PlaceModel) {
-        onPlaceFound(model);
-        return;
-      }
-
-      // Otherwise, assume we have a model ID.
-      modelId = model;
-      model = this.places[datasetId].get(modelId);
-
-      // If the model was found in the places, go ahead and use it.
-      if (model) {
-        onPlaceFound(model);
-
-      // Otherwise, fetch and use the result.
-      } else {
-        this.places[datasetId].fetchById(modelId, {
-          // Check for a valid location type before adding it to the collection
-          validate: true,
-          success: onPlaceFound,
-          error: onPlaceNotFound,
-          data: {
-            include_submissions: includeSubmissions
+      searchLoadedCollections = function(collections, property, type) {
+        var found = false,
+        searchTerm = {};
+        searchTerm[property] = args.modelId;
+        _.find(collections, function(collection, datasetId) {
+          var model = collection.where(searchTerm);
+          if (model.length === 1) {
+            found = true;
+            onFound(model[0], type, datasetId);
+            return;
           }
         });
+
+        return found;
+      };
+
+      bindCollectionsListeners = function(collections, property, type, finalCollection) {
+        var numCollections = _.keys(collections).length,
+        i = 0,
+        searchTerm = {};
+        searchTerm[property] = args.modelId;
+        _.each(collections, function(collection, datasetId) {
+          collection.on("sync", function(syncedCollection) {
+            i++;
+            var model = syncedCollection.where(searchTerm);
+            if (model.length === 1) {
+              foundInCallback = true;
+              onFound(model[0], type, datasetId);
+            } else if (numCollections === i && finalCollection && !foundInCallback) {
+              // if this is the last collection of the set and the final
+              // set of collections and no model has been found, it means the
+              // model doesn't exist.
+              onNotFound();
+            }
+          });
+        });
+      };
+
+      if (args.datasetSlug) {
+        // If we have a slug, we definitely have a place model
+        var datasetId = _.find(self.options.mapConfig.layers, function(layer) { 
+          return layer.slug === args.datasetSlug;
+        }).id;
+        model = this.places[datasetId].get(args.modelId);
+        if (model) {
+          onFound(model, "place", datasetId);
+          return;
+        } else {
+          this.places[datasetId].fetchById(args.modelId, {
+            validate: true,
+            success: function(model) {
+              onFound(model, "place", datasetId);
+              return;
+            },
+            error: function() {
+              onNotFound();
+              return;
+            },
+            data: {
+              include_submissions: includeSubmissions
+            }
+          });
+        }
+      } else {
+        // Otherwise, we have a landmark-style url, which may correspond
+        // to a place or a landmark.
+        // Conduct a search according to the following strategy: 
+        // 1. check loaded place collections
+        // 2. check loaded landmark collections
+        // 3. set up sync listeners on all place and landmark collections
+        if (searchLoadedCollections(this.places, "url-title", "place")) {
+          return;
+        };
+        if (searchLoadedCollections(this.landmarks, "id", "landmark")) {
+          return;
+        };
+        bindCollectionsListeners(this.places, "url-title", "place", false);
+        bindCollectionsListeners(this.landmarks, "id", "landmark", true);
       }
     },
+
     viewPage: function(slug) {
       var pageConfig = Util.findPageConfig(this.options.pagesConfig, {slug: slug}),
           pageTemplateName = 'pages/' + (pageConfig.name || pageConfig.slug),
@@ -953,6 +848,7 @@
       this.hideCenterPoint();
       this.setBodyClass('content-visible', 'content-expanded');
     },
+
     showPanel: function(markup, preventScrollToTop) {
       var map = this.mapView.map;
 

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -658,8 +658,8 @@
     },
     viewPlaceOrLandmark: function(args) {
       var self = this,
-        includeSubmissions = S.Config.flavor.app.list_enabled !== false,
-        layout = S.Util.getPageLayout(),
+        includeSubmissions = Shareabouts.Config.flavor.app.list_enabled !== false,
+        layout = Util.getPageLayout(),
         onFound, onNotFound, searchLoadedCollections, createCollectionsListeners,
         foundInCallback = false;
 

--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -106,7 +106,7 @@
       }
     },
     onMarkerClick: function() {
-      S.Util.log('USER', 'map', 'place-marker-click', this.model.getLoggingDetails());
+      Util.log('USER', 'map', 'place-marker-click', this.model.getLoggingDetails());
       // support places with landmark-style urls
       if (this.model.get("url-title")) {
         this.options.router.navigate('/' + this.model.get("url-title"), {trigger: true});

--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -106,10 +106,14 @@
       }
     },
     onMarkerClick: function() {
-      Util.log('USER', 'map', 'place-marker-click', this.model.getLoggingDetails());
-      this.options.router.navigate('/' + this.model.get('datasetSlug') + '/' + this.model.id, {trigger: true});
+      S.Util.log('USER', 'map', 'place-marker-click', this.model.getLoggingDetails());
+      // support places with landmark-style urls
+      if (this.model.get("url-title")) {
+        this.options.router.navigate('/' + this.model.get("url-title"), {trigger: true});
+      } else {
+        this.options.router.navigate('/' + this.model.get('datasetSlug') + '/' + this.model.id, {trigger: true});
+      }      
     },
-
     isPoint: function() {
       return this.model.get('geometry').type == 'Point';
     },

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -92,6 +92,21 @@ map:
       type: place
       slug: report
 
+    - id: vision
+      type: place
+      slug: vision
+
+    # - id: restoration
+    #   type: place
+    #   slug: restoration
+
+    - id: restoration
+      url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
+      type: landmark
+      sources:
+        - "http://a.tiles.mapbox.com/v4/smartercleanup.k9dcl2i9/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
+        - "http://a.tiles.mapbox.com/v4/smartercleanup.1pbl473a/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
+
     - id: trees
       type: place
       slug: trees
@@ -1148,7 +1163,10 @@ story:
     default_zoom: 17
     default_visible_layers:
       - restoration
+      - trees
     order:
+      - url: trees/187
+      - url: trees/276
       - url: marra
       - url: skatepark
       - url: concord

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -69,13 +69,6 @@ map:
       attribution: 'Hello World'
       type: basemap
 
-    # Legend Layers
-    - id: restoration
-      url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
-      type: landmark
-      sources:
-        - "http://a.tiles.mapbox.com/v4/smartercleanup.k9dcl2i9/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
-
     - id: dirt-corps
       type: landmark
       url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks      
@@ -96,16 +89,9 @@ map:
       type: place
       slug: vision
 
-    # - id: restoration
-    #   type: place
-    #   slug: restoration
-
     - id: restoration
-      url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
-      type: landmark
-      sources:
-        - "http://a.tiles.mapbox.com/v4/smartercleanup.k9dcl2i9/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
-        - "http://a.tiles.mapbox.com/v4/smartercleanup.1pbl473a/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
+      type: place
+      slug: restoration
 
     - id: trees
       type: place
@@ -114,12 +100,6 @@ map:
     - id: air
       type: place
       slug: air
-
-    - id: vision
-      url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
-      sources:
-        - "http://a.tiles.mapbox.com/v4/smartercleanup.mfigd1mf/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
-      type: landmark
 
        # WRIA9 watershed
     - id: watershed
@@ -289,89 +269,90 @@ place_types:
   wetland:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{style.marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{style.marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{style.marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_no-prog-or-dead.png
+
   park:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{style.marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{style.marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{style.marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_no-prog-or-dead.png
 
   school:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{style.marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{style.marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{style.marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_no-prog-or-dead.png
 
   police:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{style.marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{style.marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{style.marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_no-prog-or-dead.png
 
   rail:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{style.marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{style.marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{style.marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_no-prog-or-dead.png
 
   town-hall:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{style.marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{style.marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{style.marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_no-prog-or-dead.png
 
@@ -723,6 +704,286 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
+    - category: mapbox
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-land_comp.png
+      value: mapbox
+      label: _(Mapbox)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: wetland
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-land_comp.png
+      value: wetland
+      label: _(Wetland)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: park
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-parks_comp.png
+      value: park
+      label: _(Park)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: school
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-qual_comp.png
+      value: school
+      label: _(School)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: police
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-safe_comp.png
+      value: police
+      label: _(Police)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: rail
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-transp_comp.png
+      value: rail
+      label: _(Rail)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: town-hall
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-hist_comp.png
+      value: town-hall
+      label: _(Town Hall)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: danger
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-construction.png
+      value: danger
+      label: _(Danger)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: park2
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-heart.png
+      value: park2
+      label: _(Park2)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: industrial
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-industrial.png
+      value: industrial
+      label: _(Industrial)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: bicycle
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-bike.png
+      value: bicycle
+      label: _(Bicycle)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: swimming
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-swimming.png
+      value: swimming
+      label: _(Swimming)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: theatre
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-art.png
+      value: theatre
+      label: _(Theatre)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    - category: zoo
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-whale.png
+      value: zoo
+      label: _(Zoo)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: richTextarea
+          prompt: _(Description of this pollution:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
     - category: observation
       includeOnForm: true
       name: location_type
@@ -1163,10 +1424,7 @@ story:
     default_zoom: 17
     default_visible_layers:
       - restoration
-      - trees
     order:
-      - url: trees/187
-      - url: trees/276
       - url: marra
       - url: skatepark
       - url: concord


### PR DESCRIPTION
Addresses: #527, #549 

This PR is a major refactor of the code that loads places and landmarks. Changes include:

- Support for places with landmark-style urls. If a place model has a field called `url-title`, the value of this field will correspond to the place's url in the app. The underlying Shareabouts-style url will not be used.
- Reduced code duplication and complexity in the AppView. We now have a single `viewPlaceOrLandmark()` method, which accommodates loading from traditional place urls (`report/342`), landmark urls (`/landmark`), and places with landmark-style urls.
- Slight loading performance boost on direct url loads. We might experience quicker load times when we load the app directly to a place or landmark url.