### PR TITLE
Rewrite README for standard-readme compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
-### Hey Duwamish! - [HeyDuwamish.org](http://heyduwamish.org)
-### Hey Willamette! - [HeyWillamette.org](http://heywillamette.org)
-
-Community powered mapping for environmental health, starting with our most polluted rivers.
+# Mapseed _(platform)_
 
 [![Build Status](https://secure.travis-ci.org/mapseed/platform.png)](http://travis-ci.org/mapseed/platform)
-===========
-For a brief summary, please view: [http://smartercleanup.org/](http://smartercleanup.org/)
 
-Take a look at our [roadmap](https://github.com/mapseed/platform/wiki/Roadmap) to see where we're headed
+> Community powered mapping for environmental health, starting with our most polluted rivers.
 
-Local Setup
--------------
-Hey Duwamish! requires Python 2.7 ([Instructions for Windows found **here**](/doc/WINDOWS_SETUP.md)).
+Mapseed is a platform that allows anyone to create community-driven maps on the web. These maps allow users to report issues or submit ideas and respond to the issues & ideas of others. Combine user-generated content with exterior data overlaid on the same map to allow anyone to see what's going on in the area at a glance.
+
+## Table of Contents
+
+## Background
+
+Mapseed was originally developed for tracking the environmental cleanup of the Duwamish River. [HeyDuwamish.org](http://heyduwamish.org) runs on Mapseed. It's now used for several other websites, including [HeyWillamette.org](http://heywillamette.org). You can find out more at [SmarterCleanup.org](http://smartercleanup.org).
+
+The Mapseed platform is a fork of [Shareabouts](https://github.com/openplans/shareabouts), which was developed by [OpenPlans](http://openplans.org/) before they closed in 2014. It is a "spiritual successor" to [Qué Pasa Riachuelo?](https://github.com/garagelab/qpr2).
+
+## Install
+
+Hey Duwamish! requires Python 2.7 ([Instructions for Windows](/doc/WINDOWS_SETUP.md)) and [Node + and the latest npm](https://nodejs.org/en/download/package-manager/).
 
 Install `pip` and `virtualenv`, if not already installed. These will keep your python code isolated from the rest of your machine and ensure you have the correct versions.
 
@@ -38,32 +43,63 @@ source env/bin/activate
 pip install -r app-requirements.txt
 ```
 
-NOTE: If you run into trouble with gevent, you can safely comment it out of the requirements.txt file. It is not needed for local development. To comment it out, just add a hash "`#`" to the beginning of the line for `gevent`.
+Now install npm dependencies:
 
-NOTE: If you have trouble with `pip install -r app-requirements.txt`, you may need to install the Python development libraries (for Python.h). The Windows installation has them by default, but some UNIX-based systems with a pre-installed Python may not. On such systems, you may need to run `sudo apt-get install python-dev` or download a fresh installer from python.org.
+```
+# In project folder
+npm install
+```
 
-NOTE: For Linux users on RHEL/CentOS distros, you will need to have the following libraries installed: `sudo yum groupinstall 'Development Tools'` and `sudo yum install python-devel postgresql-devel`
+**NOTE:** If you run into trouble with gevent, you can safely comment it out of the requirements.txt file. It is not needed for local development. To comment it out, just add a hash "`#`" to the beginning of the line for `gevent`.
 
-NOTE: Mac OS X users need a command line C/C++ compiler in place for the above steps to work. This can be done by downloading Xcode from the App Store and then installing the Command Line Tools via Xcode's Preferences > Downloads area.
+**NOTE:** If you have trouble with `pip install -r app-requirements.txt`, you may need to install the Python development libraries (for Python.h). The Windows installation has them by default, but some UNIX-based systems with a pre-installed Python may not. On such systems, you may need to run `sudo apt-get install python-dev` or download a fresh installer from python.org.
 
-### Install npm dependencies
+**NOTE:** For Linux users on RHEL/CentOS distros, you will need to have the following libraries installed: `sudo yum groupinstall 'Development Tools'` and `sudo yum install python-devel postgresql-devel`
 
-Make sure that you are somewhere inside the project folder, then run:
+**NOTE:** Mac OS X users need a command line C/C++ compiler in place for the above steps to work. This can be done by downloading Xcode from the App Store and then installing the Command Line Tools via Xcode's Preferences > Downloads area.
 
-`npm install`
+## Usage
 
-Also, for best results, [install Node version 7+ and the latest npm](https://nodejs.org/en/download/package-manager/).
+**If you want to create a map for your community, don't hesitate to get in touch. We can help you with the setup process!**
 
-### Configuring the Dev API
+### Connecting to an API
 
-Now that you have the client installed, all you need to do is load the API. The API powers the database that manages the community generated reports.
+In order to collect and store user reports, the map must be configured to connect to a [Mapseed API](https://github.com/mapseed/api) backend.
 
-The platform is capable of manging multiple "flavors" - a flavor is a custom front end map deployment that can have it's own configuration and style rules, but still connect with other flavors on a shared back end, powered by the same data API.
+### Configuring
 
-Hey Duwamish has its own flavor configuration in the ``duwamish_flavor`` folder for Seattle residents, and
-Hey Willamette has its own flavor configuration in the ``willamette`` folder for Portland residents.
+To customize your map with everything from your API URL to the extra data you want to display, you'll edit your flavor's `config.yml` file. For more information on the configuration process and what options are available, see [the config documentation](https://github.com/mapseed/platform/blob/master/doc/CONFIG.md).
 
-We have a Dev API with dummy data that you can load locally. To enable it, go to the `src` folder and create a new hidden text file called `.env` and paste in the following information:
+### Starting your map server
+
+If you want to see your map in action, simply run:
+
+```
+npm start
+```
+
+By default, this will serve your map at [http://localhost:8000](http://localhost:8000).
+
+**NOTE:** If you're new to programming with virtualenv, be sure to remember to activate your virtual environment every time you start a new terminal session:
+
+```
+source env/bin/activate
+```
+
+## Maintainers
+
+- [futuresoup](https://github.com/futuresoup)
+- [LukeSwart](https://github.com/LukeSwart)
+
+## Contribute
+
+Questions and issues should be filed [right here on GitHub](https://github.com/mapseed/platform/issues).
+
+If you'd like to contribute code, we'd love to have it! Fork and submit a PR (base your branch off `master`). No change is too small!
+
+### Use the Dev API
+
+If you want to develop without setting up your own [Mapseed API backend](https://github.com/mapseed/api), we've got you covered! Copy and paste this into `src/.env` to connect your local install to the Dev API (full of dummy Duwamish data):
 
 ```
 FLAVOR=duwamish_flavor
@@ -80,33 +116,6 @@ AIR_SITE_URL=https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/air/
 AIR_DATASET_KEY=MTc3Y2E2OGM2NDQyMWYyZjJhNWVhM2E4
 ```
 
-If you want to load a different flavor, like Hey Willamette, just replace the first line with ``FLAVOR=willamette``
+## License
 
-NOTE: Flavors can load data from any number of Shareabouts datasets, provided you have a URL and key for each dataset you'd like to load. Dataset URLs and keys are set in your `.env` file, as follows:
-
-```
-<DATASET-ID>_SITE_URL=https://path/to/dataset/
-<DATASET-ID>_DATASET_KEY=dataset_key
-```
-
-`<DATASET-ID>` should be replaced with the id (in UPPERCASE) of your dataset. This is the same id that is referenced in your flavor's `config.yml` file, and corrseponds to the value of the dataset's `Slug` property defined when the dataset was created.
-
-Now you're ready to run your server locally. Just enter this command:
-
-```
-npm start
-```
-The server will, by default, be started at http://localhost:8000/. [Here is the documentation](https://github.com/openplans/shareabouts/blob/master/doc/CONFIG.md) if you want to reconfigure it.
-
-NOTE: If you're new to programming with virtualenv, be sure to remember to activate your virtual environment every time you start a new terminal session:
-
-```
-source env/bin/activate
-```
-
-Credits
--------------
-Many features are powered by Shareabouts, an open-source project of [OpenPlans](http://openplans.org).
-
-Read more about Shareabouts and find links to recent sites [on the OpenPlans website](http://openplans.org/shareabouts/).
-
+[GNU GPL](https://github.com/mapseed/platform/blob/master/LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This module, `platform`, is the tool for creating the maps themselves, while the
 
 Mapseed was originally developed for tracking the environmental cleanup of the Duwamish River. [HeyDuwamish.org](http://heyduwamish.org) runs on Mapseed. It's now used for several other websites, including [HeyWillamette.org](http://heywillamette.org). You can find out more at [SmarterCleanup.org](http://smartercleanup.org).
 
-The Mapseed platform is a fork of [Shareabouts](https://github.com/openplans/shareabouts), which was developed by [OpenPlans](http://openplans.org/) before they closed in 2014. It is a "spiritual successor" to [Qué Pasa Riachuelo?](https://github.com/garagelab/qpr2).
+The Mapseed platform is a fork of [Shareabouts](https://github.com/openplans/shareabouts), which was developed by [OpenPlans](http://openplans.org/) before they closed in 2015. It is a "spiritual successor" to [Qué Pasa Riachuelo?](https://github.com/garagelab/qpr2).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This module, `platform`, is the tool for creating the maps themselves, while the
 
 ## Table of Contents
 
+- [Background](#background)
+- [Install](#install)
+- [Usage](#usage)
+  - [Connecting to an API](#connecting-to-an-api)
+  - [Configuring](#configuring)
+  - [Starting your map server](#starting-your-map-server)
+- [Maintainers](#maintainers)
+- [Contribute](#contribute)
+  - [Use the Dev API](#use-the-dev-api)
+- [License](#license)
+
 ## Background
 
 Mapseed was originally developed for tracking the environmental cleanup of the Duwamish River. [HeyDuwamish.org](http://heyduwamish.org) runs on Mapseed. It's now used for several other websites, including [HeyWillamette.org](http://heywillamette.org). You can find out more at [SmarterCleanup.org](http://smartercleanup.org).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 > Community powered mapping for environmental health, starting with our most polluted rivers.
 
-Mapseed is a platform that allows anyone to create community-driven maps on the web. These maps allow users to report issues or submit ideas and respond to the issues & ideas of others. Combine user-generated content with exterior data overlaid on the same map to allow anyone to see what's going on in the area at a glance.
+Mapseed is a platform that allows anyone to create community-driven maps on the web. These maps allow users to report issues or submit ideas and respond to the issues & ideas of others. Combine user-generated content with external data overlaid on the same map to allow anyone to see what's going on in the area at a glance.
+
+This module, `platform`, is the tool for creating the maps themselves, while the [`api` module](https://github.com/mapseed/api) collects the user reports on the backend.
 
 ## Table of Contents
 


### PR DESCRIPTION
Very open to suggestions/feedback on this. I'm attempting to follow [the standard-readme spec](https://github.com/RichardLitt/standard-readme/blob/master/spec.md), which I think gives good structure. Of note is how much more focused this `README` is on users, as opposed to contributors.

A few things to note:
- I used our already-existing short description "Community powered mapping for environmental health, starting with our most polluted rivers" although with the Mapseed name we seem to have outgrown it.
  - We also need to change our Github repo description to match the short description.
- I listed @LukeSwart and @futuresoup as maintainers, but I wasn't sure.
- Our [license](https://github.com/mapseed/platform/blob/master/LICENSE.txt) appears to be an unchanged holdover from Shareabouts, and lists OpenPlans as the copyright holder. IANAL so I didn't want to mess with it, but we should update that.