### PR TITLE
Fix map re-centering issue

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -450,10 +450,12 @@ var Shareabouts = Shareabouts || {};
     onClickMaximizeBtn: function(evt) {
       this.setBodyClass("content-expanded", "content-visible");
       $(".maximize-btn, .minimize-btn").toggle();
+      this.mapView.map.invalidateSize({ animate:true, pan:true });
     },
     onClickMinimizeBtn: function(evt) {
       this.setBodyClass("content-visible");
       $(".maximize-btn, .minimize-btn").toggle();
+      this.mapView.map.invalidateSize({ animate:true, pan:true });
     },
     setBodyClass: function(/* newBodyClasses */) {
       var bodyClasses = ['content-visible', 'place-form-visible', 'page-visible', 'content-expanded', 'content-expanded-mid'],

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -110,14 +110,15 @@ var Shareabouts = Shareabouts || {};
     },
     // This is called from the app view
     setLatLng: function(latLng) {
-      this.center = latLng;
-      this.$('.drag-marker-instructions, .drag-marker-warning').addClass('is-visuallyhidden');
-
       // set the form to display at larger size after initial map drag
       if (!this.options.appView.hasBodyClass("content-expanded-mid") &&
           this.options.appView.hasBodyClass("place-form-visible")) {      
         this.options.appView.setBodyClass("content-visible", "content-expanded-mid");
+        this.options.appView.mapView.map.invalidateSize({ animate:true, pan:true });
       }
+
+      this.center = latLng;
+      this.$('.drag-marker-instructions, .drag-marker-warning').addClass('is-visuallyhidden');
     },
     setLocation: function(location) {
       this.location = location;

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -119,7 +119,7 @@
 
     .content-visible.place-form-visible {
         #map-container {
-            height: 65%;
+            height: 60%;
         }
     }
 


### PR DESCRIPTION
Call Leaflet's `invalidateSize()` method to make sure the map correctly re-centers when we change map container dimensions via CSS.