### PR TITLE
Editor UI and usability updates

### DIFF
--- a/src/base/static/js/views/geometry-editor-view.js
+++ b/src/base/static/js/views/geometry-editor-view.js
@@ -225,7 +225,9 @@ module.exports = Backbone.View.extend({
     this.showIconToolbar();
     this.iconUrl = this.$el.find(".geometry-toolbar-icon-field input:checked").val();
 
-    this.workingGeometry = new L.Draw.Marker(this.map, {
+    // NOTE: Creation of Markers is handled differently from polygons and polylines.
+    // We place the marker directly on the map and jump immediately into edit mode.
+    L.marker(this.map.getCenter(), {
       icon: new L.icon({
         iconUrl: this.iconUrl,
         
@@ -234,16 +236,15 @@ module.exports = Backbone.View.extend({
         iconSize: [25, 25],
         iconAnchor: [12.5, 12.5]
       })
-    });
-    this.workingGeometry.enable();
+    }).addTo(this.editingLayerGroup);
 
     this.layerType = "Point";
-    this.setGeometryToolbarHighlighting(evt.currentTarget);
-    this.displayHelpMessage("draw-marker-geometry-msg");
-    this.updateButtonText(this.layerType);
-    this.setEditingCursor();
-    this.delegateEvents();
-    this.isEditing = false;
+    this.$el.find(".edit-geometry").trigger("click");
+    this.resetWorkingGeometry();
+    this.setColorpicker();
+    this.hideIconToolbar();
+    this.swapToolbarVisibility();
+    this.displayHelpMessage("edit-marker-geometry-msg");
   },
 
   onClickCreatePolyline: function(evt) {

--- a/src/base/static/js/views/geometry-editor-view.js
+++ b/src/base/static/js/views/geometry-editor-view.js
@@ -221,7 +221,6 @@ module.exports = Backbone.View.extend({
     // Prevent repeat clicks on the same geometry drawing tool
     if (this.layerType === "Point") return;
 
-    this.resetWorkingGeometry();
     this.showIconToolbar();
     this.iconUrl = this.$el.find(".geometry-toolbar-icon-field input:checked").val();
 
@@ -241,6 +240,7 @@ module.exports = Backbone.View.extend({
     this.layerType = "Point";
     this.$el.find(".edit-geometry").trigger("click");
     this.resetWorkingGeometry();
+    this.generateGeometry(this.getLayerFromEditingLayerGroup());
     this.setColorpicker();
     this.hideIconToolbar();
     this.swapToolbarVisibility();

--- a/src/base/static/js/views/place-detail-view.js
+++ b/src/base/static/js/views/place-detail-view.js
@@ -323,6 +323,11 @@
       var self = this,
       richTextAttrs = {};
 
+      // wrap quill video embeds in a container so we can enable fluid max dimensions
+      this.$("iframe.ql-video").each(function() {
+        $(this).wrap("<div class='ql-video-container'></div>");
+      });
+
       // attach data from Quill-enabled fields
       this.$el.find(".ql-editor").each(function() {
         richTextAttrs[$(this).data("fieldName")] = $(this).html();

--- a/src/base/static/js/views/place-detail-view.js
+++ b/src/base/static/js/views/place-detail-view.js
@@ -249,9 +249,7 @@
 
       this.delegateEvents();
       this.surveyView.delegateEvents();
-
-      $("#content article").animate({ scrollTop: 0 }, "fast");
-      
+  
       // initialize datetime picker, if relevant
       $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
 
@@ -284,6 +282,24 @@
             fieldId: $(this).attr("id")
           });
         });
+
+        $("#content article")
+            .animate({ scrollTop: 0 }, "fast");
+
+        this.$qlToolbar = this.$(".ql-toolbar");
+
+        // Make sure the Quill toolbar never scrolls out of sight by fixing it to
+        // the top of the content container, right below the edit toolbar.
+        if (this.$qlToolbar.length > 0) {
+          $("#content article")
+            .on("scroll", function() {
+              if (this.scrollTop < 435) {
+                self.$qlToolbar.removeClass("fixed-top");
+              } else if (self.$qlToolbar.offset().top < 115) {
+                self.$qlToolbar.addClass("fixed-top");
+              }
+            });
+        }
       }
 
       return this;
@@ -291,6 +307,7 @@
 
     tearDown: function() {
       this.options.router.off("route", this.tearDown, this);
+      $("#content article").off("scroll");
       this.isEditingToggled = false;
       this.isModified = false;
     },

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -284,6 +284,11 @@
         }
       });
 
+      // wrap quill video embeds in a container so we can enable fluid max dimensions
+      this.$("iframe.ql-video").each(function() {
+        $(this).wrap("<div class='ql-video-container'></div>");
+      });
+
       if (this.geometryEnabled) {
         attrs.geometry = this.geometryEditorView.geometry;
       } else {

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -77,13 +77,14 @@
     },
 
     renderFormFields: function() {
-      var data = _.extend({
-        placeConfig: this.options.placeConfig,
-        commonFormElements: this.formState.commonFormElements,
-        selectedCategoryConfig: this.formState.selectedCategoryConfig,
-        user_token: this.options.userToken,
-        current_user: Shareabouts.currentUser
-      }, Shareabouts.stickyFieldValues);
+      var self = this,
+          data = _.extend({
+            placeConfig: this.options.placeConfig,
+            commonFormElements: this.formState.commonFormElements,
+            selectedCategoryConfig: this.formState.selectedCategoryConfig,
+            user_token: this.options.userToken,
+            current_user: Shareabouts.currentUser
+          }, Shareabouts.stickyFieldValues);
 
       this.$el
         .find("#place-form")
@@ -117,6 +118,21 @@
       this.initializeDatetimePicker();
       this.initializeRichTextFields();
       this.setUrlTitlePrefix();
+
+      this.$qlToolbar = this.$(".ql-toolbar");
+
+      // Make sure the Quill toolbar never scrolls out of sight by fixing it to
+      // the top of the content container.
+      if (this.$qlToolbar.length > 0) {
+        $("#content article")
+          .on("scroll", function() {
+            if (this.scrollTop < 520) {
+              self.$qlToolbar.removeClass("fixed-top no-edit-toolbar");
+            } else if (self.$qlToolbar.offset().top < 75) {
+              self.$qlToolbar.addClass("fixed-top no-edit-toolbar");
+            }
+          });
+      }
     },
 
     setUrlTitlePrefix: function() {
@@ -429,6 +445,7 @@
     closePanel: function() {
       this.center = null;
       this.resetFormState();
+      $("#content article").off("scroll");
     },
 
     // This function handles submission of data from conventional places with 

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -284,11 +284,6 @@
         }
       });
 
