### PR TITLE
Optimize layer view performance

### DIFF
--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -27,22 +27,8 @@
       // Create arrays of functions representing parsed versions of style rules
       // found in the config. This prevents us from having to re-parse each
       // style rule on every map zoom for every layer view.
-      _.each(this.placeType.rules, function(rule) {
-        var fn = new Function(["return ", rule.condition, ";"].join(""));
-
-        fn.props = {};
-
-        _.each(rule, function(prop, key) {
-          if (prop !== "condition") {
-            fn.props[key] = prop;
-          }
-        }, this);
-
-        this.styleRules.push(fn);
-      }, this);
-
-      if (this.placeType.hasOwnProperty("zoomType")) {
-        _.each(this.options.placeTypes[this.placeType.zoomType], function(rule) {
+      if (this.placeType) {
+        _.each(this.placeType.rules, function(rule) {
           var fn = new Function(["return ", rule.condition, ";"].join(""));
 
           fn.props = {};
@@ -53,8 +39,24 @@
             }
           }, this);
 
-          this.zoomRules.push(fn);
+          this.styleRules.push(fn);
         }, this);
+
+        if (this.placeType.hasOwnProperty("zoomType")) {
+          _.each(this.options.placeTypes[this.placeType.zoomType], function(rule) {
+            var fn = new Function(["return ", rule.condition, ";"].join(""));
+
+            fn.props = {};
+
+            _.each(rule, function(prop, key) {
+              if (prop !== "condition") {
+                fn.props[key] = prop;
+              }
+            }, this);
+
+            this.zoomRules.push(fn);
+          }, this);
+        }
       }
 
       this.evaluateStyleAndZoomRules();

--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -21,7 +21,9 @@
       this.model.on('unfocus', this.unfocus, this);
       this.model.on('destroy', this.onDestroy, this);
 
-      this.map.on('zoomend', this.render, this);
+      if (!this.options.mapView.options.mapConfig.suppress_zoom_rules) {
+        this.map.on('zoomend', this.render, this);
+      }
 
       // Create arrays of functions representing parsed versions of style rules
       // found in the config. This prevents us from having to re-parse each

--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -21,7 +21,6 @@
       this.model.on('unfocus', this.unfocus, this);
       this.model.on('destroy', this.onDestroy, this);
 
-      this.map.on('moveend', this.throttledRender, this);
       this.map.on('zoomend', this.render, this);
 
       // Create arrays of functions representing parsed versions of style rules
