### PR TITLE
Make filter list configurable

### DIFF
--- a/src/base/static/js/views/filter-menu-view.js
+++ b/src/base/static/js/views/filter-menu-view.js
@@ -22,7 +22,7 @@ module.exports = Backbone.View.extend({
       filters: new Backbone.Collection([])
     });
 
-    this.options.placeConfig.place_detail.forEach((item) => {
+    this.getFilters().forEach((item) => {
       let model = new locationTypeModel({
         locationType: item.category,
         iconUrl: item.icon_url,
@@ -33,6 +33,12 @@ module.exports = Backbone.View.extend({
     }, this);
 
     this.render();
+  },
+
+  getFilters () {
+    return (this.options.panelConfig.active_filters)
+      ? this.options.panelConfig.active_filters
+      : this.options.placeConfig.place_detail
   },
 
   onFilterChange (evt) {

--- a/src/base/static/js/views/sidebar-view.js
+++ b/src/base/static/js/views/sidebar-view.js
@@ -48,7 +48,8 @@ module.exports = Backbone.View.extend({
           config: panelConfig,
           sidebar: self.sidebar,
           placeConfig: this.options.placeConfig,
-          sidebarView: this
+          sidebarView: this,
+          panelConfig: panelConfig
         }).render();
       }
     }, this);

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -788,6 +788,31 @@ sidebar:
       title: _(Report Filters)
       view: FilterMenuView
       icon: filter
+      active_filters:
+        - category: conserve-water
+          icon_url: /static/css/images/markers/marker-conserve-water.png
+          label: _(Conserve Water)
+        - category: prevent-stormwater
+          icon_url: /static/css/images/markers/marker-prevent-stormwater-pollution.png
+          label: _(Prevent Stormwater Pollution)
+        - category: only-flush
+          icon_url: /static/css/images/markers/marker-only-flush-this.png
+          label: _(Only Flush This)
+        - category: conserve-energy
+          icon_url: /static/css/images/markers/marker-conserve-energy.png
+          label: _(Conserve Energy)
+        - category: waste-less
+          icon_url: /static/css/images/markers/marker-waste-less.png
+          label: _(Waste Less)
+        - category: commute-low-carbon
+          icon_url: /static/css/images/markers/marker-commute-low-carbon.png
+          label: _(Commute Low Carbon)
+        - category: eat-local-organic
+          icon_url: /static/css/images/markers/marker-eat-local-organic.png
+          label: _(Eat Local Organic)
+        - category: restore-salmon-habitat
+          icon_url: /static/css/images/markers/marker-restore-salmon-habitat.png
+          label: _(Restore Salmon Habitat)
 
 activity:
   # Optional. Activity is supported by default. Set to false to disable.


### PR DESCRIPTION
Previously, the filter-menu-view created a filter for every `location_type` in the `place_detail` section of the config. This PR allows for a custom filter list that overrides this default behavior.

Set up a custom filter list as follows:
```
- id: filters
  title: _(Report Filters)
  view: FilterMenuView
  icon: filter
  active_filters:
    - category: conserve-water
      icon_url: /static/css/images/markers/marker-conserve-water.png
      label: _(Conserve Water)
    ...
```

If no `active_filters` list is supplied, the default behavior will apply: a filter for every `location_type` found in the `place_detail` section of the config will be created.

Note that even if a `location_type` is not listed in the filter menu, map points of that `location_type` will still be affected by filter selections. This means that if filters are applied, non-listed `location_type`s will not be accessible, until filters are cleared.