### PR TITLE
Catenate, minify, and gzip files in libs/ folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "build-js-production": "webpack -p && cat src/base/static/dist/bundle.js | gzip > src/base/static/dist/bundle.js.gz",
     "watch-js": "webpack -d --watch",
     "build-css": "cat src/base/static/dist/cat-bundle.css | tee src/base/static/dist/bundle.css | gzip > src/base/static/dist/bundle.css.gz",
+    "build-libs": "cat src/base/static/dist/cat-lib-bundle.js | tee src/base/static/dist/lib-bundle.js | uglifyjs -mc | gzip > src/base/static/dist/lib-bundle.js.gz",
     "build-concat": "node scripts/concat.js",
-    "build": "NODE_ENV=production npm run build-scss-production && npm run build-concat && npm run build-js-production && npm run build-css",
+    "build": "NODE_ENV=production npm run build-scss-production && npm run build-concat && npm run build-js-production && npm run build-css && npm run build-libs",
     "prettier": "prettier --write --trailing-comma all \"{src,blah}/**/*.{js,jsx}\""
   },
   "dependencies": {
@@ -57,6 +58,7 @@
     "catw": "^1.0.1",
     "eslint-config-prettier": "^2.1.1",
     "prettier": "^1.4.4",
+    "uglify-js": "^3.0.27",
     "watchify": "^3.4.0"
   }
 }

--- a/scripts/concat.js
+++ b/scripts/concat.js
@@ -23,6 +23,15 @@ shell.cat([
   'src/flavors/' + flavor + '/static/css/custom.css'
 ]).to('src/base/static/dist/cat-bundle.css')
 
+shell.cat([
+  'src/base/static/libs/binaryajax.js',
+  'src/base/static/libs/exif.js',
+  'src/base/static/libs/swag.min.js',
+  'src/base/static/libs/leaflet.sidebar.js',
+  'src/base/static/libs/leaflet-wmts.js',
+  'src/base/static/libs/leaflet.argo.js'
+]).to('src/base/static/dist/cat-lib-bundle.js')
+
 shell.cp('-R', [
   'src/base/static/css/images/*',
   'src/flavors/' + flavor + '/static/css/images/*'

--- a/src/base/templates/base.html
+++ b/src/base/templates/base.html
@@ -229,12 +229,16 @@
   {% endif %}
   
   <!-- These are obscure or customized, self-hosted. -->
+  {% if settings.DEBUG %}
   <script src="{{STATIC_URL}}libs/binaryajax.js"></script>
   <script src="{{STATIC_URL}}libs/exif.js"></script>
   <script src="{{STATIC_URL}}libs/swag.min.js"></script>
   <script src="{{STATIC_URL}}libs/leaflet.sidebar.js"></script>
   <script src="{{STATIC_URL}}libs/leaflet-wmts.js"></script>
   <script src="{{STATIC_URL}}libs/leaflet.argo.js"></script>
+  {% else %}
+  <script src="{{STATIC_URL}}dist/lib-bundle.js?ver=0.7.6.0"></script>
+  {% endif %}
 
   <script>
     moment.locale('{{LANGUAGE_CODE}}');


### PR DESCRIPTION
Previously we were not bundling up files served in our libs/ folder for production. Doing so should give us a modest performance boost.

This commit introduces a dev dependency on the `uglify-js` package.