### PR TITLE
support admin permissions by location_type

### DIFF
--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -32,7 +32,7 @@ var self = (module.exports = {
 
   // Determine whether or not the current logged-in user has admin rights
   // for the passed datasetId. Returns true or false.
-  getAdminStatus: function(datasetId) {
+  getAdminStatus: function(datasetId, adminGroups = []) {
     var isAdmin = false;
 
     if (
@@ -40,11 +40,15 @@ var self = (module.exports = {
       Shareabouts.bootstrapped.currentUser.groups
     ) {
       _.each(Shareabouts.bootstrapped.currentUser.groups, function(group) {
+
         // Get the name of the datasetId from the end of the full url
         // provided in Shareabouts.bootstrapped.currentUser.groups
         var url = group.dataset.split("/"),
           match = url[url.length - 1];
-        if (match && match === datasetId && group.name === "administrators") {
+
+        if (match && 
+            match === datasetId && 
+            (group.name === "administrators" || adminGroups.indexOf(group.name) > -1)) {
           isAdmin = true;
         }
       });

--- a/src/base/static/js/views/place-detail-view.js
+++ b/src/base/static/js/views/place-detail-view.js
@@ -24,14 +24,14 @@ module.exports = Backbone.View.extend({
   initialize: function() {
     var self = this;
 
-    this.isEditable = Util.getAdminStatus(this.options.datasetId);
+    this.categoryConfig = _.findWhere(this.options.placeConfig.place_detail, {
+      category: this.model.get("location_type"),
+    });
+    this.isEditable = Util.getAdminStatus(this.options.datasetId, this.categoryConfig.admin_groups);
     this.isEditingToggled = false;
     this.surveyType = this.options.surveyConfig.submission_type;
     this.supportType = this.options.supportConfig.submission_type;
     this.isModified = false;
-    this.categoryConfig = _.findWhere(this.options.placeConfig.place_detail, {
-      category: this.model.get("location_type"),
-    });
     this.commonFormElements = this.options.placeConfig.common_form_elements;
     this.geometryEditorView = this.options.geometryEditorView;
     this.onAddAttachmentCallback = null;

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -176,11 +176,11 @@ module.exports = Backbone.View.extend({
   determineRenderabilityForEachCategory: function() {
     _.each(this.options.placeConfig.place_detail, function(place) {
       _.extend(place, {
-        isAdmin: Util.getAdminStatus(place.dataset),
+        isAdmin: Util.getAdminStatus(place.dataset, place.admin_groups),
         isRenderable: (function() {
           if (!place.includeOnForm) {
             return false;
-          } else if (place.admin_only && !Util.getAdminStatus(place.dataset)) {
+          } else if (place.admin_only && !Util.getAdminStatus(place.dataset, place.admin_groups)) {
             return false;
           }
 


### PR DESCRIPTION
Addresses: #764 

This PR adds the ability to set admin permissions on a `location_type`-by-`location_type` basis within a given dataset.

To set permissions for an individual `location_type`:
1. In the Django admin panel, create as many dataset groups (each with a unique name) as needed. Add social auths to groups as appropriate. Remember to grant `retrieve`, `create`, `update`, and `destroy` privileges for each group.

2. In the dynamic form section of the config, add an `admin_groups` array to each category config that you want to grant group privileges to. This array should list, by name, all the groups that have admin privileges for the given category. For example:
```
place_detail:
  - category: featured_place
     admin_only: true
     includeOnForm: true
     admin_groups:
       - approved_editors
       - student_interns
     ...
```
3. Keep in mind that members of the special dataset group called `administrators` will have admin privileges on all `location_types` for the dataset.