### PR TITLE
On panel show, call invalidateSize() inside a short timeout

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -957,7 +957,16 @@ var Shareabouts = Shareabouts || {};
       }
 
       this.setBodyClass('content-visible');
-      map.invalidateSize({ animate:true, pan:true });
+
+      // Set a very short timeout here to hopefully avoid a race condition
+      // between the CSS transition that resizes the map container and
+      // invalidateSize(). Otherwise, invalidateSize() may fire before the new
+      // map container dimensions have been set by CSS, resulting in the
+      // infamous off-center bug.
+      // NOTE: the timeout duration in use here was arbitrarily selected.
+      setTimeout(function() {
+        map.invalidateSize({ animate:true, pan:true });
+      }, 30);
 
       $(S).trigger('panelshow', [this.options.router, Backbone.history.getFragment()]);
 

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -964,6 +964,8 @@ var Shareabouts = Shareabouts || {};
       // map container dimensions have been set by CSS, resulting in the
       // infamous off-center bug.
       // NOTE: the timeout duration in use here was arbitrarily selected.
+      // TODO: this is a hack. Is there a better way to handle this? Can we 
+      // listen for an event from CSS maybe?
       setTimeout(function() {
         map.invalidateSize({ animate:true, pan:true });
       }, 30);


### PR DESCRIPTION
Addresses: #621. 

This is an effort to avoid a potential race condition between the
CSS transition that resizes the map container to accommodate the
content panel, and the call to invalidateSize() inside showPanel().
The timeout (hopefully) allows the transition to complete and the
new map dimensions to be set before invalidateSize() recenters the map.