### PR TITLE
Mobile form css hotfixes 610

### DIFF
--- a/src/base/static/scss/_buttons.scss
+++ b/src/base/static/scss/_buttons.scss
@@ -131,10 +131,14 @@
     opacity: 0;
 
     + label {
+        font-size: 1.15em;
+        min-height: 2.1em;
+        line-height: 2.1em;
+        padding-right: 10px;
+        padding-left: 60px;
+        text-indent: 0;
         position: relative;
         float: left;
-        line-height: 2.5em;
-        text-indent: 3.25em;
         margin-top: 5px;
         cursor: pointer;
         -webkit-user-select: none;
@@ -143,7 +147,7 @@
         user-select: none;
         color: $unselected-message-light-gray;
         border-radius: 4px;
-        padding-right: 10px;
+        
         border: 2px solid $unselected-highlight-light-gray;
 
         &:before {

--- a/src/base/static/scss/_buttons.scss
+++ b/src/base/static/scss/_buttons.scss
@@ -126,9 +126,7 @@
 
 .big-btn {
     position: absolute;
-    bottom: 0;
-    left: 0;
-    opacity: 0;
+    display: none;
 
     + label {
         font-size: 1.15em;


### PR DESCRIPTION
- prevent form movement on radio/checkbox selection at mobile size
- fix spacing issues with big-button style form controls at mobile size