### PR TITLE
Fix a performance bottleneck related to filtering

### DIFF
--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -232,7 +232,7 @@ Shareabouts.Util = Util;
     },
 
     getFilteredRoutes: function() {
-      return ['filterMap', 'viewPlace', 'showList', 'viewMap'];
+      return ['filterMap', 'viewPlace', 'showList', 'viewMap', 'viewLandmark'];
     },
 
     clearLocationTypeFilter: function() {


### PR DESCRIPTION
Because the viewLandmark route handler was not included on the list of routes that don't require a clear of the location type filter, we were running unnecessary filter clearing logic in routes.js and in place-list-view.js whenever a landmark (or a landmark-as-place) was clicked on.

This commit adds viewLandmark to the list of routes that don't require filter clearing.