@@ -174,19 +173,9 @@
     },
     render: function() {
       if (!this.isEditing && this.layer) {
-
-        // For point geometry:
-        if (this.layer.getLatLng &&
-            this.map.getBounds().contains(this.layer.getLatLng())) {
-          this.updateLayer();
-        
-        // For polygonal and linestring geometry:
-        } else if (this.layer.getBounds &&
-            this.map.getBounds().intersects(this.layer.getBounds())) {
-          this.updateLayer();
-        } else {
-          this.hide();
-        }
+        this.updateLayer();
+      } else {
+        this.hide();
       }
     },
     updateLayer: function() {

--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -144,11 +144,10 @@
     isPublishable: function() {
       if (this.layerIsAdminControlled) {
         return true;
-      } else if (this.model.get("published") && this.model.get("published") === "isNotPublished") {
-        return false;
       }
 
-      return true;
+      return !this.model.get("published") ||
+             this.model.get("published") !== "isNotPublished"
     },
     onDestroy: function() {
       // NOTE: it's necessary to remove the zoomend event here

--- a/src/base/static/libs/leaflet.argo.js
+++ b/src/base/static/libs/leaflet.argo.js
@@ -214,6 +214,105 @@ L.extend(L.Argo, {
   }
 });
 
+L.extend(L.Argo, {   
+   // http://mir.aculo.us/2011/03/09/little-helpers-a-tweet-sized-javascript-templating-engine/    
+   t: function t(str, obj){
+     function find(obj, key) {   
+       var parts, partKey;   
+       if (!obj) {   
+         return obj;   
+       }   
+     
+       if (key.indexOf('.') > -1) {    
+         parts = key.split('.');   
+         partKey = parts.shift();    
+         return find(obj[partKey], parts.join('.'));   
+       } else {    
+         return obj[key];    
+       }   
+     }   
+     
+     var regex = /\{\{ *([\w\.-]+) *\}\}/g,    
+       matches = str.match(regex),   
+       val, m, i;    
+     
+     if (matches) {    
+       for (i=0; i<matches.length; i++) {    
+         m = matches[i].replace(/[\{\}]/g, '');    
+         val = find(obj, m);   
+     
+         str=str.replace(new RegExp(matches[i], 'g'), val);    
+       }   
+     }   
+     
+     return str;   
+   },    
+     
+   getZoomRule: function(properties, rules) {    
+     var self = this,    
+       i, condition, len;    
+     
+     // Cycle through rules until we hit a matching condition    
+     for (i=0, len=rules.length; i<len; i++) {   
+       // Replace the template with the property variable, not the value.    
+       // this is so we don't have to worry about strings vs nums.         
+       condition = L.Argo.t(rules[i].condition, properties.style);   
+     
+       if (eval(condition)) {   
+         // The new property values (outlined in the config) are added for Leaflet compatibility   
+         // Format marker icon features    
+         if (rules[i].icon) {    
+           // Icon must be set when evaling zoom rules   
+           _.extend(properties.icon, rules[i].icon);   
+         }   
+     
+         return properties;    
+       }   
+     }   
+     return properties;    
+   },    
+   // Get the style rule for this feature by evaluating the condition option   
+   getStyleRule: function(properties, rules) {   
+     var self = this,    
+       i, condition, len;    
+     
+     // Cycle through rules until we hit a matching condition    
+     for (i=0, len=rules.length; i<len; i++) {   
+       // Replace the template with the property variable, not the value.    
+       // this is so we don't have to worry about strings vs nums.   
+       condition = L.Argo.t(rules[i].condition, ((properties.style) ? properties.style : properties));   
+     
+       if (eval(condition)) {   
+         // The new property values (outlined in the config) are added for Leaflet compatibility   
+         for (var key in rules[i].style) {   
+           if (rules[i].style.hasOwnProperty(key)) {   
+             if (typeof rules[i].style[key] == 'string' || rules[i].style[key] instanceof String) {    
+               value = L.Argo.t(rules[i].style[key], properties);    
+               properties[key] = value;    
+             } else {    
+               properties[key] = rules[i].style[key];    
+             }   
+           } else {    
+             console.log("Non-property key is discovered at: " + key);   
+             console.log("The config rule is incompatible with this feature.");    
+           }   
+         }   
+     
+         properties = {'style' : properties};    
+     
+         // Format marker icon features    
+         if (rules[i].icon) {    
+           properties.focus_icon = rules[i].focus_icon;    
+           properties.icon = rules[i].icon;    
+         }   
+     
+         return properties;    
+       }   
+     }   
+     return null;    
+   }   
+ });
+
 L.argo = function (geojson, options) {
   return new L.Argo(geojson, options);
 };

--- a/src/base/static/libs/leaflet.argo.js
+++ b/src/base/static/libs/leaflet.argo.js
@@ -4,8 +4,6 @@
  * Argo turns any GeoJSON data into a Leaflet layer.
  */
 
-var parse = require('./static-parser.js');
-
 L.Argo = L.GeoJSON.extend({
 
   initialize: function (geojson, options) {

--- a/src/base/static/libs/static-parser.js
+++ b/src/base/static/libs/static-parser.js
@@ -1,8 +1,0 @@
-var evaluate = require('static-eval');
-var parse = require('esprima').parse;
-
-module.exports = {
-  staticParse: function(condition) {
-  	return evaluate(parse(condition).body[0].expression);
-  }
-}

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -233,7 +233,8 @@
   <script src="{{STATIC_URL}}libs/swag.min.js"></script>
   <script src="{{STATIC_URL}}libs/leaflet.sidebar.js"></script>
   <script src="{{STATIC_URL}}libs/leaflet-wmts.js"></script>
-  
+  <script src="{{STATIC_URL}}libs/leaflet.argo.js"></script>
+
   <script>
     moment.locale('{{LANGUAGE_CODE}}');
     $(function() {

--- a/src/flavors/bogtobay/config.yml
+++ b/src/flavors/bogtobay/config.yml
@@ -147,21 +147,21 @@ map:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Overflowed in the last 48 hrs"'
           icon:
-            iconUrl: /static/css/images/markers/dot-dbcf2c.png
+            iconUrl: /static/css/images/markers/dot-f95016.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Overflowing now"'
           icon:
-            iconUrl: /static/css/images/markers/dot-f95016.png
+            iconUrl: /static/css/images/markers/dot-e1264d.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Data not available"'
           icon:
-            iconUrl: /static/css/images/markers/dot-5359d7.png
+            iconUrl: /static/css/images/markers/dot-0d85e9.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
@@ -199,45 +199,45 @@ map:
 place_types:
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
 
   roundZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 11'
+    - condition: 'this.map.zoom < 11'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 11'
+    - condition: 'this.map.zoom >= 11'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
 
   teardropZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 60]
         iconAnchor: [25, 25]
         shadowSize: [50, 60]
         shadowAnchor: [14, 60]
-    - condition: '{{map.zoom}} < 11'
+    - condition: 'this.map.zoom < 11'
       icon:
         iconSize: [20, 24]
         iconAnchor: [10, 24]
-    - condition: '{{map.zoom}} >= 11'
+    - condition: 'this.map.zoom >= 11'
       icon:
         iconSize: [38, 46]
         iconAnchor: [19, 46]
@@ -246,21 +246,21 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: "this.geometry.type == 'LineString'"
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.properties.stroke"
+          opacity: "this.properties['stroke-opacity']"
+          weight: "this.properties['stroke-width']"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: "this.geometry.type == 'Polygon'"
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.properties.fill"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.properties.stroke"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.properties['fill-opacity']"
+          weight: "this.properties['stroke-width']"
 
   danger:
     zoomType: mapboxZoomStyle
@@ -365,7 +365,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -374,19 +374,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -395,7 +395,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -404,19 +404,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -425,7 +425,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -434,19 +434,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -455,7 +455,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -464,19 +464,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -485,7 +485,7 @@ place_types:
   # greenwall:
   #   label: _(Green Screen Vote)
   #   rules:
-  #     - condition: '{{layer.focused}} === true'
+  #     - condition: 'this.layer.focused === true'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         shadowUrl: /static/css/images/marker-shadow.png
@@ -494,19 +494,19 @@ place_types:
   #         shadowSize: [50, 60]
   #         shadowAnchor: [14, 60]
 
-  #     - condition: '{{map.zoom}} < 15'
+  #     - condition: 'this.map.zoom < 15'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [10, 12]
   #         iconAnchor: [5, 12]
 
-  #     - condition: '{{map.zoom}} < 18'
+  #     - condition: 'this.map.zoom < 18'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [18, 21.75]
   #         iconAnchor: [9, 21.75]
 
-  #     - condition: '{{map.zoom}} >= 18'
+  #     - condition: 'this.map.zoom >= 18'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [38, 46]
@@ -516,7 +516,7 @@ place_types:
   air_watch:
     label: _(Air Watch)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -525,19 +525,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [18, 21.75]
           iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 17'
+      - condition: 'this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [38, 46]

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -197,21 +197,21 @@ map:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Overflowed in the last 48 hrs"'
           icon:
-            iconUrl: /static/css/images/markers/dot-dbcf2c.png
+            iconUrl: /static/css/images/markers/dot-f95016.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Overflowing now"'
           icon:
-            iconUrl: /static/css/images/markers/dot-f95016.png
+            iconUrl: /static/css/images/markers/dot-e1264d.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Data not available"'
           icon:
-            iconUrl: /static/css/images/markers/dot-5359d7.png
+            iconUrl: /static/css/images/markers/dot-0d85e9.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
@@ -249,35 +249,35 @@ map:
 place_types:
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
 
   roundZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 11'
+    - condition: 'this.map.zoom < 11'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 11'
+    - condition: 'this.map.zoom >= 11'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
 
   teardropZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 60]
         iconAnchor: [25, 25]
@@ -288,21 +288,21 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: "this.geometry.type == 'LineString'"
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.properties.stroke"
+          opacity: "this.properties['stroke-opacity']"
+          weight: "this.properties['stroke-width']"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: "this.geometry.type == 'Polygon'"
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.properties.fill"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.properties.stroke"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.properties['fill-opacity']"
+          weight: "this.properties['stroke-width']"
 
   danger:
     zoomType: mapboxZoomStyle
@@ -362,17 +362,17 @@ place_types:
 
   conserve-water:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-conserve-water.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-conserve-water.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -380,17 +380,17 @@ place_types:
 
   prevent-stormwater:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-prevent-stormwater-pollution.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-prevent-stormwater-pollution.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -398,17 +398,17 @@ place_types:
 
   only-flush:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-only-flush-this.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-only-flush-this.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -416,17 +416,17 @@ place_types:
 
   conserve-energy:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-conserve-energy.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-conserve-energy.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -434,17 +434,17 @@ place_types:
 
   waste-less:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-waste-less.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-waste-less.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -452,17 +452,17 @@ place_types:
 
   commute-low-carbon:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-commute-low-carbon.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-commute-low-carbon.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -470,17 +470,17 @@ place_types:
 
   eat-local-organic:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-eat-local-organic.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-eat-local-organic.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -488,17 +488,17 @@ place_types:
 
   restore-salmon-habitat:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-restore-salmon-habitat.png
           iconSize: [50, 60]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-restore-salmon-habitat.png
           iconSize: [38, 46]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-dot-commute-low-carbon.png
           iconSize: [10, 10]
@@ -518,7 +518,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -527,19 +527,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -548,7 +548,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -557,19 +557,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -578,7 +578,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -587,19 +587,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -608,7 +608,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -617,19 +617,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -638,7 +638,7 @@ place_types:
   # greenwall:
   #   label: _(Green Screen Vote)
   #   rules:
-  #     - condition: '{{layer.focused}} === true'
+  #     - condition: 'this.layer.focused === true'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         shadowUrl: /static/css/images/marker-shadow.png
@@ -647,19 +647,19 @@ place_types:
   #         shadowSize: [50, 60]
   #         shadowAnchor: [14, 60]
 
-  #     - condition: '{{map.zoom}} < 15'
+  #     - condition: 'this.map.zoom < 15'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [10, 12]
   #         iconAnchor: [5, 12]
 
-  #     - condition: '{{map.zoom}} < 18'
+  #     - condition: 'this..zoom < 18'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [18, 21.75]
   #         iconAnchor: [9, 21.75]
 
-  #     - condition: '{{map.zoom}} >= 18'
+  #     - condition: 'this.map.zoom >= 18'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [38, 46]
@@ -669,7 +669,7 @@ place_types:
   air_watch:
     label: _(Air Watch)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -678,19 +678,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [18, 21.75]
           iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 17'
+      - condition: 'this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [38, 46]

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -65,7 +65,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -74,19 +74,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -95,7 +95,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -104,19 +104,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -125,7 +125,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -134,19 +134,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -155,7 +155,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -164,19 +164,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -185,7 +185,7 @@ place_types:
   greenwall:
     label: _(Green Screen Vote)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -194,19 +194,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 18'
+      - condition: 'this.map.zoom < 18'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [18, 21.75]
           iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 18'
+      - condition: 'this.map.zoom >= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [38, 46]

--- a/src/flavors/duwamish-watershed/config.yml
+++ b/src/flavors/duwamish-watershed/config.yml
@@ -129,7 +129,7 @@ map:
 place_types:
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [45, 64]
         iconAnchor: [23, 64]
@@ -142,21 +142,21 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.style.color"
+          opacity: "this.style.opacity"
+          weight: "this.style.weight"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.style.fillColor"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.style.color"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.style.fillOpacity"
+          weight: "this.style.weight"
 
   danger:
     zoomType: mapboxZoomStyle
@@ -218,7 +218,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -227,19 +227,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -248,7 +248,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -257,19 +257,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -278,7 +278,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -287,19 +287,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -308,7 +308,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -317,19 +317,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -338,7 +338,7 @@ place_types:
   air_watch:
     label: _(Air Watch)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -347,19 +347,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [18, 21.75]
           iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 17'
+      - condition: 'this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [38, 46]

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -236,11 +236,11 @@ place_types:
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 15'
+    - condition: 'this.map.zoom < 15'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 15'
+    - condition: 'this.map.zoom >= 15'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
@@ -263,16 +263,16 @@ place_types:
 
   featured_place:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-construction-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-construction.png
           iconSize: [30, 30]
@@ -280,55 +280,55 @@ place_types:
 
   wetland:
     rules:
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_comp.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_prog.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_no-prog-or-dead.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-comp-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-prog-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-no-prog-or-dead-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_comp.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_prog.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_no-prog-or-dead.png
           iconSize: [25, 25]
@@ -336,55 +336,55 @@ place_types:
 
   park:
     rules:
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_comp.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_prog.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_no-prog-or-dead.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-comp-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-prog-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-no-prog-or-dead-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_comp.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_prog.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_no-prog-or-dead.png
           iconSize: [25, 25]
@@ -392,55 +392,55 @@ place_types:
 
   school:
     rules:
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_comp.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_prog.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_no-prog-or-dead.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-comp-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-prog-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-no-prog-or-dead-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_comp.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_prog.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_no-prog-or-dead.png
           iconSize: [25, 25]
@@ -448,55 +448,55 @@ place_types:
 
   police:
     rules:
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_comp.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_prog.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_no-prog-or-dead.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-comp-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-prog-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-no-prog-or-dead-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_comp.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_prog.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_no-prog-or-dead.png
           iconSize: [25, 25]
@@ -504,55 +504,55 @@ place_types:
 
   rail:
     rules:
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_comp.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_prog.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_no-prog-or-dead.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-comp-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-prog-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-no-prog-or-dead-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_comp.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_prog.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_no-prog-or-dead.png
           iconSize: [25, 25]
@@ -560,55 +560,55 @@ place_types:
 
   town-hall:
     rules:
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_comp.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_prog.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{layer.focused}} === true && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.layer.focused === true && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_no-prog-or-dead.png
           iconSize: [60, 60]
           iconAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-comp-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-prog-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 15 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom < 15 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-no-prog-or-dead-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "a3e46b"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_comp.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f1f075"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_prog.png
           iconSize: [25, 25]
           iconAnchor: [12.5, 12.5]
 
-      - condition: '{{map.zoom}} < 17 && "{{style.marker-color}}" == "f86767"'
+      - condition: 'this.map.zoom <= 18 && this.style["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_no-prog-or-dead.png
           iconSize: [25, 25]
@@ -636,17 +636,17 @@ place_types:
 
   danger:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-construction.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-construction-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-construction.png
           iconSize: [30, 30]
@@ -654,17 +654,17 @@ place_types:
 
   park2:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-heart.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-heart-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-heart.png
           iconSize: [30, 30]
@@ -672,17 +672,17 @@ place_types:
 
   industrial:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-industrial.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-industrial-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-industrial.png
           iconSize: [30, 30]
@@ -690,17 +690,17 @@ place_types:
 
   bicycle:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-bike.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-bike-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-bike.png
           iconSize: [30, 30]
@@ -708,17 +708,17 @@ place_types:
 
   swimming:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-swimming.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-swimming-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-swimming.png
           iconSize: [30, 30]
@@ -726,17 +726,17 @@ place_types:
 
   theatre:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-art.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-art-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-art.png
           iconSize: [30, 30]
@@ -744,17 +744,17 @@ place_types:
 
   zoo:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-whale.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-whale-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-whale.png
           iconSize: [30, 30]
@@ -762,17 +762,17 @@ place_types:
 
   tree:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-tree.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-tree-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-tree.png
           iconSize: [30, 30]
@@ -780,17 +780,17 @@ place_types:
 
   star-stroked:
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-dirtcorps.png
           iconSize: [50, 50]
           iconAnchor: [25, 25]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-dirtcorps-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-dirtcorps.png
           iconSize: [30, 30]
@@ -806,19 +806,19 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [50, 60]
           iconAnchor: [25, 30]
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-observation-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [30, 36]
@@ -827,19 +827,19 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [50, 60]
           iconAnchor: [25, 30]
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-question-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [30, 36]
@@ -848,19 +848,19 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [50, 60]
           iconAnchor: [25, 30]
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [30, 36]
@@ -869,19 +869,19 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [50, 60]
           iconAnchor: [25, 30]
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint-dot.png
           iconSize: [10, 10]
           iconAnchor: [0, 0]
-      - condition: '{{map.zoom}} <= 18'
+      - condition: 'this.map.zoom <= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [30, 36]

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -214,25 +214,25 @@ map:
 place_types:
 
   georgetownZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [60, 60]
         iconAnchor: [30, 30]
-    - condition: '{{map.zoom}} < 15'
+    - condition: 'this.map.zoom < 15'
       icon:
         iconSize: [7.5, 7.5]
         iconAnchor: [4, 4]
-    - condition: '{{map.zoom}} < 17'
+    - condition: 'this.map.zoom < 17'
       icon:
         iconSize: [25, 25]
         iconAnchor: [12.5, 12.5]
-    - condition: '{{map.zoom}} >= 17'
+    - condition: 'this.map.zoom >= 17'
       icon:
         iconSize: [40, 40]
         iconAnchor: [20, 20]
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
@@ -246,17 +246,17 @@ place_types:
         iconAnchor: [15, 15]
 
   reportsZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 60]
         iconAnchor: [25, 30]
         shadowSize: [50, 60]
         shadowAnchor: [14, 60]
-    - condition: '{{map.zoom}} < 17'
+    - condition: 'this.map.zoom < 17'
       icon:
         iconSize: [15, 18]
         iconAnchor: [7.5, 9]
-    - condition: '{{map.zoom}} >= 17'
+    - condition: 'this.map.zoom >= 17'
       icon:
         iconSize: [30, 36]
         iconAnchor: [15, 36]
@@ -618,21 +618,21 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '{{geometry.type}} == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: '"{{style.color}}'
-          opacity: '"{{style.opacity}}'
-          weight: '"{{style.weight}}'
+          color: "this.style.color"
+          opacity: "this.style.opacity"
+          weight: "this.style.weight"
     # Polygons
-      - condition: '{{geometry.type}} == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: '"{{style.fillColor}}'
+          fillColor: "this.style.fillColor"
           fill: 'true'
-          color: '"{{style.color}}'
+          color: "this.style.color"
           opacity: 0.7
-          fillOpacity: '"{{style.fillOpacity}}'
-          weight: '"{{style.weight}}'
+          fillOpacity: "this.style.fillOpacity"
+          weight: "this.style.weight"
 
   danger:
     rules:
@@ -890,7 +890,7 @@ place_types:
   # greenwall:
   #   label: _(Green Screen Vote)
   #   rules:
-  #     - condition: '{{layer.focused}} === true'
+  #     - condition: 'this.layer.focused === true'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         shadowUrl: /static/css/images/marker-shadow.png
@@ -899,19 +899,19 @@ place_types:
   #         shadowSize: [50, 60]
   #         shadowAnchor: [14, 60]
 
-  #     - condition: '{{map.zoom}} < 15'
+  #     - condition: 'this.map.zoom < 15'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [10, 12]
   #         iconAnchor: [5, 12]
 
-  #     - condition: '{{map.zoom}} < 18'
+  #     - condition: 'this.map.zoom < 18'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [18, 21.75]
   #         iconAnchor: [9, 21.75]
 
-  #     - condition: '{{map.zoom}} >= 18'
+  #     - condition: 'this.map.zoom >= 18'
   #       icon:
   #         iconUrl: /static/css/images/markers/marker-greenwall.png
   #         iconSize: [38, 46]
@@ -921,7 +921,7 @@ place_types:
   air_watch:
     label: _(Air Watch)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -930,19 +930,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [18, 21.75]
           iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 17'
+      - condition: 'this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [38, 46]

--- a/src/flavors/greensboropb/config.yml
+++ b/src/flavors/greensboropb/config.yml
@@ -71,38 +71,38 @@ place_types:
   culture:
     label: _(Art & Culture)
     rules:
-      - condition: '"{{location_type}}" === "culture" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "culture" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "culture" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "culture" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "culture" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "culture" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "culture" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "culture" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-b75ab8.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "culture" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "culture" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/fountain-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "culture" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "culture" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/fountain-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "culture" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "culture" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/fountain.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -113,38 +113,38 @@ place_types:
   education:
     label: _(Education)
     rules:
-      - condition: '"{{location_type}}" === "education" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "education" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "education" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "education" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "education" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "education" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "education" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "education" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-0f779e.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "education" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "education" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/education-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "education" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "education" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/education-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "education" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "education" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/education.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -155,38 +155,38 @@ place_types:
   environment:
     label: _(Environment)
     rules:
-      - condition: '"{{location_type}}" === "environment" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "environment" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "environment" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "environment" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "environment" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "environment" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "environment" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "environment" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-7fccd9.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "environment" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "environment" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/tree-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "environment" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "environment" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/tree-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "environment" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "environment" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/tree.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -197,38 +197,38 @@ place_types:
   parks:
     label: _(Parks & Recreation)
     rules:
-      - condition: '"{{location_type}}" === "parks" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "parks" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "parks" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "parks" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "parks" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "parks" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "parks" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "parks" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-55a504.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "parks" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "parks" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/playground-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "parks" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "parks" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/playground-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "parks" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "parks" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/playground.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -239,38 +239,38 @@ place_types:
   health:
     label: _(Public Health)
     rules:
-      - condition: '"{{location_type}}" === "health" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "health" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "health" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "health" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "health" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "health" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "health" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "health" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-ff78be.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "health" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "health" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/health-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "health" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "health" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/health-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "health" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "health" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/health.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -281,38 +281,38 @@ place_types:
   seniors:
     label: _(Seniors)
     rules:
-      - condition: '"{{location_type}}" === "seniors" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "seniors" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "seniors" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "seniors" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "seniors" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "seniors" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "seniors" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "seniors" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-c4ed52.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "seniors" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "seniors" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/seniors-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "seniors" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "seniors" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/seniors-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "seniors" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "seniors" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/seniors.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -323,38 +323,38 @@ place_types:
   streets:
     label: _(Streets & Sidewalks)
     rules:
-      - condition: '"{{location_type}}" === "streets" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "streets" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "streets" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "streets" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "streets" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "streets" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "streets" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "streets" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-8ea4b8.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "streets" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "streets" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/street-sidewalk-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "streets" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "streets" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/street-sidewalk-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "streets" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "streets" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/street-sidewalk.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -365,38 +365,38 @@ place_types:
   safety:
     label: _(Safety & Environment)
     rules:
-      - condition: '"{{location_type}}" === "safety" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "safety" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "safety" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "safety" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "safety" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "safety" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "safety" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "safety" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-fc9229.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "safety" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "safety" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/safety-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "safety" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "safety" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/safety-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "safety" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "safety" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/safety.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -407,38 +407,38 @@ place_types:
   other:
     label: _(Other Idea)
     rules:
-      - condition: '"{{location_type}}" === "other" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "other" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "other" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "other" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "other" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "other" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "other" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "other" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-ffd614.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "other" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "other" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/idea-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "other" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "other" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/idea-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "other" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "other" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/idea.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png
@@ -449,38 +449,38 @@ place_types:
   youth:
     label: _(Youth)
     rules:
-      - condition: '"{{location_type}}" === "youth" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "youth" && this.winner === "winner" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [11, 11]
           iconAnchor: [6, 6]
-      - condition: '"{{location_type}}" === "youth" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "youth" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "youth" && "{{winner}}" === "winner" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "youth" && this.winner === "winner" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/dot-white.png
           iconSize: [20, 20]
           iconAnchor: [10, 10]
 
-      - condition: '"{{location_type}}" === "youth" && {{layer.focused}} === false && {{map.zoom}} < 14'
+      - condition: 'this.location_type === "youth" && this.layer.focused === false && this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/new/dot-ffd614.png
           iconSize: [15, 15]
           iconAnchor: [8, 8]
-      - condition: '"{{location_type}}" === "youth" && {{layer.focused}} === false && {{map.zoom}} >= 14 && {{map.zoom}} < 17'
+      - condition: 'this.location_type === "youth" && this.layer.focused === false && this.map.zoom >= 14 && this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/new/youth-small.png
           iconSize: [25, 30]
           iconAnchor: [13, 30]
-      - condition: '"{{location_type}}" === "youth" && {{layer.focused}} === false && {{map.zoom}} >= 17'
+      - condition: 'this.location_type === "youth" && this.layer.focused === false && this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/new/youth-small.png
           iconSize: [40, 48]
           iconAnchor: [20, 48]
-      - condition: '"{{location_type}}" === "youth" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "youth" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/new/youth.png
           shadowUrl: /static/css/images/markers/new/marker-shadow.png

--- a/src/flavors/greenways/config.yml
+++ b/src/flavors/greenways/config.yml
@@ -118,15 +118,15 @@ map:
 place_types:
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
@@ -135,26 +135,26 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.style.color"
+          opacity: "this.style.opacity"
+          weight: "this.style.weight"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.style.fillColor"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.style.color"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.style.fillOpacity"
+          weight: "this.style.weight"
 
   vegetation:
     label: _(vegetation report)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-vegetation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -163,19 +163,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-vegetation.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-vegetation.png
           iconSize: [38, 46]
@@ -184,7 +184,7 @@ place_types:
   signage:
     label: _(signage report)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-signage.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -193,19 +193,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-signage.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-signage.png
           iconSize: [38, 46]
@@ -214,7 +214,7 @@ place_types:
   pavement:
     label: _(pavement report)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-pavement.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -223,19 +223,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-pavement.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-pavement.png
           iconSize: [38, 46]
@@ -244,7 +244,7 @@ place_types:
   walkability:
     label: _(walkability report)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-walkability.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -253,19 +253,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-walkability.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-walkability.png
           iconSize: [38, 46]
@@ -275,7 +275,7 @@ place_types:
   accessibility:
     label: _(accessibility report)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-accessibility.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -284,19 +284,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-accessibility.png
           iconSize: [18, 21.75]
           iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-accessibility.png
           iconSize: [38, 46]
@@ -305,7 +305,7 @@ place_types:
   traffic:
       label: _(traffic report)
       rules:
-        - condition: '{{layer.focused}} === true'
+        - condition: 'this.layer.focused === true'
           icon:
             iconUrl: /static/css/images/markers/marker-traffic.png
             shadowUrl: /static/css/images/marker-shadow.png
@@ -314,19 +314,19 @@ place_types:
             shadowSize: [50, 60]
             shadowAnchor: [14, 60]
 
-        - condition: '{{map.zoom}} < 11'
+        - condition: 'this.map.zoom < 11'
           icon:
             iconUrl: /static/css/images/markers/dot-f95016.png
             iconSize: [10, 12]
             iconAnchor: [5, 12]
 
-        - condition: '{{map.zoom}} < 14'
+        - condition: 'this.map.zoom < 14'
           icon:
             iconUrl: /static/css/images/markers/marker-traffic.png
             iconSize: [15, 18]
             iconAnchor: [7.5, 18]
 
-        - condition: '{{map.zoom}} >= 14'
+        - condition: 'this.map.zoom >= 14'
           icon:
             iconUrl: /static/css/images/markers/marker-traffic.png
             iconSize: [38, 46]
@@ -335,7 +335,7 @@ place_types:
   design:
       label: _(design suggestion)
       rules:
-        - condition: '{{layer.focused}} === true'
+        - condition: 'this.layer.focused === true'
           icon:
             iconUrl: /static/css/images/markers/marker-design.png
             shadowUrl: /static/css/images/marker-shadow.png
@@ -344,19 +344,19 @@ place_types:
             shadowSize: [50, 60]
             shadowAnchor: [14, 60]
 
-        - condition: '{{map.zoom}} < 11'
+        - condition: 'this.map.zoom < 11'
           icon:
             iconUrl: /static/css/images/markers/dot-f95016.png
             iconSize: [10, 12]
             iconAnchor: [5, 12]
 
-        - condition: '{{map.zoom}} < 14'
+        - condition: 'this.map.zoom < 14'
           icon:
             iconUrl: /static/css/images/markers/marker-design.png
             iconSize: [15, 18]
             iconAnchor: [7.5, 18]
 
-        - condition: '{{map.zoom}} >= 14'
+        - condition: 'this.map.zoom >= 14'
           icon:
             iconUrl: /static/css/images/markers/marker-design.png
             iconSize: [38, 46]

--- a/src/flavors/gtopenspace/config.yml
+++ b/src/flavors/gtopenspace/config.yml
@@ -120,39 +120,39 @@ map:
 place_types:
 
   georgetownZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [60, 60]
         iconAnchor: [30, 30]
-    - condition: '{{map.zoom}} < 15'
+    - condition: 'this.map.zoom < 15'
       icon:
         iconSize: [7.5, 7.5]
         iconAnchor: [4, 4]
-    - condition: '{{map.zoom}} < 17'
+    - condition: 'this.map.zoom < 17'
       icon:
         iconSize: [25, 25]
         iconAnchor: [12.5, 12.5]
-    - condition: '{{map.zoom}} >= 17'
+    - condition: 'this.map.zoom >= 17'
       icon:
         iconSize: [40, 40]
         iconAnchor: [20, 20]
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
 
   openspaceZoomStyle:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -161,7 +161,7 @@ place_types:
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           iconSize: [12, 12]
@@ -170,7 +170,7 @@ place_types:
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           iconSize: [18, 18]
@@ -179,11 +179,11 @@ place_types:
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} >= 15'
+      - condition: 'this.map.zoom >= 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           iconSize: [30, 30]
-          iconAnchor: [15, 15]    
+          iconAnchor: [15, 15]
           shadowUrl: /static/css/images/marker-shadow.png
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
@@ -191,89 +191,89 @@ place_types:
   wetland:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_no-prog-or-dead.png
   park:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_no-prog-or-dead.png
 
   school:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_no-prog-or-dead.png
 
   police:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_no-prog-or-dead.png
 
   rail:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_no-prog-or-dead.png
 
   town-hall:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_no-prog-or-dead.png
 
@@ -281,21 +281,21 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.properties.stroke"
+          opacity: 'this.properties.stroke-opacity'
+          weight: "this.properties.stroke-width"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.properties.fill"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.properties.stroke"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: 'this.properties.fill-opacity'
+          weight: "this.properties.stroke-width"
 
 
   danger:
@@ -359,7 +359,7 @@ place_types:
   low:
     label: _(Low priority item)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-a5cf32.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -368,19 +368,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/marker-a5cf32.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 17'
+      - condition: 'this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/marker-a5cf32.png
           iconSize: [38, 46]
@@ -388,7 +388,7 @@ place_types:
   medium:
     label: _(Medium priority item)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-f39914.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -397,19 +397,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/marker-f39914.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 17'
+      - condition: 'this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/marker-f39914.png
           iconSize: [38, 46]
@@ -417,7 +417,7 @@ place_types:
   high:
     label: _(High priority item)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-e1264d.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -426,19 +426,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 17'
+      - condition: 'this.map.zoom < 17'
         icon:
           iconUrl: /static/css/images/markers/marker-e1264d.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 17'
+      - condition: 'this.map.zoom >= 17'
         icon:
           iconUrl: /static/css/images/markers/marker-e1264d.png
           iconSize: [38, 46]
@@ -446,7 +446,7 @@ place_types:
   streetscape:
     label: _(Streetscape)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -455,19 +455,19 @@ place_types:
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           iconSize: [12, 12]
           iconAnchor: [6, 6]
 
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           iconSize: [18, 18]
           iconAnchor: [9, 9]
 
-      - condition: '{{map.zoom}} >= 15'
+      - condition: 'this.map.zoom >= 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           iconSize: [30, 30]
@@ -476,7 +476,7 @@ place_types:
   park-improvement:
     label: _(Park Improvement)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -485,19 +485,19 @@ place_types:
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           iconSize: [12, 12]
           iconAnchor: [6, 6]
 
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           iconSize: [18, 18]
           iconAnchor: [9, 9]
 
-      - condition: '{{map.zoom}} >= 15'
+      - condition: 'this.map.zoom >= 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star-green.png
           iconSize: [30, 30]
@@ -507,7 +507,7 @@ place_types:
   streetscape:
     label: _(Streetscape)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-star-maroon.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -516,19 +516,19 @@ place_types:
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-star-maroon.png
           iconSize: [12, 12]
           iconAnchor: [6, 6]
 
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star-maroon.png
           iconSize: [18, 18]
           iconAnchor: [9, 9]
 
-      - condition: '{{map.zoom}} >= 15'
+      - condition: 'this.map.zoom >= 15'
         icon:
           iconUrl: /static/css/images/markers/marker-star-maroon.png
           iconSize: [30, 30]

--- a/src/flavors/lakewashington/config.yml
+++ b/src/flavors/lakewashington/config.yml
@@ -91,15 +91,15 @@ map:
 place_types:
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
@@ -107,7 +107,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -116,19 +116,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -137,7 +137,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -146,19 +146,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -167,7 +167,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -176,19 +176,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -197,7 +197,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -206,19 +206,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -236,29 +236,29 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.properties.stroke"
+          opacity: "this.properties['stroke-opacity']"
+          weight: "this.properties['stroke-width']"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.properties.fill"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.properties.stroke"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.properties['fill-opacity']"
+          weight: "this.properties['stroke-width']"
 
-      - condition: '"{{geometry.type}}" == "Point"'
+      - condition: 'this.geometry.type == "Point"'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           iconSize: [30, 30]
           iconAnchor: [15, 15]
 
-      - condition: '"{{geometry.type}}" == "Point" && "{{layer.focused}}" === true'
+      - condition: 'this.geometry.type == "Point" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           iconSize: [50, 60]

--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -67,21 +67,21 @@ map:
       url: "https://heyduwamishcore.carto.com/api/v2/viz/b852afe8-bc1c-11e6-b3fb-0e05a8b3e3d7/viz.json"
       rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: "this.geometry.type == 'LineString'"
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.properties.stroke"
+          opacity: "this.properties['stroke-opacity']"
+          weight: "this.properties['stroke-width']"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: "this.geometry.type == 'Polygon'"
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.properties.fill"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.properties.stroke"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.properties['fill-opacity']"
+          weight: "this.properties['stroke-width']"
 
     - id: pboakland
       type: place
@@ -91,19 +91,19 @@ map:
 place_types:
 
   markerZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [75, 90]
         iconAnchor: [38, 90]
-    - condition: '{{map.zoom}} < 14'
+    - condition: 'this.map.zoom < 14'
       icon:
         iconSize: [15, 18]
         iconAnchor: [7.5, 18]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [30, 36]
         iconAnchor: [15, 36]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [50, 60]
         iconAnchor: [25, 60]

--- a/src/flavors/pugetsound/config.yml
+++ b/src/flavors/pugetsound/config.yml
@@ -87,21 +87,21 @@ map:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Overflowed in the last 48 hrs"'
           icon:
-            iconUrl: /static/css/images/markers/dot-dbcf2c.png
+            iconUrl: /static/css/images/markers/dot-f95016.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Overflowing now"'
           icon:
-            iconUrl: /static/css/images/markers/dot-f95016.png
+            iconUrl: /static/css/images/markers/dot-e1264d.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
             opacity: 0.9
         - condition: '"{{properties.description}}" === "Data not available"'
           icon:
-            iconUrl: /static/css/images/markers/dot-5359d7.png
+            iconUrl: /static/css/images/markers/dot-0d85e9.png
             iconSize: [20, 20]
             iconAnchor: [10, 10]
           style:
@@ -111,15 +111,15 @@ map:
 place_types:
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
@@ -134,7 +134,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -143,19 +143,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -164,7 +164,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -173,19 +173,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -194,7 +194,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -203,19 +203,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -224,7 +224,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -233,19 +233,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -254,7 +254,7 @@ place_types:
   greenwall:
     label: _(Green Screen Vote)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -263,19 +263,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 15'
+      - condition: 'this.map.zoom < 15'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 18'
+      - condition: 'this.map.zoom < 18'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [18, 21.75]
           iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 18'
+      - condition: 'this.map.zoom >= 18'
         icon:
           iconUrl: /static/css/images/markers/marker-greenwall.png
           iconSize: [38, 46]

--- a/src/flavors/rail/config.yml
+++ b/src/flavors/rail/config.yml
@@ -77,7 +77,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -86,7 +86,7 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           # iconSize: [15, 18]
@@ -94,7 +94,7 @@ place_types:
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -103,7 +103,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -112,7 +112,7 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           # iconSize: [15, 18]
@@ -120,7 +120,7 @@ place_types:
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -129,7 +129,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -138,7 +138,7 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           # iconSize: [15, 18]
@@ -146,7 +146,7 @@ place_types:
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-      - condition: '{{map.zoom}} >= 16'
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -155,7 +155,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -164,15 +164,15 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 16'
+      - condition: 'this.map.zoom < 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           # iconSize: [15, 18]
           # iconAnchor: [7.5, 18]
           iconSize: [38, 46]
           iconAnchor: [19, 46]
-          
-      - condition: '{{map.zoom}} >= 16'
+
+      - condition: 'this.map.zoom >= 16'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]

