### PR TITLE
Add combobox autocomplete feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dotenv": "^4.0.0",
     "esprima": "^3.1.3",
     "glob": "^7.1.1",
+    "@mapseed/accessible-autocomplete": "https://github.com/mapseed/accessible-autocomplete.git#6dcaafbdf154d0cb8c46ff6e50c350ee313d3985",
     "node-env-file": "^0.1.7",
     "node-sass": "^4.0.0",
     "shelljs": "^0.5.3",

--- a/src/base/jstemplates/place-form-field-types.html
+++ b/src/base/jstemplates/place-form-field-types.html
@@ -141,6 +141,23 @@
   <div style="clear:both"></div>
 {{/is}}
 
+{{#is type "dropdown-autocomplete"}}
+  <div>
+    <select id="dropdown-autocomplete-container-{{../name}}"
+            class="dropdown-autocomplete-container"
+            name={{ ../name }} 
+            data-placeholder="{{ ../placeholder }}"
+            {{^optional}}required{{/optional}}
+            {{#if isAutocomplete}}class="is-autocomplete"{{/if}}>
+      <option value="" name="no_response"></option>
+      {{#each content}}
+          <option value={{value}} {{#is value ../existingContent}}selected{{/is}}>{{label}}</option>
+      {{/each}}
+    </select>
+  </div>
+  <div style="clear:both"></div>
+{{/is}}
+
 {{#is type "url-title"}}
   <div class="url-readout-container">
     <p class="url-readout-msg">{{#_}}Your post will be accessible at:{{/_}}</p>

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -306,7 +306,8 @@ var self = (module.exports = {
     } else if (
       fieldConfig.type === "checkbox_big_buttons" ||
       fieldConfig.type === "radio_big_buttons" ||
-      fieldConfig.type === "dropdown"
+      fieldConfig.type === "dropdown" ||
+      fieldConfig.type === "dropdown-autocomplete"
     ) {
       // Checkboxes, radio buttons, and dropdowns
       if (!_.isArray(existingValue)) {

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -1,3 +1,5 @@
+import accessibleAutocomplete from 'accessible-autocomplete';
+
 var Util = require("../utils.js");
 var Gatekeeper = require("../../libs/gatekeeper.js");
 var GeocodeAddressPlaceView = require("mapseed-geocode-address-place-view");
@@ -132,6 +134,41 @@ module.exports = Backbone.View.extend({
         }
       });
     }
+
+    // Set up autocomplete comboboxes
+    Array.prototype.forEach.call(
+      document.getElementsByClassName("dropdown-autocomplete-container"),
+      (elt) => {
+        let node = document.getElementsByName(elt.name)[0],
+            optionsArray = Array.prototype.map.call(
+              node.options,
+              (opt) => {
+                return opt.textContent
+              }
+            );
+
+        accessibleAutocomplete.enhanceSelectElement({
+          id: node.id,
+          selectElement: node,
+          displayMenu: "overlay",
+          showAllValues: true,
+          required: node.required,
+          placeholder: node.dataset.placeholder,
+          onConfirm: function(confirmed) {
+            if (confirmed) {
+
+              // Set the value of the underlying select element
+              document.getElementById(this.id + "-select").selectedIndex = 
+                optionsArray.indexOf(confirmed);
+            }
+          }
+        });
+
+        // Remove a required attribute on the underlying select element, to 
+        // prevent problems with validating a hidden element
+        node.required = false;
+      }
+    );
   },
 
   setUrlTitlePrefix: function() {

--- a/src/base/static/scss/_forms.scss
+++ b/src/base/static/scss/_forms.scss
@@ -1,4 +1,5 @@
 // Forms - Selectors
+@import "../../../../node_modules/accessible-autocomplete/dist/accessible-autocomplete.min";
 
 form {}
 

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -1244,6 +1244,7 @@ place:
     - name: school-name
       hideFromDetailView: true
       optional: false
+      placeholder: _(Type or select a school name...)
       type: dropdown-autocomplete
       prompt: _(Your school:)
       content:

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -1242,8 +1242,9 @@ place:
       placeholder: _(Address)
       optional: true
     - name: school-name
-      type: dropdown
       hideFromDetailView: true
+      optional: false
+      type: dropdown-autocomplete
       prompt: _(Your school:)
       content:
         - label: _(Alcott Elementary School)


### PR DESCRIPTION
This PR adds the ability to create autocomplete combobox dropdown fields on the dynamic form. Use the `type: dropdown-autocomplete` flag to create an autocomplete field.

Following suggestions in [this issue](https://github.com/mapseed/platform/issues/781), we have a fork of the [alphagov/accessible-autocomplete module](https://github.com/alphagov/accessible-autocomplete) with [minor modifications](https://github.com/mapseed/accessible-autocomplete/pull/1) for our own purposes.