### PR TITLE
Update filtering logic

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -474,6 +474,7 @@
       this.hideSpotlightMask();
       if (this.mapView.locationTypeFilter) {
         this.options.router.navigate('filter/' + this.mapView.locationTypeFilter, {trigger: true});
+        this.hidePanel();
       } else {
         this.options.router.navigate('/', {trigger: true});
       }

--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -262,19 +262,22 @@
     filter: function(locationType) {
       var self = this;
       this.locationTypeFilter = locationType;
-      this.collection.each(function(model) {
-        var modelLocationType = model.get('location_type');
 
-        if (modelLocationType &&
-          modelLocationType.toUpperCase() === locationType.toUpperCase()) {
-          self.layerViews[model.cid].show();
-        } else {
-          self.layerViews[model.cid].hide();
-        }
+      _.each(this.places, function(collection, collectionId) {
+        collection.each(function(model) {
+          var modelLocationType = model.get('location_type');
+
+          if (modelLocationType &&
+            modelLocationType.toUpperCase() === locationType.toUpperCase()) {
+            self.layerViews[collectionId][model.cid].show();
+          } else {
+            self.layerViews[collectionId][model.cid].hide();
+          }
+        });
       });
 
-      _.each(Object.keys(self.landmarks), function(collectionId) {
-        self.landmarks[collectionId].each(function(model) {
+      _.each(this.landmarks, function(collection, collectionId) {
+        collection.each(function(model) {
           var modelLocationType = model.get('location_type');
 
           if (modelLocationType &&


### PR DESCRIPTION
Apparently we missed a bit of filtering logic in the multidataset
refactor. This commit corrects the omission. It also adds a call to
hidePanel() when closing the content panel on maps with active
location_type filters. Previously, the content panel wouldn't close
in this situation.