--- a/src/flavors/raingardens/config.yml
+++ b/src/flavors/raingardens/config.yml
@@ -32,6 +32,12 @@ map:
   geocoding_bar_enabled: false # add a geocode bar across the map
   geocode_bounding_box: [45.2, -125, 49.3, -116.4] # Including cushion
 
+  # If set to true, suppress_zoom_rules will prevent style rules from being evaluated
+  # on map zooms. For flavors like raingardens which do not make much of zoom rules
+  # in the first place, the performance gains from suppressing them are significant
+  # while the functionality loss is minimal.
+  suppress_zoom_rules: true
+
   counter: true
   counter_min: 0
   counter_max: 12000
@@ -68,7 +74,7 @@ map:
 #      description: <img src="/static/css/images/legend-nlcd2011.png" alt="legend">
 #      title: _(Land covereage data)
 #      visible: false
-      
+
 
   # Report filters
 
@@ -88,23 +94,11 @@ place_types:
   raingarden:
     label: _(rain garden)
     rules:
-      - condition: 'this.location_type === "raingarden" && this.map.zoom < 11 && this.layer.focused === false'
-        icon:
-          iconUrl: /static/css/images/markers/marker-drop.png
-          iconSize: [7, 12]
-          iconAnchor: [5, 12]
-
-      - condition: 'this.location_type === "raingarden" && this.map.zoom < 13 && this.layer.focused === false'
+      - condition: 'this.location_type === "raingarden" && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           iconSize: [24, 29]
           iconAnchor: [12, 29]
