### PR TITLE
Add support for staggered layer activation in story mode

### DIFF
--- a/src/base/static/js/models/model-utils.js
+++ b/src/base/static/js/models/model-utils.js
@@ -41,6 +41,8 @@ var addStoryObj = function(response, type) {
         spotlight: story.order[url].spotlight,
         hasCustomZoom: story.order[url].hasCustomZoom,
         sidebarIconUrl: story.order[url].sidebarIconUrl,
+        layerAddDelay: story.order[url].layerAddDelay,
+        basemapAddDelay: story.order[url].basemapAddDelay
       };
     }
   });

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -74,6 +74,36 @@ var self = (module.exports = {
     ].join("");
   },
 
+  // Build and execute a sequence of functions separated by a specified delay
+  chainExecute: function() {
+    let queue = [],
+      _push = (fn, delay) => {
+        queue.push({
+          fn: fn,
+          delay: delay || 1000
+        });
+      },
+      _exec = () => {
+        let current = queue.shift();
+
+        window.setTimeout(() => {
+          current.fn();
+          if (queue.length > 0) {
+            _exec();
+          }
+        }, current.delay);
+      },
+      _clear = () => {
+        queue = [];
+      };
+
+    return {
+      push: _push,
+      exec: _exec,
+      clear: _clear
+    }
+  },
+
   getSocialUrl: function(model, service) {
     var appConfig = Shareabouts.Config.app,
       shareUrl = "http://social.mapseed.org",

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -345,6 +345,8 @@ module.exports = Backbone.View.extend({
           basemap: config.basemap || story.default_basemap,
           spotlight: config.spotlight === false ? false : true,
           sidebarIconUrl: config.sidebar_icon_url,
+          layerAddDelay: config.layer_add_delay,
+          basemapAddDelay: config.basemap_add_delay
         };
       });
       story.order = storyStructure;
@@ -750,36 +752,43 @@ module.exports = Backbone.View.extend({
     this.setBodyClass("content-visible", "place-form-visible");
   },
 
-  // If a model has a story object, set the appropriate layer
-  // visilbilities and update legend checkboxes
   setStoryLayerVisibility: function(model) {
-    // change the basemap if it's been set in the story config
-    if (model.get("story").basemap) {
-      this.setLayerVisibility(model.get("story").basemap, true, true);
+    let story = model.get("story"),
+        chainExecute = (story.layerAddDelay) ? Util.chainExecute() : null;
+
+    // Set basemap visibility
+    if (story.basemap) {
+      if (chainExecute) {
+        chainExecute.push(
+
+          // TODO: it's only necessary to chain the basemap add if we're changing
+          // the basemap. Otherwise it's dead time.
+          () => this.setLayerVisibility(story.basemap, true, true),
+          story.basemapAddDelay
+        );
+      } else {
+        this.setLayerVisibility(story.basemap, true, true);
+      }
     }
 
-    // set layer visibility based on story config
+    // Set other layers' visibility
     _.each(
-      model.get("story").visibleLayers,
-      function(targetLayer) {
-        this.setLayerVisibility(targetLayer, true, false);
-      },
-      this,
+      this.options.mapConfig.layers.filter((layer) => layer.type !== "basemap"),
+      function(layer) {
+        let isVisible = _.contains(story.visibleLayers, layer.id);
+
+        if (chainExecute && isVisible) {
+          chainExecute.push(
+            () => this.setLayerVisibility(layer.id, true, false),
+            story.layerAddDelay
+          );
+        } else {
+          this.setLayerVisibility(layer.id, isVisible, false);
+        }
+      }, this
     );
 
-    // switch off all other layers
-    _.each(
-      this.options.mapConfig.layers,
-      function(targetLayer) {
-        if (!_.contains(model.attributes.story.visibleLayers, targetLayer.id)) {
-          // don't turn off basemap layers!
-          if (targetLayer.type !== "basemap") {
-            this.setLayerVisibility(targetLayer.id, false, false);
-          }
-        }
-      },
-      this,
-    );
+    chainExecute && chainExecute.exec();
   },
 
   restoreDefaultLayerVisibility: function() {

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -1212,7 +1212,9 @@ story:
         basemap: satellite
       - url: sammamish
         zoom: 10
+        basemap_add_delay: 1200
         basemap: light-nolabels
+        layer_add_delay: 750
         visible_layers:
           - wria-7-8-9
           - watershed-sammamish

--- a/src/flavors/central-puget-sound/static/css/custom.css
+++ b/src/flavors/central-puget-sound/static/css/custom.css
@@ -4,6 +4,37 @@
  * NOTE: "With great power comes great responsibility."
  */
 
+/* zoom and fade animations */
+.leaflet-fade-anim .leaflet-tile,
+.leaflet-fade-anim .leaflet-popup {
+  opacity: 0;
+  -webkit-transition: opacity .8s linear !important;
+     -moz-transition: opacity .8s linear !important;
+       -o-transition: opacity .8s linear !important;
+          transition: opacity .8s linear !important;
+  }
+.leaflet-fade-anim .leaflet-tile-loaded,
+.leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
+  opacity: 1;
+  }
+
+.leaflet-zoom-anim .leaflet-zoom-animated {
+  -webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1) !important;
+     -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1) !important;
+       -o-transition:      -o-transform 0.25s cubic-bezier(0,0,0.25,1) !important;
+          transition:         transform 0.25s cubic-bezier(0,0,0.25,1) !important;
+  }
+.leaflet-zoom-anim .leaflet-tile,
+.leaflet-pan-anim .leaflet-tile,
+.leaflet-touching .leaflet-zoom-animated {
+  -webkit-transition: none !important;
+     -moz-transition: none !important;
+       -o-transition: none !important;
+          transition: none !important;
+  }
+
+
+
 @font-face {
   font-family: 'Permanent Marker';
   src: url('PermanentMarker.ttf');


### PR DESCRIPTION
**NOT READY TO MERGE YET**

When the story mode changes layers, zoom level, and map pan all at once it can be disorienting for the user.

This PR allows us to delay and stagger layer adds in story mode. Use the following properties in each story item config for which you'd like to set delays:

```
basemap_add_delay: 1200
layer_add_delay: 750
```
Delays are in milliseconds. Layers will add themselves one by one in the order listed in the story config, preceded by the basemap if specified.