### PR TITLE
Revert use of invalidateSize() inside a timeout

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -862,18 +862,7 @@
       }
 
       this.setBodyClass('content-visible');
-
-      // Set a very short timeout here to hopefully avoid a race condition
-      // between the CSS transition that resizes the map container and
-      // invalidateSize(). Otherwise, invalidateSize() may fire before the new
-      // map container dimensions have been set by CSS, resulting in the
-      // infamous off-center bug.
-      // NOTE: the timeout duration in use here was arbitrarily selected.
-      // TODO: this is a hack. Is there a better way to handle this? Can we 
-      // listen for an event from CSS maybe?
-      setTimeout(function() {
-        map.invalidateSize({ animate:true, pan:true });
-      }, 30);
+      map.invalidateSize({ animate:true, pan:true });
 
       $(Shareabouts).trigger('panelshow', [this.options.router, Backbone.history.getFragment()]);
 


### PR DESCRIPTION
This PR reverts changes introduced in #622, which placed a call to `invalidateSize()` inside a very short timeout in an effort to defeat the off-center bug that sometimes causes the map to center incorrectly on a selected place.

But as @LukeSwart originally noted in #622, using a timeout in this way is hacky and not a great idea. There have been cases where the timeout causes the centerpoint of the map to wander around, and with the spotlight visible it's really apparent that something weird is happening.

I think the map is actually more usable without this hack in the code. We might still encounter the off-center bug from time to time, but perhaps we can think of another less fragile way to counteract that behavior down the road.