### PR TITLE
Revert to Leaflet 0.7.5

### DIFF
--- a/src/base/static/js/models/model-utils.js
+++ b/src/base/static/js/models/model-utils.js
@@ -40,8 +40,7 @@ var addStoryObj = function(response, type) {
         basemap: story.order[url].basemap,
         spotlight: story.order[url].spotlight,
         hasCustomZoom: story.order[url].hasCustomZoom,
-        sidebarIconUrl: story.order[url].sidebarIconUrl,
-        flyTo: story.order[url].flyTo
+        sidebarIconUrl: story.order[url].sidebarIconUrl
       }
     }
   });

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -294,8 +294,7 @@
             "next": story.order[(i + 1) % totalStoryElements].url,
             "basemap": config.basemap || story.default_basemap,
             "spotlight": (config.spotlight === false) ? false : true,
-            "sidebarIconUrl": config.sidebar_icon_url,
-            "flyTo": config.flyTo || false
+            "sidebarIconUrl": config.sidebar_icon_url
           }
         });
         story.order = storyStructure;
@@ -713,7 +712,7 @@
 
       function onFound(model, type, datasetId) {
         var map = self.mapView.map,
-            layer, center, zoom, flyTo, detailView, $responseToScrollTo;
+            layer, center, zoom, detailView, $responseToScrollTo;
 
         if (type === "place") {
 
@@ -761,37 +760,24 @@
             self.setStoryLayerVisibility(model);
             center = model.get("story").panTo || center;
             zoom = model.get("story").zoom;
-            flyTo = model.get("story").flyTo;
           }
 
           if (layer.getLatLng) {
-            if (flyTo) {
-              map.flyTo(center, zoom);
-            } else {
-              map.setView(center, zoom, {
-                animate: true
-              }); 
-            }
+            map.setView(center, zoom, {
+              animate: true
+            }); 
           } else {
 
             // If we've defined a custom zoom for a polygon layer for some reason,
             // don't use fitBounds and instead set the zoom defined
             if (model.get("story") && model.get("story").hasCustomZoom) {
-              if (flyTo) {
-                map.flyTo(center, model.get("story").zoom);
-              } else {
-                map.setView(center, model.get("story").zoom, {
-                  animate: true
-                });
-              }
+              map.setView(center, model.get("story").zoom, {
+                animate: true
+              });
             } else {
-              if (flyTo) {
-                map.flyToBounds(layer.getBounds());
-              } else {
-                map.fitBounds(layer.getBounds(), {
-                  animate: true
-                });
-              }
+              map.fitBounds(layer.getBounds(), {
+                animate: true
+              });
             }
           }
         }

--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -405,14 +405,6 @@
       } else if (config.type && config.type === 'cartodb') {
         cartodb.createLayer(self.map, config.url, { legends: false })
           .on('done', function(cartoLayer) {
-
-            // NOTE: this no-op is a monkey patch to make cartodb_noleaflet.js play
-            // nicely with leaflet 1.0. This is so we can have both carto and leaflet's
-            // flyTo method available on the same map, as carto (as of v. 3.15) does
-            // not yet support flyTo.
-            // See here: https://github.com/CartoDB/cartodb.js/issues/1503
-            cartoLayer._adjustTilePoint = function(){};
-
             self.layers[config.id] = cartoLayer;
             // This is only set when the 'visibility' event is fired before
             // our carto layer is loaded:

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -57,18 +57,18 @@
 
   {% if config.map.cartodb_enabled %}
   <link rel="stylesheet" href="//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css" />
   {% else %}
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css" />
   {% endif %}
 
   {% if config.cluster %}
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.5/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.5/MarkerCluster.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.Default.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.css" />
   {% endif %}
 
   <!--[if lte IE 8]>
-      <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.ie.css" />
+      <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.ie.css" />
   <![endif]-->
 
   <!--[if lt IE 9]>
@@ -173,15 +173,12 @@
   <script>window.jQuery || document.write('<script src="{{ STATIC_URL }}libs/jquery-1.10.2.js"><\/script>')</script><!-- FIXME: Maybe this should be pulled into the repo as a git submodule-->
 
   {% if config.map.cartodb_enabled %}
-  <!-- NOTE: we're loading both leaflet and cartodb_noleaflet, as standalone cartodb does
-    not yet support all leaflet 1.0 features -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js"></script>
-  <script src="//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb_noleaflet.js"></script>
+  <script src="//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
   {% else %}
-  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js"></script>
   {% endif %}
   {% if config.cluster %}
-  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.5/leaflet.markercluster.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>
   {% endif %}
 
   {% if settings.MAPBOX_TOKEN %}


### PR DESCRIPTION
This PR reverts changes introduced in #739.

There are too many weird interactions between Leaflet 1.0.x and CartoDB 3.15.x (i.e. flickering map tiles, inexplicably absent features).

For now, it's better to use an older version of Leaflet with Carto.