-
-      - condition: 'this.location_type === "raingarden" && this.map.zoom >= 13 && this.layer.focused === false'
-        icon:
-          iconUrl: /static/css/images/markers/marker-drop.png
-          iconSize: [38, 46]
-          iconAnchor: [19, 46]
 
       - condition: 'this.location_type === "raingarden" && this.layer.focused === true'
         icon:

--- a/src/flavors/raingardens/config.yml
+++ b/src/flavors/raingardens/config.yml
@@ -88,25 +88,25 @@ place_types:
   raingarden:
     label: _(rain garden)
     rules:
-      - condition: '"{{location_type}}" === "raingarden" && {{map.zoom}} < 11 && {{layer.focused}} === false'
+      - condition: '{{location_type}} === "raingarden" && {{map.zoom}} < 11 && {{layer.focused}} === false'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           iconSize: [7, 12]
           iconAnchor: [5, 12]
 
-      - condition: '"{{location_type}}" === "raingarden" && {{map.zoom}} < 13 && {{layer.focused}} === false'
+      - condition: '{{location_type}} === "raingarden" && {{map.zoom}} < 13 && {{layer.focused}} === false'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           iconSize: [24, 29]
           iconAnchor: [12, 29]
 
-      - condition: '"{{location_type}}" === "raingarden" && {{map.zoom}} >= 13 && {{layer.focused}} === false'
+      - condition: '{{location_type}} === "raingarden" && {{map.zoom}} >= 13 && {{layer.focused}} === false'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-      - condition: '"{{location_type}}" === "raingarden" && {{layer.focused}} === true'
+      - condition: '{{location_type}} === "raingarden" && {{layer.focused}} === true'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -117,25 +117,25 @@ place_types:
   idea:
     label: _(idea)
     rules:
