### PR TITLE
add WMTS support

### DIFF
--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -384,6 +384,23 @@
           .on('error', function(err) {
             Util.log('Cartodb layer creation error:', err);
           });
+      } else if (config.type && config.type === 'wmts') {
+        layer = L.tileLayer.wmts(config.url, {
+          service: 'WMTS',
+          tilematrixSet: config.tilematrixSet,
+          layers: config.layers,
+          format: config.format,
+          transparent: config.transparent,
+          version: config.version,
+          crs: L.CRS.EPSG3857,
+          // default TileLayer options
+          attribution: config.attribution,
+          opacity: config.opacity,
+          fillColor: config.color,
+          weight: config.weight,
+          fillOpacity: config.fillOpacity
+        });
+        self.layers[config.id] = layer;
       } else if (config.layers) {
         // If "layers" is present, then we assume that the config
         // references a Leaflet WMS layer.

--- a/src/base/static/libs/leaflet-wmts.js
+++ b/src/base/static/libs/leaflet-wmts.js
@@ -1,0 +1,85 @@
+L.TileLayer.WMTS = L.TileLayer.extend({
+
+    defaultWmtsParams: {
+        service: 'WMTS',
+        request: 'GetTile',
+        version: '1.0.0',
+        layer: '',
+        style: '',
+        tilematrixSet: '',
+        format: 'image/jpeg'
+    },
+
+    initialize: function (url, options) { // (String, Object)
+        this._url = url;
+        var wmtsParams = L.extend({}, this.defaultWmtsParams),
+        tileSize = options.tileSize || this.options.tileSize;
+        if (options.detectRetina && L.Browser.retina) {
+            wmtsParams.width = wmtsParams.height = tileSize * 2;
+        } else {
+            wmtsParams.width = wmtsParams.height = tileSize;
+        }
+        for (var i in options) {
+            // all keys that are not TileLayer options go to WMTS params
+            if (!this.options.hasOwnProperty(i) && i!="matrixIds") {
+                wmtsParams[i] = options[i];
+            }
+        }
+        this.wmtsParams = wmtsParams;
+        this.matrixIds = options.matrixIds||this.getDefaultMatrix();
+        L.setOptions(this, options);
+    },
+
+    onAdd: function (map) {
+        L.TileLayer.prototype.onAdd.call(this, map);
+    },
+
+    getTileUrl: function (tilePoint, zoom) { // (Point, Number) -> String
+        var map = this._map;
+        crs = map.options.crs;
+        tileSize = this.options.tileSize;
+        nwPoint = tilePoint.multiplyBy(tileSize);
+        //+/-1 in order to be on the tile
+        nwPoint.x+=1;
+        nwPoint.y-=1;
+        sePoint = nwPoint.add(new L.Point(tileSize, tileSize));
+        nw = crs.project(map.unproject(nwPoint, zoom));
+        se = crs.project(map.unproject(sePoint, zoom));
+        tilewidth = se.x-nw.x;
+        zoom=map.getZoom();
+        ident = this.matrixIds[zoom].identifier;
+        X0 = this.matrixIds[zoom].topLeftCorner.lng;
+        Y0 = this.matrixIds[zoom].topLeftCorner.lat;
+        tilecol=Math.floor((nw.x-X0)/tilewidth);
+        tilerow=-Math.floor((nw.y-Y0)/tilewidth);
+        url = L.Util.template(this._url, {s: this._getSubdomain(tilePoint)});
+        return url + L.Util.getParamString(this.wmtsParams, url) + "&tilematrix=" + ident + "&tilerow=" + tilerow +"&tilecol=" + tilecol ;
+    },
+
+    setParams: function (params, noRedraw) {
+        L.extend(this.wmtsParams, params);
+        if (!noRedraw) {
+            this.redraw();
+        }
+        return this;
+    },
+    
+    getDefaultMatrix : function () {
+        /**
+         * the matrix3857 represents the projection 
+         * for in the IGN WMTS for the google coordinates.
+         */
+        var matrixIds3857 = new Array(22);
+        for (var i= 0; i<22; i++) {
+            matrixIds3857[i]= {
+                identifier    : "" + i,
+                topLeftCorner : new L.LatLng(20037508.3428,-20037508.3428)
+            };
+        }
+        return matrixIds3857;
+    }
+});
+
+L.tileLayer.wmts = function (url, options) {
+    return new L.TileLayer.WMTS(url, options);
+};

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -232,6 +232,7 @@
   <script src="{{STATIC_URL}}libs/gatekeeper.js"></script>
   <script src="{{STATIC_URL}}libs/swag.min.js"></script>
   <script src="{{STATIC_URL}}libs/leaflet.sidebar.js"></script>
+  <script src="{{STATIC_URL}}libs/leaflet-wmts.js"></script>
   
   <script>
     moment.locale('{{LANGUAGE_CODE}}');


### PR DESCRIPTION
This PR adds support for WMTS layers (an optimized version of WMS layers) via a [small plugin](https://github.com/mylen/leaflet.TileLayer.WMTS) and a new layer type setting.

Use `type: wmts` in the layer config to declare a WMTS layer.