### PR TITLE
Support multiple datasets per layer

### DIFF
--- a/src/base/jstemplates/gis-legend-content.html
+++ b/src/base/jstemplates/gis-legend-content.html
@@ -37,6 +37,9 @@
                      {{#if visibleDefault}}
                      checked="checked"
                      {{/if}}
+                     {{#if constituentLayers}}
+                     data-constituent-layers="{{#each constituentLayers}}{{this}} {{/each}}"
+                     {{/if}}
                      class="map-legend-checkbox" type="checkbox"></input>
               <label for="map-{{ id }}">{{ title }}</label>
             </div>

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -151,6 +151,7 @@
       this.mapView = new MapView({
         el: '#map',
         mapConfig: this.options.mapConfig,
+        sidebarConfig: this.options.sidebarConfig,
         basemapConfigs: basemapConfigs,
         legend_enabled: !!this.options.sidebarConfig.legend_enabled,
         places: this.places,

--- a/src/base/static/js/views/gis-legend-view.js
+++ b/src/base/static/js/views/gis-legend-view.js
@@ -21,8 +21,8 @@
       });
 
       var initialBasemap = _.find(this.options.config.basemaps, function(basemap) {
-                               return !!basemap.visibleDefault;
-                             });
+        return !!basemap.visibleDefault;
+      });
 
       $(Shareabouts).trigger('visibility', [initialBasemap.id, !!initialBasemap.visibleDefault, true]);
 

--- a/src/base/static/js/views/gis-legend-view.js
+++ b/src/base/static/js/views/gis-legend-view.js
@@ -16,7 +16,14 @@
 
       _.each(this.options.config.groupings, function(group) {
         _.each(group.layers, function(layer) {
-          $(Shareabouts).trigger('visibility', [layer.id, !!layer.visibleDefault]);
+
+          if (layer.constituentLayers) {
+            layer.constituentLayers.forEach(function(id) {
+              $(Shareabouts).trigger('visibility', [id, !!layer.visibleDefault]);
+            });
+          } else {
+            $(Shareabouts).trigger('visibility', [layer.id, !!layer.visibleDefault]);
+          }
         });
       });
 
@@ -33,9 +40,18 @@
     toggleVisibility: function(evt) {
       var $cbox = $(evt.target),
           id = $cbox.attr('data-layerid'),
+          constituentLayers = $cbox.attr('data-constituent-layers'),
           isChecked = !!$cbox.is(':checked');
 
-      $(Shareabouts).trigger('visibility', [id, isChecked]);
+
+      if (constituentLayers) {
+        constituentLayers = constituentLayers.trim().split(" ");        
+        constituentLayers.forEach(function(id) {
+          $(Shareabouts).trigger('visibility', [id, isChecked]);
+        });
+      } else {
+        $(Shareabouts).trigger('visibility', [id, isChecked]);
+      }
     },
 
     toggleBasemap: function(evt) {

--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -77,33 +77,57 @@
 
       // Bind visiblity event for custom layers
       $(Shareabouts).on('visibility', function (evt, id, visible, isBasemap) {
-        var layer = self.layers[id],
-        config = _.find(self.options.mapConfig.layers, function(c) {
-          return c.id === id;
-        });
-        if (config && !config.loaded && visible) {
-          self.createLayerFromConfig(config);
-          config.loaded = true;
-          layer = self.layers[id];
-        }
-        if (isBasemap) {
-          _.each(self.options.basemapConfigs, function(basemap) {
-            if (basemap.id === id) {
-              self.map.addLayer(layer);
-              layer.bringToBack();
-            } else if (self.layers[basemap.id]) {
-              self.map.removeLayer(self.layers[basemap.id]);
-            }
-          });
-        } else if (layer) {
-          self.setLayerVisibility(layer, visible);
+        var layerIds;
+
+        // If this layer is a composite of other layers, get the list of
+        // constituent layers to turn off or on. Otherwise, assume the group id
+        // corresponds to the id of the layer to turn off or on.
+        // NOTE: we assume the gis-layers section on the sidebar config is the
+        // first section listed under the panels section.
+        var sidebarLayerItem = _(self.options.sidebarConfig.panels[0].groupings)
+          .chain()
+          .pluck("layers")
+          .flatten()
+          .findWhere({id: id})
+          .value();
+
+        if (sidebarLayerItem && sidebarLayerItem.constituentLayers) {
+          layerIds = sidebarLayerItem.constituentLayers;
         } else {
-          // Handles cases when we fire events for layers that are not yet
-          // loaded (ie cartodb layers, which are loaded asynchronously)
-          // We are setting the asynch layer config's default visibility here to
-          // ensure they are added to the map when they are eventually loaded:
-          config.asyncLayerVisibleDefault = visible;
+          layerIds = [id];
         }
+  
+        _.each(layerIds, function(layerId) {
+          var layer = self.layers[layerId],
+          config = _.find(self.options.mapConfig.layers, function(c) {
+            return c.id === layerId;
+          });
+
+          if (config && !config.loaded && visible) {
+            self.createLayerFromConfig(config);
+            config.loaded = true;
+            layer = self.layers[layerId];
+          }
+
+          if (isBasemap) {
+            _.each(self.options.basemapConfigs, function(basemap) {
+              if (basemap.id === layerId) {
+                self.map.addLayer(layer);
+                layer.bringToBack();
+              } else if (self.layers[basemap.id]) {
+                self.map.removeLayer(self.layers[basemap.id]);
+              }
+            });
+          } else if (layer) {
+            self.setLayerVisibility(layer, visible);
+          } else {
+            // Handles cases when we fire events for layers that are not yet
+            // loaded (ie cartodb layers, which are loaded asynchronously)
+            // We are setting the asynch layer config's default visibility here to
+            // ensure they are added to the map when they are eventually loaded:
+            config.asyncLayerVisibleDefault = visible;
+          }
+        }); 
       });
     }, // end initialize
 


### PR DESCRIPTION
Addresses: #557, #612.

This PR makes it possible to group multiple layers under one visibility checkbox in the sidebar panel. Any layer types can be arbitrarily grouped together: Shareabouts place layers, third-party GeoJSON, esri, KML, etc.

To group layers, use the `constituentLayers` key in the sidebar section of the config. For example, to group the `restoration` and `vision` layers together, remove the individual entries for `restoration` and `vision` and add the following:

```
- id: vision_and_restoration
  title: _(Vision and Restoration Sites)
  visibleDefault: true
  constituentLayers:
    - vision
    - restoration
```