-      - condition: '"{{location_type}}" === "idea" && {{map.zoom}} < 11 && {{layer.focused}} === false'
+      - condition: '{{location_type}} === "idea" && {{map.zoom}} < 11 && {{layer.focused}} === false'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           iconSize: [7, 12]
           iconAnchor: [5, 12]
 
-      - condition: '"{{location_type}}" === "idea" && {{map.zoom}} < 13 && {{layer.focused}} === false'
+      - condition: '{{location_type}} === "idea" && {{map.zoom}} < 13 && {{layer.focused}} === false'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           iconSize: [24, 29]
           iconAnchor: [12, 29]
 
-      - condition: '"{{location_type}}" === "idea" && {{map.zoom}} >= 13 && {{layer.focused}} === false'
+      - condition: '{{location_type}} === "idea" && {{map.zoom}} >= 13 && {{layer.focused}} === false'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-      - condition: '"{{location_type}}" === "idea" && {{layer.focused}} === true'
+      - condition: '{{location_type}} === "idea" && {{layer.focused}} === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           shadowUrl: /static/css/images/marker-shadow.png

--- a/src/flavors/raingardens/config.yml
+++ b/src/flavors/raingardens/config.yml
@@ -88,25 +88,25 @@ place_types:
   raingarden:
     label: _(rain garden)
     rules:
