### PR TITLE
Detail view design changes

### DIFF
--- a/src/base/jstemplates/place-detail-promotion-bar.html
+++ b/src/base/jstemplates/place-detail-promotion-bar.html
@@ -1,6 +1,6 @@
-        <section class="promotion clearfix">
-          <div class="support"></div>
-          <div class="social">
+        <section class="promotion clearfix {{#if story}}single-line{{/if}}">
+          <div class="support {{#if story}}single-line{{/if}}"></div>
+          <div class="social {{#if story}}single-line{{/if}}">
             <ul class="sharing unstyled-list">
               <li class="share-link share-twitter"><a href="https://twitter.com/intent/tweet?url={{ place_url id }}&text={{ name }}" target="_blank" data-shareto="twitter">{{#_}}Tweet This{{/_}}</a></li>
               <li class="share-link share-facebook"><a href="https://www.facebook.com/sharer/sharer.php?u={{ place_url id }}" target="_blank" data-shareto="facebook">{{#_}}Recommend on Facebook{{/_}}</a></li>

--- a/src/base/static/scss/_content.scss
+++ b/src/base/static/scss/_content.scss
@@ -183,6 +183,20 @@ a.minimize-btn {
     background: url(images/facebook-32.png) 0 0 no-repeat scroll;
 }
 
+// styles for configuring the promotion bar to appear on one line
+.promotion.single-line {
+    margin-bottom: 0;
+}
+
+.support.single-line {
+    float: right;
+    margin-left: 10px;
+}
+
+.social.single-line {
+    float: left;
+}
+
 // Places - Selectors
 
 .place-header {

--- a/src/base/static/scss/_forms.scss
+++ b/src/base/static/scss/_forms.scss
@@ -132,4 +132,8 @@ select {
     background-color: rgba(250, 128, 114, 0.48);
     padding: 5px;
     border-radius: 4px;
-} 
+}
+
+.place-header-title {
+    line-height: 1.2em;
+}

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -368,9 +368,9 @@ place_types:
     # LineString
       - condition: '"{{geometry.type}}" == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "{{style.color}}"
+          opacity: "{{style.opacity}}"
+          weight: "{{style.weight}}"
     # Polygons
       - condition: '"{{geometry.type}}" == "Polygon"'
         style:

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -738,7 +738,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: wetland
@@ -758,7 +758,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: park
@@ -778,7 +778,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: school
@@ -798,7 +798,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: police
@@ -818,7 +818,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: rail
@@ -838,7 +838,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: town-hall
@@ -858,7 +858,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: danger
@@ -878,7 +878,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: park2
@@ -898,7 +898,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: industrial
@@ -918,7 +918,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: bicycle
@@ -938,7 +938,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: swimming
@@ -958,7 +958,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: theatre
@@ -978,7 +978,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: zoo
@@ -998,7 +998,7 @@ place:
         - name: description
           type: richTextarea
           prompt: _(Description of this pollution:)
-          display_prompt: _(Further description:)
+          display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
     - category: observation


### PR DESCRIPTION
Addresses: #665.

Detail view styling changes made to the base project:

* Tighten line spacing in detail view headers
* Remove "Further description" prompt from restoration and vision detail views
* In story mode, place promotion bar controls on a single line; leave them on two lines otherwise
* Fix an issue with incorrectly configured linestring style info