### PR TITLE
Integrate social media functionality with sharing microservice

### DIFF
--- a/src/base/jstemplates/place-detail-promotion-bar.html
+++ b/src/base/jstemplates/place-detail-promotion-bar.html
@@ -2,8 +2,8 @@
           <div class="support {{#if story}}single-line{{/if}}"></div>
           <div class="social {{#if story}}single-line{{/if}}">
             <ul class="sharing unstyled-list">
-              <li class="share-link share-twitter"><a href="https://twitter.com/intent/tweet?url={{ place_url id }}&text={{ name }}" target="_blank" data-shareto="twitter">{{#_}}Tweet This{{/_}}</a></li>
-              <li class="share-link share-facebook"><a href="https://www.facebook.com/sharer/sharer.php?u={{ place_url id }}" target="_blank" data-shareto="facebook">{{#_}}Recommend on Facebook{{/_}}</a></li>
+              <li class="share-link share-twitter">{{#_}}Tweet This{{/_}}</li>
+              <li class="share-link share-facebook">{{#_}}Recommend on Facebook{{/_}}</li>
             </ul>
           </div>
         </section>

--- a/src/base/static/js/models/attachment-collection.js
+++ b/src/base/static/js/models/attachment-collection.js
@@ -12,5 +12,9 @@ module.exports = Backbone.Collection.extend({
         thingUrl = thingModel.url();
 
     return thingUrl + '/attachments';
+  },
+
+  parse: function(response) {
+    return response.results;
   }
 });

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -54,6 +54,59 @@ var self = module.exports = {
       return isAdmin;
     },
 
+    getPathname: function(model) {
+      if (model.get("url-title")) {
+        return model.get("url-title");
+      } else if (model.get("datasetSlug")) {
+        return model.get("datasetSlug") + "/" + model.get("id");
+      } else {
+        return model.get("id");
+      }
+    },
+
+    onSocialShare: function(model, service) {
+      var appConfig = Shareabouts.Config.app,
+          title = model.get("title") ||
+                  model.get("name") || 
+                  appConfig.title,
+          desc = model.get("description") || 
+                        appConfig.meta_description,
+          protocol = window.location.protocol,
+          host = window.location.host,
+          pathname = this.getPathname(model),
+          img = (model.attachmentCollection.models.length > 0) ?
+                 model.attachmentCollection.models[0].get("file") :
+                 protocol + "//" + host + appConfig.thumbnail,
+          redirectUrl = [protocol, "//", host, "/", pathname].join(""),
+          // shareUrl = "http://social.mapseed.org",
+          // TEMPORARY
+          // shareUrl = "http://52f34701.ngrok.io/" + Date.now(),
+          shareUrl = "http://52f34701.ngrok.io/",
+          queryString = [  
+            "?url=", redirectUrl,
+            "&title=", title,
+            "&img=", img,
+            "&desc=", desc
+          ].join("");
+
+      // if (service === "twitter") {
+      //   shareUrl = ["https://twitter.com/intent/tweet?url=",
+      //               shareUrl].join("");
+      //               // "&text=",
+      //               // title].join("");
+      // } else if (service === "facebook") {
+      //   shareUrl = ["https://www.facebook.com/sharer/sharer.php?u=",
+      //               shareUrl].join("");
+      // }
+
+      if (service === "facebook") {
+        FB.ui({
+          method: 'share',
+          href: shareUrl + queryString
+        }, function(response){});
+      }
+    },
+
     // Given the information provided in a url (that is, an id and possibly a slug),
     // attempt to find the corresponding model within all collections on the page.
     // Three conditions are possible:

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -78,15 +78,12 @@ var self = module.exports = {
                  model.attachmentCollection.models[0].get("file") :
                  protocol + "//" + host + appConfig.thumbnail,
           redirectUrl = [protocol, "//", host, "/", pathname].join(""),
-          // shareUrl = "http://social.mapseed.org",
-          // TEMPORARY
-          // shareUrl = "http://52f34701.ngrok.io/" + Date.now(),
-          shareUrl = "http://52f34701.ngrok.io/",
+          shareUrl = "http://social.mapseed.org",
           queryString = [  
-            "?url=", redirectUrl,
-            "&title=", title,
-            "&img=", img,
-            "&desc=", desc
+            "?url=", encodeURIComponent(redirectUrl),
+            "&title=", encodeURIComponent(title),
+            "&img=", encodeURIComponent(img),
+            "&desc=", encodeURIComponent(desc)
           ].join("");
 
       // if (service === "twitter") {

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -76,17 +76,11 @@ var self = module.exports = {
     },
 
     initiateShare: function(service, shareUrl, queryString) {
-      // if (service === "twitter") {
-      //   shareUrl = ["https://twitter.com/intent/tweet?url=",
-      //               shareUrl].join("");
-      //               // "&text=",
-      //               // title].join("");
-      // } else if (service === "facebook") {
-      //   shareUrl = ["https://www.facebook.com/sharer/sharer.php?u=",
-      //               shareUrl].join("");
-      // }
-
-      if (service === "facebook") {
+      if (service === "twitter") {
+        shareUrl = ["https://twitter.com/intent/tweet?url=",
+                    encodeURIComponent(shareUrl + queryString)].join("");
+        window.open(shareUrl, "Twitter", "height=300, width=600");
+      } else if (service === "facebook") {
         FB.ui({
           method: 'share',
           href: shareUrl + queryString

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -77,13 +77,18 @@ var self = module.exports = {
           img = (model.attachmentCollection.models.length > 0) ?
                  model.attachmentCollection.models[0].get("file") :
                  protocol + "//" + host + appConfig.thumbnail,
+          $img = $("img[src='" + img + "']"),
+          height = $img.height() || 630,
+          width = $img.width() || 1200,
           redirectUrl = [protocol, "//", host, "/", pathname].join(""),
           shareUrl = "http://social.mapseed.org",
           queryString = [  
             "?url=", encodeURIComponent(redirectUrl),
             "&title=", encodeURIComponent(title),
             "&img=", encodeURIComponent(img),
-            "&desc=", encodeURIComponent(desc)
+            "&desc=", encodeURIComponent(desc),
+            "&height=", encodeURIComponent(height),
+            "&width=", encodeURIComponent(width)
           ].join("");
 
       // if (service === "twitter") {

--- a/src/base/static/js/views/place-detail-view.js
+++ b/src/base/static/js/views/place-detail-view.js
@@ -18,7 +18,7 @@
       'click input[data-input-type="binary_toggle"]': 'onBinaryToggle',
       'change .publish-control-container input': 'onPublishedStateChange',
       'change input, textarea': 'saveDraftChanges',
-      'keyup input[name="url-title"]': 'onUpdateUrlTitle'
+      'keyup input[name="url-title"]': 'onUpdateUrlTitle',
       'click .share-twitter': 'onShareTwitter',
       'click .share-facebook': 'onShareFacebook'
     },

--- a/src/base/static/js/views/place-detail-view.js
+++ b/src/base/static/js/views/place-detail-view.js
@@ -19,6 +19,8 @@
       'change .publish-control-container input': 'onPublishedStateChange',
       'change input, textarea': 'saveDraftChanges',
       'keyup input[name="url-title"]': 'onUpdateUrlTitle'
+      'click .share-twitter': 'onShareTwitter',
+      'click .share-facebook': 'onShareFacebook'
     },
     initialize: function() {
       var self = this;
@@ -132,6 +134,14 @@
 
     clearDraftChanges: function() {
       Util.localstorage.destroy(this.LOCALSTORAGE_KEY);
+    },
+
+    onShareTwitter: function() {
+      Util.onSocialShare(this.model, "twitter");
+    },
+
+    onShareFacebook: function() {
+      Util.onSocialShare(this.model, "facebook");
     },
 
     onClickStoryPrevious: function() {

--- a/src/base/static/js/views/place-list-view.js
+++ b/src/base/static/js/views/place-list-view.js
@@ -45,6 +45,12 @@
 
       return data;
     },
+
+    events: {
+      'click .share-twitter': 'onShareTwitter',
+      'click .share-facebook': 'onShareFacebook'
+    },
+
     initialize: function() {
       var supportType = Shareabouts.Config.support.submission_type;
 
@@ -59,6 +65,12 @@
         supportConfig: Shareabouts.Config.support,
         userToken: Shareabouts.Config.userToken
       });
+    },
+    onShareTwitter: function() {
+      Util.onSocialShare(this.model, "twitter");
+    },
+    onShareFacebook: function() {
+      Util.onSocialShare(this.model, "facebook");
     },
     onBeforeRender: function() {
       // if an attachmentCollection has models in it, make sure the place

--- a/src/base/static/scss/_content.scss
+++ b/src/base/static/scss/_content.scss
@@ -165,21 +165,19 @@ a.minimize-btn {
     float: right;
     padding: 0 !important;
     margin-left: 10px;
-
-    a {
-        display: block;
-        width: 32px;
-        height: 32px;
-        overflow: hidden;
-        text-indent: -9999px;
-    }
+    display: block;
+    width: 32px;
+    height: 32px;
+    overflow: hidden;
+    text-indent: -9999px;
+    cursor: pointer;
 }
 
-.share-twitter a {
+.share-twitter {
     background: url(images/twitter-32.png) 0 0 no-repeat scroll;
 }
 
-.share-facebook a {
+.share-facebook {
     background: url(images/facebook-32.png) 0 0 no-repeat scroll;
 }
 

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -296,6 +296,7 @@
         S.bootstrapped.currentUser ?
         'user:' + S.bootstrapped.currentUser.id :
         {{ user_token_json|safe }}),
+      app:        {{ config.app|as_json }},
       flavor:     {{ config.data|as_json }},
       place:      {{ config.place|as_json }},
       placeTypes: {{ config.place_types|as_json }},

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -78,6 +78,25 @@
 </head>
   <body class="{% if config.map.geocoding_bar_enabled %} geocoding-bar-enabled{% endif %}">
 
+  <script>
+    window.fbAsyncInit = function() {
+      FB.init({
+        appId      : '1916504771954333',
+        xfbml      : true,
+        version    : 'v2.9'
+      });
+      FB.AppEvents.logPageView();
+    };
+
+    (function(d, s, id){
+       var js, fjs = d.getElementsByTagName(s)[0];
+       if (d.getElementById(id)) {return;}
+       js = d.createElement(s); js.id = id;
+       js.src = "//connect.facebook.net/en_US/sdk.js";
+       fjs.parentNode.insertBefore(js, fjs);
+     }(document, 'script', 'facebook-jssdk'));
+  </script>
+
   <header id="site-header" class="clearfix{% if pages_config %} has-pages{% endif %}">
     <h1 id="site-title">{% block site-title %}{% endblock %}</h1>
 

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -78,6 +78,7 @@
 </head>
   <body class="{% if config.map.geocoding_bar_enabled %} geocoding-bar-enabled{% endif %}">
 
+  <!-- Facebook widgets -->
   <script>
     window.fbAsyncInit = function() {
       FB.init({

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -78,26 +78,6 @@
 </head>
   <body class="{% if config.map.geocoding_bar_enabled %} geocoding-bar-enabled{% endif %}">
 
-  <!-- Facebook widgets -->
-  <script>
-    window.fbAsyncInit = function() {
-      FB.init({
-        appId      : '1916504771954333',
-        xfbml      : true,
-        version    : 'v2.9'
-      });
-      FB.AppEvents.logPageView();
-    };
-
-    (function(d, s, id){
-       var js, fjs = d.getElementsByTagName(s)[0];
-       if (d.getElementById(id)) {return;}
-       js = d.createElement(s); js.id = id;
-       js.src = "//connect.facebook.net/en_US/sdk.js";
-       fjs.parentNode.insertBefore(js, fjs);
-     }(document, 'script', 'facebook-jssdk'));
-  </script>
-
   <header id="site-header" class="clearfix{% if pages_config %} has-pages{% endif %}">
     <h1 id="site-title">{% block site-title %}{% endblock %}</h1>
 

--- a/src/flavors/bogtobay/templates/index.html
+++ b/src/flavors/bogtobay/templates/index.html
@@ -7,43 +7,6 @@
 </a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-    <meta name="og:image" content="{{STATIC_URL}}css/images/fb-thumbnail.png">
-
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -9,6 +9,8 @@ app:
   # Meta author that will show up in Google search results
   meta_author: SmarterCleanup.org
 
+  facebook_app_id: 1865303377128313
+
   # When the map loads, existing places will be loaded in chunks. By default,
   # the size of the chunks will be a reasonable default dictated by the API
   # server. If you would like to override the chunk size, use this setting:

--- a/src/flavors/central-puget-sound/templates/index.html
+++ b/src/flavors/central-puget-sound/templates/index.html
@@ -5,43 +5,6 @@
 <a href="/page/about" rel="internal">{{ config.app.name }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-    <meta name="og:image" content="{{STATIC_URL}}css/images/fb-thumbnail.png">
-
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/central-puget-sound/templates/index.html
+++ b/src/flavors/central-puget-sound/templates/index.html
@@ -33,4 +33,24 @@
     })
   }(Shareabouts));
 </script>
+
+<!-- Facebook widgets -->
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : {{ config.app.facebook_app_id }},
+      xfbml      : true,
+      version    : 'v2.9'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
 {% endblock %}

--- a/src/flavors/defaultflavor/templates/index.html
+++ b/src/flavors/defaultflavor/templates/index.html
@@ -5,39 +5,6 @@
 <a href="/">{{ config.app.name }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/duwamish-watershed/templates/index.html
+++ b/src/flavors/duwamish-watershed/templates/index.html
@@ -7,43 +7,6 @@ The Green-Duwamish Watershed
 </a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-    <meta name="og:image" content="{{STATIC_URL}}css/images/fb-thumbnail.png">
-
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -9,6 +9,9 @@ app:
   # Meta author that will show up in Google search results
   meta_author: SmarterCleanup.org
 
+  # Fallback image to use for sharing on social services if no model image is present
+  thumbnail: /static/css/images/fb-thumbnail.png
+
   # When the map loads, existing places will be loaded in chunks. By default,
   # the size of the chunks will be a reasonable default dictated by the API
   # server. If you would like to override the chunk size, use this setting:

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -12,6 +12,8 @@ app:
   # Fallback image to use for sharing on social services if no model image is present
   thumbnail: /static/css/images/fb-thumbnail.png
 
+  facebook_app_id: 433349350355712
+
   # When the map loads, existing places will be loaded in chunks. By default,
   # the size of the chunks will be a reasonable default dictated by the API
   # server. If you would like to override the chunk size, use this setting:

--- a/src/flavors/duwamish_flavor/templates/index.html
+++ b/src/flavors/duwamish_flavor/templates/index.html
@@ -35,4 +35,24 @@
     })
   }(Shareabouts));
 </script>
+
+<!-- Facebook widgets -->
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : {{ config.app.facebook_app_id }},
+      xfbml      : true,
+      version    : 'v2.9'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
 {% endblock %}

--- a/src/flavors/duwamish_flavor/templates/index.html
+++ b/src/flavors/duwamish_flavor/templates/index.html
@@ -8,40 +8,20 @@
 {% endblock %}
 
 {% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
+  <!-- NOTE: social meta tag content gets populated client-side. -->
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:widgets:csp" content="on">
+  <meta name="twitter:title" content="">
+  <meta name="twitter:description" content="">
+  <meta name="twitter:image:src" content="">
+  <meta name="twitter:creator" content="">
 
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-    <meta name="og:image" content="{{STATIC_URL}}css/images/fb-thumbnail.png">
-
-  {% endif%}
+  <!-- Facebook -->
+  <meta property="og:site_name" content="" />
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta name="og:image" content="">
 {% endblock %}
 
 <!--

--- a/src/flavors/duwamish_flavor/templates/index.html
+++ b/src/flavors/duwamish_flavor/templates/index.html
@@ -7,23 +7,6 @@
 </a>
 {% endblock %}
 
-{% block meta %}
-  <!-- NOTE: social meta tag content gets populated client-side. -->
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:widgets:csp" content="on">
-  <meta name="twitter:title" content="">
-  <meta name="twitter:description" content="">
-  <meta name="twitter:image:src" content="">
-  <meta name="twitter:creator" content="">
-
-  <!-- Facebook -->
-  <meta property="og:site_name" content="" />
-  <meta property="og:title" content="" />
-  <meta property="og:description" content="" />
-  <meta name="og:image" content="">
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/greensboropb/config.yml
+++ b/src/flavors/greensboropb/config.yml
@@ -9,6 +9,8 @@ app:
   district:
   tagline: _(How would YOU spend $100K?)
 
+  facebook_app_id: 1865303377128313
+
 
 # languages:
 #   - code: en

--- a/src/flavors/greensboropb/templates/index.html
+++ b/src/flavors/greensboropb/templates/index.html
@@ -121,4 +121,24 @@
 
   // }(Shareabouts, jQuery));
 </script>
+
+<!-- Facebook widgets -->
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : {{ config.app.facebook_app_id }},
+      xfbml      : true,
+      version    : 'v2.9'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
 {% endblock %}

--- a/src/flavors/greensboropb/templates/index.html
+++ b/src/flavors/greensboropb/templates/index.html
@@ -9,41 +9,6 @@
 <script>try{Typekit.load({ async: true });}catch(e){}</script>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-{% endblock %}
-
 {% block app_icons %}
   <!-- Favicon & Progressively-Enhanced Touch Icons: http://mathiasbynens.be/notes/touch-icons#sizes -->
   <link rel="icon" href="{{ config.static_url }}css/images/greensboro-logo-small.png">

--- a/src/flavors/greenways/templates/index.html
+++ b/src/flavors/greenways/templates/index.html
@@ -8,39 +8,6 @@
 </a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/gtopenspace/templates/index.html
+++ b/src/flavors/gtopenspace/templates/index.html
@@ -7,43 +7,6 @@
 </a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-    <meta name="og:image" content="{{STATIC_URL}}css/images/fb-thumbnail.png">
-
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/lakewashington/config.yml
+++ b/src/flavors/lakewashington/config.yml
@@ -9,6 +9,8 @@ app:
   # Meta author that will show up in Google search results
   meta_author: smartercleanup.org
 
+  facebook_app_id: 1476977695699521
+
 
   # When the map loads, existing places will be loaded in chunks. By default,
   # the size of the chunks will be a reasonable default dictated by the API

--- a/src/flavors/lakewashington/templates/index.html
+++ b/src/flavors/lakewashington/templates/index.html
@@ -22,4 +22,26 @@
   Analytics, custom JS, and such go here
  -->
 {% block includes %}
+
+<!-- Facebook widgets -->
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : {{ config.app.facebook_app_id }},
+      xfbml      : true,
+      version    : 'v2.9'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
+
 {% endblock %}
+

--- a/src/flavors/lakewashington/templates/index.html
+++ b/src/flavors/lakewashington/templates/index.html
@@ -5,39 +5,6 @@
 <a href="/">{{ config.app.name }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -9,6 +9,8 @@ app:
   # Meta author that will show up in Google search results
   meta_author: HaxGeo.com
 
+  facebook_app_id: 211870442664924
+
   # When the map loads, existing places will be loaded in chunks. By default,
   # the size of the chunks will be a reasonable default dictated by the API
   # server. If you would like to override the chunk size, use this setting:

--- a/src/flavors/pboakland/templates/index.html
+++ b/src/flavors/pboakland/templates/index.html
@@ -24,4 +24,25 @@
   Analytics, custom JS, and such go here
  -->
 {% block includes %}
+
+<!-- Facebook widgets -->
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : {{ config.app.facebook_app_id }},
+      xfbml      : true,
+      version    : 'v2.9'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
+
 {% endblock %}

--- a/src/flavors/pboakland/templates/index.html
+++ b/src/flavors/pboakland/templates/index.html
@@ -7,39 +7,6 @@
 </a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/pugetsound/templates/index.html
+++ b/src/flavors/pugetsound/templates/index.html
@@ -5,39 +5,6 @@
 <a href="/">{{ config.app.name }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/rail/templates/index.html
+++ b/src/flavors/rail/templates/index.html
@@ -5,39 +5,6 @@
 <a href="/">{{ config.app.name }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/raingardens/config.yml
+++ b/src/flavors/raingardens/config.yml
@@ -11,6 +11,8 @@ app:
   # Meta author that will show up in Google search results
   meta_author: SmarterCleanup.org
 
+  facebook_app_id: 1877110258972873
+
 
   # When the map loads, existing places will be loaded in chunks. By default,
   # the size of the chunks will be a reasonable default dictated by the API

--- a/src/flavors/raingardens/templates/index.html
+++ b/src/flavors/raingardens/templates/index.html
@@ -5,42 +5,6 @@
 <a href="{{ config.app.link }}"><img src="/static/css/images/12000_logo_wide.png"></a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/raingardens/templates/index.html
+++ b/src/flavors/raingardens/templates/index.html
@@ -33,4 +33,24 @@
     })
   }(Shareabouts));
 </script>
+
+<!-- Facebook widgets -->
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : {{ config.app.facebook_app_id }},
+      xfbml      : true,
+      version    : 'v2.9'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
 {% endblock %}

--- a/src/flavors/snoqualmie/templates/index.html
+++ b/src/flavors/snoqualmie/templates/index.html
@@ -5,43 +5,6 @@
 <a href="/">{{ config.app.name }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-    <meta name="og:image" content="{{STATIC_URL}}css/images/fb-thumbnail.png">
-
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/trees/templates/index.html
+++ b/src/flavors/trees/templates/index.html
@@ -5,42 +5,6 @@
 <a href="{{ config.app.link }}">{{ config.app.title }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-    <meta name="twitter:widgets:csp" content="on"> <!--- # Added by LMS for SSL compatibility --->
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/waterfront/templates/index.html
+++ b/src/flavors/waterfront/templates/index.html
@@ -5,39 +5,6 @@
 <a href="/">{{ config.app.name }}</a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->

--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -9,6 +9,8 @@ app:
   # Meta author that will show up in Google search results
   meta_author: smartercleanup.org
 
+  facebook_app_id: 1925392277683737
+
 
   # When the map loads, existing places will be loaded in chunks. By default,
   # the size of the chunks will be a reasonable default dictated by the API

--- a/src/flavors/willamette/templates/index.html
+++ b/src/flavors/willamette/templates/index.html
@@ -24,4 +24,25 @@
   Analytics, custom JS, and such go here
  -->
 {% block includes %}
+
+<!-- Facebook widgets -->
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId      : {{ config.app.facebook_app_id }},
+      xfbml      : true,
+      version    : 'v2.9'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>
+
 {% endblock %}

--- a/src/flavors/willamette/templates/index.html
+++ b/src/flavors/willamette/templates/index.html
@@ -7,39 +7,6 @@
 </a>
 {% endblock %}
 
-{% block meta %}
-  {% if place %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ place.properties.name }}">
-    <meta name="twitter:description" content="{{ place.properties.description }}">
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="twitter:image:src" content="{{ attachment.file }}">
-    {% endwith %}
-    {% comment %} TODO: Fill this in when we know if the username is from twitter
-      <meta name="twitter:creator" content="place.submitter.username">
-    {% endcomment %}
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ place.properties.name }}" />
-    <meta property="og:description" content="{{ place.properties.description }}" />
-    {% with attachment=place.properties.attachments|first %}
-    <meta name="og:image" content="{{ attachment.file }}">
-    {% endwith %}
-  {% else %}
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ config.app.title }}">
-    <meta name="twitter:description" content="{{ config.app.meta_description }}">
-
-    <!-- Facebook -->
-    <meta property="og:site_name" content="{{ config.app.title }}" />
-    <meta property="og:title" content="{{ config.app.title }}" />
-    <meta property="og:description" content="{{ config.app.meta_description }}" />
-  {% endif%}
-{% endblock %}
-
 <!--
   This will place content at the top of the side bar
  -->


### PR DESCRIPTION
Addresses: #292, #655 

#### Changes introduced:
* Remove a hard-coded use of the `place/` dataset slug in a template helper function used for generating Twitter and Facebook sharing urls
~~* Move all social meta tag handling client-side. That way, we can update the content of meta tags as users navigate around the app, instead of relying on the Django-generated tags on page load. This actually addresses a bit of #655~~
* Use the social.mapseed.org microservice to create sharing metadata