-      - condition: '{{location_type}} === "raingarden" && {{map.zoom}} < 11 && {{layer.focused}} === false'
+      - condition: 'this.location_type === "raingarden" && this.map.zoom < 11 && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           iconSize: [7, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{location_type}} === "raingarden" && {{map.zoom}} < 13 && {{layer.focused}} === false'
+      - condition: 'this.location_type === "raingarden" && this.map.zoom < 13 && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           iconSize: [24, 29]
           iconAnchor: [12, 29]
 
-      - condition: '{{location_type}} === "raingarden" && {{map.zoom}} >= 13 && {{layer.focused}} === false'
+      - condition: 'this.location_type === "raingarden" && this.map.zoom >= 13 && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-      - condition: '{{location_type}} === "raingarden" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "raingarden" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-drop.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -117,25 +117,25 @@ place_types:
   idea:
     label: _(idea)
     rules:
-      - condition: '{{location_type}} === "idea" && {{map.zoom}} < 11 && {{layer.focused}} === false'
+      - condition: 'this.location_type === "idea" && this.map.zoom < 11 && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           iconSize: [7, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{location_type}} === "idea" && {{map.zoom}} < 13 && {{layer.focused}} === false'
+      - condition: 'this.location_type === "idea" && this.map.zoom < 13 && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           iconSize: [24, 29]
           iconAnchor: [12, 29]
 
