### PR TITLE
Set right-sidebar-visible class via jquery

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -65,7 +65,7 @@ var Shareabouts = Shareabouts || {};
       });
 
       if (this.options.activityConfig.show_in_right_panel === true) {
-        this.setBodyClass("right-sidebar-visible");
+        $("body").addClass("right-sidebar-visible");
         $("#right-sidebar").html("<ul class='recent-points unstyled-list'></ul>");
       }
 

--- a/src/base/static/scss/_sidebar.scss
+++ b/src/base/static/scss/_sidebar.scss
@@ -64,6 +64,7 @@
     overflow: auto;
     box-shadow: (-0.325em) 0 0 $opacity-very-low-black;
     z-index: 10;
+    background-color: white;
     
 }
 


### PR DESCRIPTION
Prevent unrecognized body class error.
Also, set background color of the sidebar to prevent the spotlight shadow from being visible in the sidebar when activity content is loading.