### PR TITLE
Activity stream support tweaks

### DIFF
--- a/src/base/static/js/views/activity-view.js
+++ b/src/base/static/js/views/activity-view.js
@@ -208,6 +208,13 @@ var Shareabouts = Shareabouts || {};
             anonSubmitterName = this.options.surveyConfig.anonymous_name;
           } else if (actionType === supportConfig.submission_type) {
             // Support
+            if (supportConfig.show_in_activity_stream === false) {
+              // skip supports if they're configured not to be shown
+              return;
+            } 
+            
+            // show associated place model title instead of generic support text 
+            placeData.name = placeData.title;
             actionText = this.options.supportConfig.action_text;
             anonSubmitterName = this.options.supportConfig.anonymous_name;
           }

--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -490,6 +490,7 @@ survey:
       sticky: true
 
 support:
+  show_in_activity_stream: false
   submission_type: support
   submit_btn_text: _(Support)
   response_name: _(support)


### PR DESCRIPTION
Addresses: #616.

- add config param to disable supports in activity stream
  - under the `support` section of the config, set the `show_in_activity_stream` flag to `false` to disable supports in the activity stream. This flag will default to `true`.
- show place model title in support activity stream items
  - supports will now appear as `So-and-so supported Recreation Center` instead of `So-and-so supported an idea for Parks and Recreation`