### PR TITLE
Layer panel improvements

### DIFF
--- a/src/base/jstemplates/gis-legend-content.html
+++ b/src/base/jstemplates/gis-legend-content.html
@@ -11,7 +11,7 @@
                      {{#if visibleDefault}}
                      checked="checked"
                      {{/if}}
-                     class="map-legend-basemap-radio" type="radio" name="basemap"></input>
+                     class="map-legend-basemap-radio is-visuallyhidden" type="radio" name="basemap"></input>
               <label for="map-{{ id }}">{{ title }}</label>
             </div>
           </li>
@@ -21,7 +21,7 @@
   {{# groupings}}
     <li class="layer-type-grouping">
       <div class="layer-type-grouping-title">
-        <input id="{{ id }}" class="map-legend-grouping-checkbox"
+        <input id="{{ id }}" class="map-legend-grouping-checkbox is-visuallyhidden"
                type="checkbox"
                {{#if visibleDefault}}
                checked="checked"
@@ -40,8 +40,14 @@
                      {{#if constituentLayers}}
                      data-constituent-layers="{{#each constituentLayers}}{{this}} {{/each}}"
                      {{/if}}
-                     class="map-legend-checkbox" type="checkbox"></input>
+                     class="map-legend-checkbox is-visuallyhidden" type="checkbox"></input>
               <label for="map-{{ id }}">{{ title }}</label>
+              {{#if info}}
+                <span class="info-icon" 
+                      data-info-content="{{info}}"
+                      data-info-title="{{title}}">
+                </span>
+              {{/if}}
             </div>
           </li>
         {{/layers}}

--- a/src/base/jstemplates/layer-info-window.html
+++ b/src/base/jstemplates/layer-info-window.html
@@ -1,0 +1,12 @@
+<!-- A template for rendering popup layer info windows -->
+<div class="caret-left"></div>
+<div class="layer-info-window-content">
+	<div class="info-window-header">
+		<div class="info-window-close-btn">&#10005;</div>
+		<div class="info-window-title">{{title}}</div>
+		<hr />
+	</div>
+	<div class="info-window-body-container">
+		<div class="info-window-body">{{{body}}}</div>
+	</div>
+</div>

--- a/src/base/static/js/views/gis-legend-view.js
+++ b/src/base/static/js/views/gis-legend-view.js
@@ -1,8 +1,13 @@
+var LayerInfoWindowView = require("./layer-info-window-view.js");
+const INFO_WINDOW_LEFT_OFFSET_ADJUST = 30;
+const INFO_WINDOW_TOP_OFFSET_ADJUST = -67;
+
 module.exports = Backbone.View.extend({
   events: {
     "change .map-legend-basemap-radio": "toggleBasemap",
     "change .map-legend-checkbox": "toggleVisibility",
     "change .map-legend-grouping-checkbox": "toggleHeaderVisibility",
+    "click .info-icon": "onClickInfoIcon"
   },
 
   render: function() {
@@ -88,4 +93,22 @@ module.exports = Backbone.View.extend({
       $("#map-" + layer.id).prop("checked", isChecked);
     }
   },
+
+  onClickInfoIcon: function(evt) {
+    let $currentTarget = $(evt.currentTarget);
+
+    if (!this.layerInfoWindowView) {
+      this.layerInfoWindowView = new LayerInfoWindowView({
+        el: "#layer-info-window-container",
+        sidebar: this.options.sidebar
+      });
+    }
+
+    this.layerInfoWindowView.setState({
+      title: $currentTarget.data("info-title"),
+      body: $currentTarget.data("info-content"),
+      left: $currentTarget.parent().offset().left + evt.currentTarget.offsetLeft + INFO_WINDOW_LEFT_OFFSET_ADJUST,
+      top: $currentTarget.parent().offset().top + evt.currentTarget.offsetTop + INFO_WINDOW_TOP_OFFSET_ADJUST
+    });
+  }
 });

--- a/src/base/static/js/views/layer-info-window-view.js
+++ b/src/base/static/js/views/layer-info-window-view.js
@@ -1,0 +1,48 @@
+/* A view for managing tooltip layer info windows */
+
+module.exports = Backbone.View.extend({
+  events: {
+    "click .info-window-close-btn": "onClickCloseWindowBtn",
+  },
+
+  initialize: function() {
+    this.state = new Backbone.Model({
+      body: "",
+      title: "",
+      top: 0,
+      left: 0
+    });
+
+    this.options.sidebar.on("closing", this.onClickCloseWindowBtn, this);
+    this.options.sidebar.on("content", this.onClickCloseWindowBtn, this);
+
+    return this;
+  },
+
+  setState: function(content = {}) {
+    for (let prop in content) {
+      this.state.set(prop, content[prop]);
+    }
+
+    this.render();
+  },
+
+  onClickCloseWindowBtn: function() {
+    this.$el.addClass("is-hidden");
+  },
+
+  render: function() {
+    let data = {
+      title: this.state.get("title"),
+      body: this.state.get("body")
+    };
+
+    this.$el
+      .removeClass("is-hidden")
+      .html(Handlebars.templates["layer-info-window"](data))
+      .css({
+        top: this.state.get("top") - (this.$el.height() / 2),
+        left: this.state.get("left")
+      });
+  }
+});

--- a/src/base/static/js/views/sidebar-view.js
+++ b/src/base/static/js/views/sidebar-view.js
@@ -33,6 +33,10 @@ module.exports = Backbone.View.extend({
 
     this.$el.html(Handlebars.templates["sidebar"](data));
 
+    this.sidebar = L.control.sidebar("sidebar", {
+      position: "left",
+    });
+
     _.each(this.options.sidebarConfig.panels, function(panelConfig) {
       // TODO: Generalize this for views rendered outside of the sidebar:
       // (or for views with more complicated dependencies like ActivityView)
@@ -41,13 +45,11 @@ module.exports = Backbone.View.extend({
           el: "#" + panelConfig.id,
           mapView: self.options.mapView,
           config: panelConfig,
+          sidebar: self.sidebar
         }).render();
       }
     });
 
-    self.sidebar = L.control.sidebar("sidebar", {
-      position: "left",
-    });
     self.sidebar.addTo(this.options.mapView);
   },
 });

--- a/src/base/static/scss/_legend.scss
+++ b/src/base/static/scss/_legend.scss
@@ -17,7 +17,6 @@
 .layer-type-list {
     font-size: 1.4em;
     font-weight: normal;
-    letter-spacing: 1px;
 }
 
 .layer-type-grouping-list {
@@ -90,28 +89,66 @@
     }
 }
 
-
 .layer-type-list {
     font-size: 0.875em;
 }
 
-.layer-type-title label {
-    vertical-align: middle;
-    margin-right: 8px;
-    font-size: 1.33em;
-    letter-spacing: 1px;
-}
+.layer-type-title {
+    border: 1px solid transparent;
+    border-radius: 3px;
 
-.layer-type-title input {
-    vertical-align: middle;
-    margin-right: 8px;
-    font-size: 1.33em;
-    letter-spacing: 1px;
-}
+    .info-icon {
+        float: right;
+        font-family: "FontAwesome";
 
+        &:before {
+            content: "\f05a";
+        }
+
+        &:hover {
+            cursor: pointer;
+            color: #777;
+        }
+    }
+
+    label {
+        vertical-align: middle;
+        margin-right: 8px;
+        font-size: 1em;
+
+        &:hover {
+            background-color: lightyellow;
+        }
+    }
+
+    input {
+        vertical-align: middle;
+        margin-right: 8px;
+        font-size: 1em;
+
+        &:checked+label {
+            background-color: yellow;
+        }
+    }    
+}
 
 .layer-type-title:active label:hover, .shareabouts-layer-li:active a {
     color: $hover-highlight-blue;
+}
+
+.layer-type-grouping-title {
+    margin-top: 8px;
+    font-size: 15px;
+    font-weight: bold;
+
+    label {
+        font-size: 15px;
+        font-weight: bold;
+
+        &:hover {
+            cursor: pointer;
+        }
+    }
 }
 
 .map-layer-list {
@@ -177,8 +214,7 @@
     margin-bottom: 0;
 
     .shareabouts-layer-li {
-        font-size: 16px;
-        letter-spacing: 1.4px;
+        font-size: 14px;
     }
     .unstyled-list {
         overflow: visible;

--- a/src/base/static/scss/_map.scss
+++ b/src/base/static/scss/_map.scss
@@ -307,3 +307,70 @@
 .leaflet-draw-tooltip {
     display: none;
 }
+
+/* layer info popup windows */
+#layer-info-window-container {
+    position: absolute;
+    padding: 10px;
+    font-size: 0.8em;
+    max-height: 200px;
+    width: 200px;
+    background-color: #FFF;
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.65);
+    border-radius: 3px;
+    z-index: 3000;
+
+    .layer-info-window-content {
+
+        .info-window-header {
+            background-color: #FFF;
+            width: 200px;
+
+            .info-window-close-btn {
+                float: right;
+                color: #ff5e99;
+
+                &:hover {
+                    cursor: pointer;
+                    color: #cd2c67;                
+                }
+            }
+
+            .info-window-title {
+                font-weight: 800;
+            }
+
+            hr {
+                margin-top: 5px;
+                margin-bottom: 5px;
+            }
+        }
+
+        .info-window-body-container {
+            max-height: 175px;
+            overflow: auto;
+        }
+    }
+
+    .caret-left {
+        width: 24px;
+        height: 24px;
+        position: absolute;
+        overflow: hidden;
+        box-shadow: 0 16px 10px -17px rgba(0, 0, 0, 0.5);
+        left: -24px;
+        top: calc(50% - 12px);
+
+        &:after {
+            content: "";
+            position: absolute;
+            width: 12px;
+            height: 12px;
+            background: #FFF;
+            transform: rotate(45deg);
+            top: 6px;
+            left: 18px;
+            box-shadow: 0 1px 5px rgba(0, 0, 0, 0.65);
+        }
+    }
+}

--- a/src/base/static/scss/_media.scss
+++ b/src/base/static/scss/_media.scss
@@ -56,9 +56,7 @@
 
 @media only screen and (min-height: 768px) and (max-width: 60em) {}
 
-// Catchall media query for screen widths below 60em. Calculated screen heights
-// mean we don't need several media queries as above, and in general don't need
-// to worry about querying heights.
+// Catchall media query for screen widths below 60em.
 @media only screen and (max-width: 60em) {
     html, body, #map {
         height: 100%;
@@ -171,6 +169,10 @@
         .right-sidebar-content {
             width: 100%;
         }
+    }
+
+    .info-icon {
+        display: none;
     }
 }
 

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -135,6 +135,7 @@
         <div id="sidebar-container"></div>
       {% endif %}
 
+      <div id="layer-info-window-container" class="is-hidden"></div>
     </div>
 
     <div id="content"><!-- .place or .page -->

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -746,10 +746,12 @@ sidebar:
             - id: school-boundaries
               title: _(School Districts)
               visibleDefault: false
+              info: _(This is some great information about the school boundaries layer. People LOVE it.)
 
             - id: zoning
               title: _(Zoning)
               visibleDefault: false
+              info: _(This is a tiny window.)
 
         - id: grp-natural-boundaries
           title: _(Natural Boundaries)
@@ -758,6 +760,7 @@ sidebar:
             - id: wria-7-8-9
               title: _(WRIA boundaries)
               visibleDefault: false
+              info: _(WRIA 9 is comprised of the Green River and Duwamish River Watersheds. It aso includes the nearshore habitat and small drainages along Elliott Bay (downtown Seattle), plus the Puget Sound shoreline along West Seattle, Burien, Normandy Park, Des Moines and Federal Way, as well as all of Vashon Island.<br><br>A natural watershed is the total land area draining into a river, lake, or Puget Sound defined by its ridgelines. Water Resource Inventory Areas (WRIAs) are administrative units authorized under the Water Resources Act of 1971. These boundaries, which can include more than one watershed and many sub-basins, help resource managers, planners, and policy makers improve collaborative decision making around salmon recovery, farms, flooding, forestry, and stormwater management.<br><br>The Washington State Department of Ecology was given the responsibility for the development and management of these administrative and planning boundaries. There are 62 "Water Resource Inventory Areas" across the state.)
 
             - id: watershed-cedar
               title: _(Cedar River - Lake Washington Watershed)

--- a/src/flavors/central-puget-sound/static/css/custom.css
+++ b/src/flavors/central-puget-sound/static/css/custom.css
@@ -72,28 +72,6 @@
   font-size: 0.9em;
 }
 
-/* =Leaflet sidebar overrides
--------------------------------------------------------------- */
-.map-legend-grouping-checkbox {
-  -ms-transform: scale(1.4); /* IE */
-  -moz-transform: scale(1.4); /* FF */
-  -webkit-transform: scale(1.4); /* Safari and Chrome */
-  -o-transform: scale(1.4); /* Opera */
-  transform: scale(1.4);
-}
-
-.layer-type-grouping-title, .map-legend-grouping-checkbox + label {
-  font-size: 1.1em;
-  font-weight: bold;
-  vertical-align: middle;
-  padding-left: 8px;
-}
-
-.map-legend-basemap-radio + label, .map-legend-checkbox + label {
-  font-size: 1.1em;
-}
-
-
 /* =Grid-based layout on about page
 Adapted from http://littlesnippets.net/snip1579/
 -------------------------------------------------------------- */


### PR DESCRIPTION
This PR makes the following changes to the layers panel:
- remove checkboxes and radio buttons
- add new hover and selected styling for individual layers
- tweak spacing and lettering
- add the option of displaying an icon next to each layer in the layer panel which, when clicked, opens a popup with information about the layer.
    - Use the `info:` flag in the `sidebar` section of the config to define the content that appears in popups.