-      - condition: '{{location_type}} === "idea" && {{map.zoom}} >= 13 && {{layer.focused}} === false'
+      - condition: 'this.location_type === "idea" && this.map.zoom >= 13 && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-      - condition: '{{location_type}} === "idea" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "idea" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea-trans.png
           shadowUrl: /static/css/images/marker-shadow.png

--- a/src/flavors/snoqualmie/config.yml
+++ b/src/flavors/snoqualmie/config.yml
@@ -78,15 +78,15 @@ map:
 place_types:
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
@@ -95,26 +95,26 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.style.color"
+          opacity: "this.style.opacity"
+          weight: "this.style.weight"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.style.fillColor"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.style.color"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.style.fillOpacity"
+          weight: "this.style.weight"
 
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -123,19 +123,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [29, 35]
@@ -144,7 +144,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -153,19 +153,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [29, 35]
@@ -174,7 +174,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -183,19 +183,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [29, 35]
@@ -204,7 +204,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -213,19 +213,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 13'
+      - condition: 'this.map.zoom < 13'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [15, 18]
           iconAnchor: [7.5, 18]
 
-      - condition: '{{map.zoom}} >= 13'
+      - condition: 'this.map.zoom >= 13'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [29, 35]

--- a/src/flavors/trees/config.yml
+++ b/src/flavors/trees/config.yml
@@ -101,35 +101,35 @@ map:
   # Icon Controls
 
 place_types:
-  
+
   georgetownZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [60, 60]
         iconAnchor: [30, 30]
-    - condition: '{{map.zoom}} < 14'
+    - condition: 'this.map.zoom < 14'
       icon:
         iconSize: [7.5, 7.5]
         iconAnchor: [4, 4]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [15, 15]
         iconAnchor: [8, 8]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
 
   mapboxZoomStyle:
