### PR TITLE
Upgrade to Leaflet 1.0.3

### DIFF
--- a/src/base/jstemplates/place-form-field-types.html
+++ b/src/base/jstemplates/place-form-field-types.html
@@ -171,7 +171,7 @@
       <p class="edit-marker-geometry-msg hidden"><em>{{#_}}Drag your marker to reposition it{{/_}}</em></p>
       <p class="draw-poly-geometry-start-msg hidden"><em>{{#_}}Click anywhere on the map to start drawing{{/_}}</em></p>
       <p class="draw-polygon-continue-msg hidden"><em>{{#_}}Click to continue drawing your shape{{/_}}</em></p>
-      <p class="draw-polygon-finish-msg hidden"><em>{{#_}}Click to continue drawing, or double click to complete your shape{{/_}}</em></p>
+      <p class="draw-polygon-finish-msg hidden"><em>{{#_}}Click to continue drawing, or click on your first point to complete your shape{{/_}}</em></p>
       <p class="draw-polyline-continue-msg hidden"><em>{{#_}}Click to continue drawing{{/_}}</em></p>
       <p class="draw-polyline-finish-msg hidden"><em>{{#_}}Click to continue drawing, or double click to complete your shape{{/_}}</em></p>
       <p class="draw-marker-geometry-msg hidden"><em>{{#_}}Click anywhere on the map to place your marker{{/_}}</em></p>

--- a/src/base/static/js/models/model-utils.js
+++ b/src/base/static/js/models/model-utils.js
@@ -40,7 +40,8 @@ var addStoryObj = function(response, type) {
         basemap: story.order[url].basemap,
         spotlight: story.order[url].spotlight,
         hasCustomZoom: story.order[url].hasCustomZoom,
-        sidebarIconUrl: story.order[url].sidebarIconUrl
+        sidebarIconUrl: story.order[url].sidebarIconUrl,
+        flyTo: story.order[url].flyTo
       }
     }
   });

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -294,7 +294,8 @@
             "next": story.order[(i + 1) % totalStoryElements].url,
             "basemap": config.basemap || story.default_basemap,
             "spotlight": (config.spotlight === false) ? false : true,
-            "sidebarIconUrl": config.sidebar_icon_url
+            "sidebarIconUrl": config.sidebar_icon_url,
+            "flyTo": config.flyTo || false
           }
         });
         story.order = storyStructure;
@@ -711,7 +712,7 @@
 
       function onFound(model, type, datasetId) {
         var map = self.mapView.map,
-            layer, center, zoom, detailView, $responseToScrollTo;
+            layer, center, zoom, flyTo, detailView, $responseToScrollTo;
 
         if (type === "place") {
 
@@ -759,24 +760,37 @@
             self.setStoryLayerVisibility(model);
             center = model.get("story").panTo || center;
             zoom = model.get("story").zoom;
+            flyTo = model.get("story").flyTo;
           }
 
           if (layer.getLatLng) {
-            map.setView(center, zoom, {
-              animate: true
-            });
+            if (flyTo) {
+              map.flyTo(center, zoom);
+            } else {
+              map.setView(center, zoom, {
+                animate: true
+              }); 
+            }
           } else {
 
             // If we've defined a custom zoom for a polygon layer for some reason,
             // don't use fitBounds and instead set the zoom defined
             if (model.get("story") && model.get("story").hasCustomZoom) {
-              map.setView(center, model.get("story").zoom, {
-                animate: true
-              });
+              if (flyTo) {
+                map.flyTo(center, model.get("story").zoom);
+              } else {
+                map.setView(center, model.get("story").zoom, {
+                  animate: true
+                });
+              }
             } else {
-              map.fitBounds(layer.getBounds(), {
-                animate: true
-              });
+              if (flyTo) {
+                map.flyToBounds(layer.getBounds());
+              } else {
+                map.fitBounds(layer.getBounds(), {
+                  animate: true
+                });
+              }
             }
           }
         }

--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -402,6 +402,14 @@
       } else if (config.type && config.type === 'cartodb') {
         cartodb.createLayer(self.map, config.url, { legends: false })
           .on('done', function(cartoLayer) {
+
+            // NOTE: this no-op is a monkey patch to make cartodb_noleaflet.js play
+            // nicely with leaflet 1.0. This is so we can have both carto and leaflet's
+            // flyTo method available on the same map, as carto (as of v. 3.15) does
+            // not yet support flyTo.
+            // See here: https://github.com/CartoDB/cartodb.js/issues/1503
+            cartoLayer._adjustTilePoint = function(){};
+
             self.layers[config.id] = cartoLayer;
             // This is only set when the 'visibility' event is fired before
             // our carto layer is loaded:

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -57,8 +57,9 @@
 
   {% if config.map.cartodb_enabled %}
   <link rel="stylesheet" href="//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css" />
   {% else %}
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css" />
   {% endif %}
 
   {% if config.cluster %}
@@ -172,9 +173,12 @@
   <script>window.jQuery || document.write('<script src="{{ STATIC_URL }}libs/jquery-1.10.2.js"><\/script>')</script><!-- FIXME: Maybe this should be pulled into the repo as a git submodule-->
 
   {% if config.map.cartodb_enabled %}
-  <script src="//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
+  <!-- NOTE: we're loading both leaflet and cartodb_noleaflet, as standalone cartodb does
+    not yet support all leaflet 1.0 features -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js"></script>
+  <script src="//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb_noleaflet.js"></script>
   {% else %}
-  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js"></script>
   {% endif %}
   {% if config.cluster %}
   <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>


### PR DESCRIPTION
Addresses: #466 

This PR bumps us up to Leaflet 1.0.3. 

For flavors which use Carto, we replace `cartodb.js` with `cartodb_noleaflet.js` and a separate load of Leaflet itself. This is to work around the fact that Carto has apparently not migrated all Leaflet 1.0 features yet.

This PR also adds the ability to use Leaflet's `flyTo` method on story points. Set the following flag in a story point's config to use `flyTo`:
```
flyTo: true
```

**NOTE:** Some testing has revealed that `flyTo` does not work well on Carto layers, causing some pretty nasty-looking errors. So although we can combine Carto and standalone Leaflet 1.0.3 on the same map, we should avoid setting the `flyTo: true` flag on story points that contain Carto layers.