-      // wrap quill video embeds in a container so we can enable fluid max dimensions
-      this.$("iframe.ql-video").each(function() {
-        $(this).wrap("<div class='ql-video-container'></div>");
-      });
-
       if (this.geometryEnabled) {
         attrs.geometry = this.geometryEditorView.geometry;
       } else {
@@ -527,6 +522,11 @@
           "showMetadata": self.formState.selectedCategoryConfig.showMetadata
         });
         model = collection.at(collection.length - 1);
+
+        // wrap quill video embeds in a container so we can enable fluid max dimensions
+        this.$("iframe.ql-video").each(function(a) {
+          $(this).wrap("<div class='ql-video-container'></div>");
+        });
 
         if (self.formState.attachmentData.length > 0) {
           self.formState.attachmentData.forEach(function(attachment) {

--- a/src/base/static/scss/_buttons.scss
+++ b/src/base/static/scss/_buttons.scss
@@ -393,7 +393,7 @@ button.sp-selected, button.sp-selected:hover {
     margin-top: 20px;
     padding: 10px;
     border-radius: 5px;
-    background-color: $button-background-lightblue;
+    background-color: #888888;
     .geometry-toolbar-create, .geometry-toolbar-edit {
         display: inline-block;
         text-align: center;

--- a/src/base/static/scss/_content.scss
+++ b/src/base/static/scss/_content.scss
@@ -455,3 +455,19 @@ a.auth-inline {
     cursor: auto;
 }
 
+/* rich text embedded video dimensions */
+.ql-video-container {
+    position:relative;
+    padding-bottom:56.25%;
+    padding-top: 0;
+    height: 0;
+    overflow:hidden;
+}
+
+.ql-video-container iframe, .ql-video-container object, .ql-video-container embed {
+    position:absolute;
+    top:0;
+    left:0;
+    width:100%;
+    height:100%;
+}

--- a/src/base/static/scss/_forms.scss
+++ b/src/base/static/scss/_forms.scss
@@ -165,7 +165,7 @@ select {
 }
 
 .url-readout-container {
-    background-color: #a3c7d9;
+    background-color: #888888;
     padding: 10px;
     border-radius: 6px;
     margin-bottom: 5px;

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -541,20 +541,25 @@
     }
 
     /* rich text editor toolbar, in fixed-top mode */
-    .ql-toolbar.fixed-top {
-        position: fixed;
-        top: $header-height-fullscreen + 47px;
-        background-color: #EFEFEF;
-        border: none;
-        z-index: 400;
-        width: calc(#{$content-visible-width} - 47px);
-        border-bottom-width: 0.30em;
-        border-bottom-style: solid;
-        border-bottom-color: #a3c7d9;
-        border-top-width: 1px !important;
-        border-top-color: #DEDEDE !important;
-        border-left-width: 0 !important;
-        border-right-width: 0 !important;
+    .ql-toolbar {
+        &.fixed-top {
+            position: fixed;
+            top: $header-height-fullscreen + 47px;
+            background-color: #EFEFEF;
+            border: none;
+            z-index: 400;
+            width: calc(#{$content-visible-width} - 47px);
+            border-bottom-width: 0.30em;
+            border-bottom-style: solid;
+            border-bottom-color: #a3c7d9;
+            border-top-width: 1px !important;
+            border-top-color: #DEDEDE !important;
+            border-left-width: 0 !important;
+            border-right-width: 0 !important;
+        }
+        &.no-edit-toolbar {
+            top: $header-height-fullscreen;
+        }
     }
 
     // Geocoding

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -516,12 +516,28 @@
 
     #content > article {
         overflow: auto;
-        padding: 1em 1em 2em;
+        padding-top: 50px;
+        padding-right: 1em;
+        padding-left: 1em;
+        padding-bottom: 2em;
         width: 100%;
         height: 100%;
         -webkit-box-sizing: border-box;
         -moz-box-sizing: border-box;
         box-sizing: border-box;
+    }
+
+    /* place detail edit bar */
+    .place-detail-edit-bar {
+        position: fixed;
+        background-color: #FFFFFF;
+        z-index: 5;
+        padding-left: 8px;
+        padding-right: 8px;
+        padding-top: 8px;
+        padding-bottom: 16px;
+        top: $header-height-fullscreen;
+        width: calc(#{$content-visible-width} - 45px);
     }
 
     // Geocoding

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -540,6 +540,23 @@
         width: calc(#{$content-visible-width} - 45px);
     }
 
+    /* rich text editor toolbar, in fixed-top mode */
+    .ql-toolbar.fixed-top {
+        position: fixed;
+        top: $header-height-fullscreen + 47px;
+        background-color: #EFEFEF;
+        border: none;
+        z-index: 400;
+        width: calc(#{$content-visible-width} - 47px);
+        border-bottom-width: 0.30em;
+        border-bottom-style: solid;
+        border-bottom-color: #a3c7d9;
+        border-top-width: 1px !important;
+        border-top-color: #DEDEDE !important;
+        border-left-width: 0 !important;
+        border-right-width: 0 !important;
+    }
+
     // Geocoding
     #geocode-address-bar {
         position: absolute;


### PR DESCRIPTION
- set background color of editor toolbars to charcoal gray
- after clicking Create Marker on the form, place a marker on the map at the centerpoint and jump immediately into editing mode
- fix the height of Quill-inserted iframes (to prevent strange dimensions on embedded videos)
- make save/delete toolbar and Quill toolbars stick to the top of place detail views when scrolling down
- make the Quill toolbar stick to the top of the place form view when scrolling down