-    - condition: '{{layer.focused}} === true'
+    - condition: 'this.layer.focused === true'
       icon:
         iconSize: [50, 50]
         iconAnchor: [25, 25]
-    - condition: '{{map.zoom}} < 16'
+    - condition: 'this.map.zoom < 16'
       icon:
         iconSize: [20, 20]
         iconAnchor: [10, 10]
-    - condition: '{{map.zoom}} >= 16'
+    - condition: 'this.map.zoom >= 16'
       icon:
         iconSize: [30, 30]
         iconAnchor: [15, 15]
@@ -137,89 +137,89 @@ place_types:
   wetland:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_no-prog-or-dead.png
   park:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_no-prog-or-dead.png
 
   school:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_no-prog-or-dead.png
 
   police:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_no-prog-or-dead.png
 
   rail:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_no-prog-or-dead.png
 
   town-hall:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: 'this.properties["marker-color"] == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: 'this.properties["marker-color"] == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: 'this.properties["marker-color"] == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_no-prog-or-dead.png
 
@@ -227,21 +227,21 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.style.color"
+          opacity: "this.style.opacity"
+          weight: "this.style.weight"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.style.fillColor"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.style.color"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: "this.style.fillOpacity"
+          weight: "this.style.weight"
 
   danger:
     zoomType: mapboxZoomStyle
@@ -295,13 +295,13 @@ place_types:
   tree:
     label: _(tree)
     rules:
-      - condition: '"{{location_type}}" === "tree" && {{layer.focused}} === false'
+      - condition: 'this.location_type === "tree" && this.layer.focused === false'
         icon:
           iconUrl: /static/css/images/markers/tree.png
           iconSize: [18, 25]
           iconAnchor: [9, 25]
 
-      - condition: '"{{location_type}}" === "tree" && {{layer.focused}} === true'
+      - condition: 'this.location_type === "tree" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/tree.png
           shadowUrl: /static/css/images/marker-shadow.png

--- a/src/flavors/waterfront/config.yml
+++ b/src/flavors/waterfront/config.yml
@@ -95,7 +95,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -104,19 +104,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -125,7 +125,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -134,19 +134,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -155,7 +155,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -164,19 +164,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -185,7 +185,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -194,19 +194,19 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: 'this.map.zoom < 11'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 14'
+      - condition: 'this.map.zoom < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [12, 14.5]
           iconAnchor: [6, 14.5]
 
-      - condition: '{{map.zoom}} >= 14'
+      - condition: 'this.map.zoom >= 14'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -216,29 +216,29 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.properties.stroke"
+          opacity: 'this.properties["stroke-opacity"]'
+          weight: "this.properties['stroke-width']"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.properties.fill"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.properties.stroke"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: 'this.properties["fill-opacity"]'
+          weight: "this.properties['stroke-width']"
 
-      - condition: '"{{geometry.type}}" == "Point"'
+      - condition: 'this.geometry.type == "Point"'
         icon:
           iconUrl: /static/css/images/markers/marker-option-a.png
           iconSize: [30, 30]
           iconAnchor: [15, 15]
 
-      - condition: '"{{geometry.type}}" == "Point" && "{{layer.focused}}" === true'
+      - condition: 'this.geometry.type == "Point" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-option-a.png
           iconSize: [50, 60]

--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -80,7 +80,7 @@ place_types:
   observation:
     label: _(Observation)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -89,13 +89,13 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 10'
+      - condition: 'this.map.zoom < 10'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} >= 10'
+      - condition: 'this.map.zoom >= 10'
         icon:
           iconUrl: /static/css/images/markers/marker-observation.png
           iconSize: [38, 46]
@@ -104,7 +104,7 @@ place_types:
   question:
     label: _(Question)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -113,13 +113,13 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 10'
+      - condition: 'this.map.zoom < 10'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} >= 10'
+      - condition: 'this.map.zoom >= 10'
         icon:
           iconUrl: /static/css/images/markers/marker-question.png
           iconSize: [38, 46]
@@ -128,7 +128,7 @@ place_types:
   idea:
     label: _(Idea)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -137,13 +137,13 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 10'
+      - condition: 'this.map.zoom < 10'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} >= 10'
+      - condition: 'this.map.zoom >= 10'
         icon:
           iconUrl: /static/css/images/markers/marker-idea.png
           iconSize: [38, 46]
@@ -152,7 +152,7 @@ place_types:
   complaint:
     label: _(Complaint)
     rules:
-      - condition: '{{layer.focused}} === true'
+      - condition: 'this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           shadowUrl: /static/css/images/marker-shadow.png
@@ -161,13 +161,13 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 10'
+      - condition: 'this.map.zoom < 10'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]
           iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} >= 10'
+      - condition: 'this.map.zoom >= 10'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [38, 46]
@@ -177,23 +177,23 @@ place_types:
     # Mapbox Points
     rules:
     # LineString
-      - condition: '"{{geometry.type}}" == "LineString"'
+      - condition: 'this.geometry.type == "LineString"'
         style:
-          color: "{{properties.stroke}}"
-          opacity: '{{properties.stroke-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          color: "this.properties.stroke"
+          opacity: 'this.properties["stroke-opacity"]'
+          weight: "this.properties['stroke-width']"
     # Polygons
-      - condition: '"{{geometry.type}}" == "Polygon"'
+      - condition: 'this.geometry.type == "Polygon"'
         style:
           shapeType: polygon
-          fillColor: "{{properties.fill}}"
+          fillColor: "this.properties.fill"
           fill: 'true'
-          color: "{{properties.stroke}}"
+          color: "this.properties.stroke"
           opacity: 0.7
-          fillOpacity: '{{properties.fill-opacity}}'
-          weight: "{{properties.stroke-width}}"
+          fillOpacity: 'this.properties["fill-opacity"]'
+          weight: "this.properties['stroke-width']"
 
-      - condition: '"{{geometry.type}}" == "Point" && {{layer.focused}} === true'
+      - condition: 'this.geometry.type == "Point" && this.layer.focused === true'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           iconSize: [60, 60]
@@ -201,7 +201,7 @@ place_types:
           shadowSize: [60, 60]
           shadowAnchor: [30, 30]
 
-      - condition: '"{{geometry.type}}" == "Point"'
+      - condition: 'this.geometry.type == "Point"'
         icon:
           iconUrl: /static/css/images/markers/marker-star.png
           iconSize: [30, 30]


### PR DESCRIPTION
Addresses: #704.

**This PR needs to be carefully tested on each flavor before merging**, as it introduces changes in the way zoom and style rules are handled.

Improve layer view performance by reducing unnecessary and duplicated work spent evaluating zoom and style rules.

- evaluate style rules for visible layers only
- draw newly visible geometry on `moveend`, not `move`
- cache style rules on layer views as functions

Caching style rules as functions eliminates not only the need for `eval` statements for layer views, but for their static parse replacement as well. Instead, we cache style and zoom rules on layer views as functions we can call later, using `new Function()`.

Note that we retain the `L.argo` style and zoom rule evaluation functionality. This is to support json and ESRI layers, which don't have layer views associated with them but do have style rules. We parse these style rules once, on page load.