### PR TITLE
Embedded image uploads in the dynamic form

### DIFF
--- a/src/base/static/js/models/attachment-model.js
+++ b/src/base/static/js/models/attachment-model.js
@@ -45,7 +45,7 @@ module.exports = Backbone.Model.extend({
         return myXhr;
       },
       //Ajax events
-      success: function() {
+      success: function(attachmentResponse) {
         var args = Array.prototype.slice.call(arguments);
 
         // Set the save attribute on the incoming data so that we know it's
@@ -56,7 +56,6 @@ module.exports = Backbone.Model.extend({
         if (options.success) {
           options.success.apply(this, args);
         }
-
       },
       error: options.error,
       // Form data

--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -16,7 +16,7 @@
       this.zoomRules = [];
       this.layerUpdatedAfterLastMapChange = false;
 
-      this.model.on('change', this.createLayer, this);
+      this.model.on('change', function() { this.createLayer(); this.render() }, this);
       this.model.on('focus', this.focus, this);
       this.model.on('unfocus', this.unfocus, this);
       this.model.on('destroy', this.onDestroy, this);

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -284,11 +284,6 @@
         }
       });
 
-      // Add content that has been modified by Quill rich text fields
-      this.$(".rich-text-field").each(function() {
-        attrs[$(this).attr("name")] = $(this).find(".ql-editor").html();
-      });
-      
       if (this.geometryEnabled) {
         attrs.geometry = this.geometryEditorView.geometry;
       } else {
@@ -528,43 +523,90 @@
         });
         model = collection.at(collection.length - 1);
 
-        // if an attachment has been added...
-        if (self.formState.attachmentData) {
-          var attachment = model.attachmentCollection.find(function(attachmentModel) {
-            return attachmentModel.get('name') === self.formState.attachmentData.name;
+        if (self.formState.attachmentData.length > 0) {
+          self.formState.attachmentData.forEach(function(attachment) {
+            model.attachmentCollection.add(attachment);
           });
-
-          if (_.isUndefined(attachment)) {
-            model.attachmentCollection.add(self.formState.attachmentData);
-          } else {
-            attachment.set(self.formState.attachmentData);
-          }
+        } else {
+          // Add rich text content. If we're on this path, it means no images
+          // have been embedded.
+          self.$(".rich-text-field").each(function() {
+            attrs[$(this).attr("name")] = $(this).find(".ql-editor").html();
+          });
         }
+      }
 
-        $button.attr('disabled', 'disabled');
-        spinner = new Spinner(Shareabouts.smallSpinnerOptions).spin(self.$('.form-spinner')[0]);
-        Util.log('USER', 'new-place', 'submit-place-btn-click');
-        Util.setStickyFields(attrs, Shareabouts.Config.survey.items, Shareabouts.Config.place.items);
+      $button.attr('disabled', 'disabled');
+      spinner = new Spinner(Shareabouts.smallSpinnerOptions).spin(self.$('.form-spinner')[0]);
+      Util.log('USER', 'new-place', 'submit-place-btn-click');
+      Util.setStickyFields(attrs, Shareabouts.Config.survey.items, Shareabouts.Config.place.items);
 
-        // Save and redirect
-        model.save(attrs, {
-          success: function() {
+      // Save and redirect
+      model.save(attrs, {
+        success: function(response) {
+          if (self.formState.attachmentData.length > 0 &&
+              self.$(".rich-text-field").length > 0) {
+
+            // If there is rich text image content on the form, add it now and replace
+            // img data urls with their S3 bucket equivalents.
+            // NOTE: this success handler is called when all attachment models have
+            // saved to the server.
+            model.attachmentCollection.fetch({
+              reset: true,
+              success: function(collection) {
+                collection.each(function(attachment) {
+                  self.$("img[name='" + attachment.get("name") + "']")
+                    .attr("src", attachment.get("file"));
+                });
+
+                // Add content that has been modified by Quill rich text fields
+                self.$(".rich-text-field").each(function() {
+                  attrs[$(this).attr("name")] = $(this).find(".ql-editor").html();
+                });
+
+                model.saveWithoutAttachments(attrs, {
+                  success: function(response) {
+                    Util.log('USER', 'new-place', 'successfully-add-place');
+                    router.navigate(Util.getUrl(model), { trigger: true });
+                  },
+                  error: function() {
+                    Util.log('USER', 'new-place', 'fail-to-embed-attachments');
+                  },
+                  complete: function() {
+                    if (self.geometryEditorView) {
+                      self.geometryEditorView.tearDown();
+                    }
+                    $button.removeAttr('disabled');
+                    spinner.stop();
+                    self.resetFormState();
+                    collection.each(function(attachment) {
+                      attachment.set({saved: true});
+                    });
+                  }
+                });
+              },
+              error: function() {
+                Util.log('USER', 'new-place', 'fail-to-fetch-embed-urls');
+              }
+            });
+          } else {
+
+            // Otherwise, go ahead and route to the newly-created place.
             Util.log('USER', 'new-place', 'successfully-add-place');
             router.navigate(Util.getUrl(model), { trigger: true });
-          },
-          error: function() {
-            Util.log('USER', 'new-place', 'fail-to-add-place');
-          },
-          complete: function() {
             if (self.geometryEditorView) {
               self.geometryEditorView.tearDown();
             }
             $button.removeAttr('disabled');
             spinner.stop();
             self.resetFormState();
-          },
-          wait: true
-        });
-      }
+          }
+        },
+        error: function() {
+          Util.log('USER', 'new-place', 'fail-to-add-place');
+        },
+        wait: true
+      });
+
     }, null)
   });

