### PR TITLE
add option for selectively hiding form fields on place detail views

### DIFF
--- a/src/base/jstemplates/place-detail.html
+++ b/src/base/jstemplates/place-detail.html
@@ -90,8 +90,10 @@
         {{#if ../isEditingToggled}}
           {{> place-form-field-types}}
         {{else}}
-          <div class="place-label place-label-{{ name }}">{{ display_prompt }}</div>
-          {{> place-detail-field-types}}
+          {{#unless hideFromDetailView}}
+            <div class="place-label place-label-{{ name }}">{{ display_prompt }}</div>
+            {{> place-detail-field-types}}
+          {{/unless}}
         {{/if}}
         <div style="clear:both"></div>
       </div>

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -1117,6 +1117,7 @@ place:
       optional: true
     - name: school-name
       type: dropdown
+      hideFromDetailView: true
       prompt: _(Your school:)
       content:
         - label: _(School A)


### PR DESCRIPTION
This is a simple feature that lets us hide an individual form field from the detail view on which it would otherwise appear.

This is different from the existing `private-` field functionality, which prevents data of this type from ever being sent to the client at all. Hidden fields are sent to the client (and thus can be edited in editor mode), but are not visible on rendered place detail views.

Add a `hideFromDetailView: true` flag to a field config to enable this behavior.