### PR TITLE
On panel show, call invalidateSize() inside a short timeout

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -996,7 +996,16 @@ module.exports = Backbone.View.extend({
     }
 
     this.setBodyClass("content-visible");
-    map.invalidateSize({ animate: true, pan: true });
+
+    // Set a very short timeout here to hopefully avoid a race condition
+    // between the CSS transition that resizes the map container and
+    // invalidateSize(). Otherwise, invalidateSize() may fire before the new
+    // map container dimensions have been set by CSS, resulting in the
+    // infamous off-center bug.
+    // NOTE: the timeout duration in use here was arbitrarily selected.
+    setTimeout(function() {
+      map.invalidateSize({ animate:true, pan:true });
+    }, 1);
 
     $(Shareabouts).trigger("panelshow", [
       this.options.router,


### PR DESCRIPTION
This PR reverts the revert introduced in #745, as the off-center bug continues to be very distracting. We're using a shorter timeout this time around. It's still hacky and not ideal though, although it seems to solve the off-center bug.

This is an effort to avoid a potential race condition between the CSS transition that resizes the map container to accommodate the content panel, and the call to invalidateSize() inside showPanel(). The timeout (hopefully) allows the transition to complete and the new map dimensions to be set before invalidateSize() recenters the map.