--- a/src/base/static/js/views/rich-text-editor-view.js
+++ b/src/base/static/js/views/rich-text-editor-view.js
@@ -46,11 +46,9 @@ module.exports = Backbone.View.extend({
     // Override default image upload behavior; instead, trigger a save to our
     // S3 bucket and embed and img tag with the resulting src.
     this.toolbar.addHandler("image", function() {
+      $("#" + self.options.fieldId + " input[type='file']").remove();
       $("#" + self.options.fieldId)
-        .remove("input[type='file']")
         .append("<input class='is-hidden quill-file-input' type='file' accept='image/png, image/gif, image/jpeg' />");
-
-      self.delegateEvents();
 
       $("#" + self.options.fieldId + " input[type='file']").trigger("click");
     });

--- a/src/base/static/js/views/rich-text-editor-view.js
+++ b/src/base/static/js/views/rich-text-editor-view.js
@@ -77,10 +77,8 @@ module.exports = Backbone.View.extend({
 
       Util.fileToCanvas(file, function(canvas) {
         canvas.toBlob(function(blob) {
-
-          var fieldName = Math.random().toString(36).substring(7),
-          data = {
-            name: fieldName,
+          var data = {
+            name: Math.random().toString(36).substring(7),
             blob: blob,
             file: canvas.toDataURL('image/jpeg')
           }
@@ -97,6 +95,11 @@ module.exports = Backbone.View.extend({
             // Otherwise, store up the added attachments in the place form view
             self.options.placeFormView.formState.attachmentData.push(data);
             self.quill.insertEmbed(self.quill.getSelection().index, "image", data.file, "user");
+            self.$("img").filter(function() {
+              return !$(this).attr("name");
+            })
+              .last()
+              .attr("name", data.name);
           }
 
         }, 'image/jpeg');


### PR DESCRIPTION
**WAIT TO MERGE--NEEDS ANOTHER ROUND OF TESTING**

This PR fixes an issue with embedded images added via the Quill rich text editor in the dynamic form. 

Previously, when embedding images in the dynamic form, we persisted data urls of those images to the server. Now, we make sure to save all embedded images first (as attachment models), then replace any rich text content data urls with their corresponding S3 bucket urls, then re-save the host place model with any rich text `<img>` tags set to their S3 source.