### PR TITLE
Support arbitrary placement of common_form_elements

### DIFF
--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -400,27 +400,13 @@ var self = (module.exports = {
     _.each(
       args.fields,
       function(field, i) {
+        if (field.type === "commonFormElement") {
+          Object.assign(args.fields[i], args.commonFormElements[args.fields[i].name]);
+        }
+
         var fieldData = _.extend(
           {},
           args.fields[i],
-          self.buildFieldContent(field, args.model.get(field.name)),
-        );
-
-        if (args.isEditingToggled && fieldIsValidForEditor(fieldData)) {
-          fields.push(fieldData);
-        } else if (fieldIsValid(fieldData)) {
-          fields.push(fieldData);
-        }
-      },
-      this,
-    );
-
-    _.each(
-      args.commonFormElements,
-      function(field, i) {
-        var fieldData = _.extend(
-          {},
-          args.commonFormElements[i],
           self.buildFieldContent(field, args.model.get(field.name)),
         );
 

--- a/src/base/static/js/views/place-form-view.js
+++ b/src/base/static/js/views/place-form-view.js
@@ -240,38 +240,24 @@ module.exports = Backbone.View.extend({
   },
 
   // Before we render the fields for a given category, do the following:
-  // 1. Build an appropriate content object for each field
-  // 2. Check the autocomplete status of each field
-  // 3. Check the admin-only status of each field
+  // 1. Resolve common_form_elements
+  // 2. Build an appropriate content object for each field
+  // 3. Check the autocomplete status of each field
+  // 4. Check the admin-only status of each field
   prepareFormFieldsForRender: function() {
     var self = this;
 
-    // Prepare category-specific fields
-    _.each(
-      this.formState.selectedCategoryConfig.fields,
-      function(field, i) {
-        _.extend(
-          this.formState.selectedCategoryConfig.fields[i],
-          Util.buildFieldContent(
-            field,
-            field.autocomplete ? Util.getAutocompleteValue(field.name) : null,
-          ),
-          self.determineFieldRenderability(
-            self.formState.selectedCategoryConfig,
-            field,
-          ),
-        );
+    // Prepare form fields
+    this.formState.selectedCategoryConfig.fields.forEach((field, i) => {
 
-        this.formState.selectedCategoryConfig.fields[i].isAutocomplete =
-          field.hasValue && field.autocomplete;
-      },
-      this,
-    );
+      if (this.formState.selectedCategoryConfig.fields[i].type === "commonFormElement") {
+        let name = this.formState.selectedCategoryConfig.fields[i].name;
+        Object.assign(this.formState.selectedCategoryConfig.fields[i], 
+          this.formState.commonFormElements[name]);
+      }
 
-    // Prepare common form fields
-    this.formState.commonFormElements.forEach(function(field, i) {
-      _.extend(
-        this.formState.commonFormElements[i],
+      Object.assign(
+        this.formState.selectedCategoryConfig.fields[i],
         Util.buildFieldContent(
           field,
           field.autocomplete ? Util.getAutocompleteValue(field.name) : null,
@@ -282,10 +268,8 @@ module.exports = Backbone.View.extend({
         ),
       );
 
-      this.formState.commonFormElements[i].isAutocomplete = field.hasValue &&
-        field.autocomplete
-        ? true
-        : false;
+      this.formState.selectedCategoryConfig.fields[i].isAutocomplete =
+        field.hasValue && field.autocomplete;
     }, this);
   },
 

--- a/src/flavors/bogtobay/config.yml
+++ b/src/flavors/bogtobay/config.yml
@@ -730,6 +730,14 @@ place:
           display_prompt: _( )
           placeholder: _(Enter comments...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: conservation-pledge
       includeOnForm: true
       name: location_type
@@ -750,6 +758,14 @@ place:
           display_prompt: _( )
           placeholder: _(Enter comments...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: wastewater-pledge
       includeOnForm: true
       name: location_type
@@ -770,6 +786,14 @@ place:
           display_prompt: _( )
           placeholder: _(Enter comments...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: observation
       includeOnForm: true
       name: location_type
@@ -809,6 +833,14 @@ place:
           display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: question
       includeOnForm: true
       name: location_type
@@ -828,6 +860,14 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: idea
       includeOnForm: false
       name: location_type
@@ -848,6 +888,14 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: complaint
       includeOnForm: false
       name: location_type
@@ -868,6 +916,14 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: air_watch  #defines a top-level form category
       includeOnForm: false
       name: location_type  #needs to be "location_type"
@@ -1009,22 +1065,30 @@ place:
           type: text
           prompt: _(Provide any additional comments)
           display_prompt: _(Additional comments:)
-          optional: true   
+          optional: true
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -1032,7 +1096,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -899,6 +899,11 @@ place:
           prompt: _(Choose a custom URL for this place:)
           placeholder: "my-new-featured-place"
           optional: true
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
+
     - category: conserve-water
       includeOnForm: true
       name: location_type
@@ -908,16 +913,9 @@ place:
       label: _(Conserve Water)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title:)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -955,11 +953,17 @@ place:
               value: removed-lawn
           optional: true 
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: prevent-stormwater
       includeOnForm: true
@@ -970,16 +974,9 @@ place:
       label: _(Prevent Stormwater Pollution)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title:)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -1014,11 +1011,17 @@ place:
             - label: _(Inspect and fix home septic system)
               value: fix-septic-system
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: only-flush
       includeOnForm: true
@@ -1029,16 +1032,9 @@ place:
       label: _(Only Flush This)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -1063,11 +1059,17 @@ place:
             - label: _(Never flush condoms)
               value: never-flush-condoms
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: conserve-energy
       includeOnForm: true
@@ -1078,16 +1080,9 @@ place:
       label: _(Conserve Energy)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title:)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -1117,11 +1112,17 @@ place:
               value: added-solar-power
           optional: false 
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: waste-less
       includeOnForm: true
@@ -1132,16 +1133,9 @@ place:
       label: _(Waste Less)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title:)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -1169,11 +1163,17 @@ place:
               value: use-take-it-back-network
           optional: false 
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: commute-low-carbon
       includeOnForm: true
@@ -1184,16 +1184,9 @@ place:
       label: _(Commute Low Carbon)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title:)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -1217,11 +1210,17 @@ place:
               value: fly-rarely
           optional: false 
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: eat-local-organic
       includeOnForm: true
@@ -1232,16 +1231,9 @@ place:
       label: _(Eat Local Organic)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title:)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -1259,11 +1251,17 @@ place:
               value: shop-local-organic
           optional: false 
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: restore-salmon-habitat
       includeOnForm: true
@@ -1274,16 +1272,9 @@ place:
       label: _(Restore Salmon Habitat)
       fields:
         - name: address
-          type: geocoding
-          prompt: _(Your address:)
-          placeholder: _(Address)
-          optional: true
+          type: commonFormElement
         - name: title
-          type: text
-          prompt: _(Post title:)
-          display_prompt: _( )
-          placeholder: _( )
-          optional: false
+          type: commonFormElement
         - name: pledge_type
           type: checkbox_big_buttons
           prompt: _(My actions:)
@@ -1299,15 +1290,40 @@ place:
               value: backyard-wildlife-habitat
           optional: false 
         - name: comments
-          type: textarea
-          prompt: _(Additional comments:)
-          display_prompt: _( )
-          placeholder: _(Enter comments...)
-          optional: false
+          type: commonFormElement
+        - name: school-name
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
-  # define form elements that appear on every form here
+  # Define form elements that appear on every form here.
+  # The key of each common_form_element should match the "name" property
+  # of the referencing element in the form config above.
   common_form_elements:
-    - name: school-name
+    address:
+      type: geocoding
+      prompt: _(Your address:)
+      placeholder: _(Address)
+      optional: true
+    title:
+      type: text
+      prompt: _(Post title:)
+      display_prompt: _( )
+      placeholder: _( )
+      optional: false
+    comments:
+      type: textarea
+      prompt: _(Additional comments:)
+      display_prompt: _( )
+      placeholder: _(Enter comments...)
+      optional: false
+    school-name:
       hideFromDetailView: true
       optional: false
       placeholder: _(Type or select a school name...)
@@ -1652,12 +1668,12 @@ place:
           value: "Chief-Sealth-High-District"
         - label: _(Denny Middle School)
           value: "Denny-Middle-School"
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       optional: true
@@ -1667,7 +1683,7 @@ place:
           value: _(Receive email updates on your report)
         - key: size
           value: 30
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -1675,7 +1691,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -332,6 +332,15 @@ place:
           display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
+
     - category: question
       includeOnForm: true
       name: location_type
@@ -351,6 +360,15 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _( )
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
+
     - category: idea
       includeOnForm: true
       name: location_type
@@ -371,6 +389,15 @@ place:
           display_prompt: "_( )"
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
+
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -391,6 +418,15 @@ place:
           display_prompt: _( )
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
+
     - category: greenwall
       includeOnForm: false
       name: location_type
@@ -401,21 +437,29 @@ place:
       fields:
         - name: name
           type: text
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -423,7 +467,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -1514,6 +1514,9 @@ place:
           prompt: _(Choose a custom URL for this place:)
           placeholder: "my-new-featured-place"
           optional: true
+        - name: submit
+          type: commonFormElement
+
     - category: observation
       includeOnForm: true
       name: location_type
@@ -1587,6 +1590,9 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
+
     - category: question
       includeOnForm: true
       name: location_type
@@ -1629,6 +1635,9 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
+
     - category: idea
       includeOnForm: true
       name: location_type
@@ -1672,6 +1681,9 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
+
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -1715,6 +1727,9 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
+
     - category: air_watch  #defines a top-level form category
       includeOnForm: true
       name: location_type  #needs to be "location_type"
@@ -1880,6 +1895,9 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
+
     - category: tree
       includeOnForm: false
       name: location_type
@@ -1923,10 +1941,13 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/greensboropb/config.yml
+++ b/src/flavors/greensboropb/config.yml
@@ -743,6 +743,28 @@ place:
           display_prompt: _( )
           placeholder: _(...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: parks
       includeOnForm: true
       name: location_type
@@ -775,6 +797,28 @@ place:
           display_prompt: _( )
           placeholder: _(...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: streets
       includeOnForm: true
       name: location_type
@@ -807,6 +851,28 @@ place:
           display_prompt: _( )
           placeholder: _(...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: health
       includeOnForm: true
       name: location_type
@@ -839,6 +905,28 @@ place:
           display_prompt: _( )
           placeholder: _(...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: safety
       includeOnForm: true
       name: location_type
@@ -871,6 +959,28 @@ place:
           display_prompt: _( )
           placeholder: _(...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: other
       includeOnForm: true
       name: location_type
@@ -903,10 +1013,32 @@ place:
           display_prompt: _( )
           placeholder: _(...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -914,21 +1046,21 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - name: demographics-header
+    demographics-header:
       type: section_header
       horizontal_rule: false
       content: _(Demographic information)
-    - name: demographics-description
+    demographics-description:
       type: section_description
       content: _(This info is kept private, and is to ensure we are serving a diversity of people who best represent the needs of the community.)
-    - name: private-age
+    private-age:
       autocomplete: true
       type: text
       prompt: _(Your age:)
       display_prompt: _()
       placeholder: _(Your age will not appear on the map)
       optional: true
-    - name: private-ethnicity
+    private-ethnicity:
       autocomplete: true
       type: checkbox_big_buttons
       annotation: _(Your ethnicity will not appear on the map)
@@ -950,7 +1082,7 @@ place:
         - label: _(Other)
           value: other-ethnicity
       optional: true
-    - name: private-income
+    private-income:
       autocomplete: true
       type: dropdown
       prompt: _(Your income:)
@@ -975,27 +1107,27 @@ place:
         - label: _($150,000 or more)
           value: 150k-or-more
       optional: true
-    - name: submitter_name
+    submitter_name:
       autocomplete: true
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       autocomplete: true
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your idea)
       optional: true
       sticky: true
-    - name: private-phone
+    private-phone:
       autocomplete: true
       type: text
       prompt: _(Your phone number:)
       display_prompt: _()
       placeholder: _(Your phone number will not appear on the map)
       optional: true
-    - name: private-volunteer
+    private-volunteer:
       type: binary_toggle
       prompt: _(I'd like to volunteer as a Budget Delegate)
       content:
@@ -1005,7 +1137,8 @@ place:
           value: "no"
       optional: true
       attribution: _(Budget Delegates will meet 6 - 8 times from December through June​ to evaluate project ideas, work with city staff to research the projects and will receive training and support to develop proposals for the ballot.)
-    - type: submit
+    submit:
+      type: submit
       label: _(Submit!)
 
 survey:

--- a/src/flavors/greenways/config.yml
+++ b/src/flavors/greenways/config.yml
@@ -493,6 +493,14 @@ place:
           display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: signage
       includeOnForm: true
       name: location_type
@@ -512,6 +520,14 @@ place:
           prompt: "_(Description:)"
           display_prompt: _( )
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: pavement
       includeOnForm: true
       name: location_type
@@ -532,6 +548,14 @@ place:
           display_prompt: "_( )"
           placeholder: _(Description...) 
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: walkability
       includeOnForm: true
       name: location_type
@@ -567,6 +591,14 @@ place:
           display_prompt: _( )
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: accessibility
       includeOnForm: true
       name: location_type
@@ -587,6 +619,14 @@ place:
           display_prompt: _( )
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: traffic
       includeOnForm: true
       name: location_type
@@ -607,6 +647,14 @@ place:
           display_prompt: _( )
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: design
       includeOnForm: true
       name: location_type
@@ -627,6 +675,14 @@ place:
           display_prompt: _( )
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     # - category: accessibility  #defines a top-level form category
     #   includeOnForm: true
     #   name: location_type  #needs to be "location_type"
@@ -772,18 +828,18 @@ place:
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -791,7 +847,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/gtopenspace/config.yml
+++ b/src/flavors/gtopenspace/config.yml
@@ -670,6 +670,10 @@ place:
           display_prompt:
           placeholder: _(Enter comment...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: medium
       includeOnForm: true
       name: location_type
@@ -690,6 +694,10 @@ place:
           display_prompt:
           placeholder: _(Enter comment...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: low
       includeOnForm: true
       name: location_type
@@ -710,6 +718,10 @@ place:
           display_prompt:
           placeholder: _(Enter comment...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: streetscape
       includeOnForm: false
       name: location_type
@@ -730,6 +742,10 @@ place:
           display_prompt:
           placeholder: _(Enter comment...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: park-improvement
       includeOnForm: false
       name: location_type
@@ -750,6 +766,10 @@ place:
           display_prompt:
           placeholder: _(Enter comment...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: streetscape
       includeOnForm: false     
@@ -771,6 +791,10 @@ place:
           display_prompt:
           placeholder: _(Enter comment...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
     - category: park-improvement
       includeOnForm: false     
@@ -792,26 +816,14 @@ place:
           display_prompt:
           placeholder: _(Enter comment...)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    # - name: submitter_name
-    #   type: text
-    #   prompt: _(Your name)
-    #   placeholder: _(Name)
-    #   optional: true
-    # - name: private-submitter_email
-    #   type: text
-    #   prompt: _(Your Email)
-    #   placeholder: _(Receive email updates on your report)
-    #   optional: true
-    #   sticky: true
-    #   attrs:
-    #     - key: placeholder
-    #       value: _(Receive email updates on your report)
-    #     - key: size
-    #       value: 30
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -819,7 +831,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/lakewashington/config.yml
+++ b/src/flavors/lakewashington/config.yml
@@ -449,6 +449,8 @@ place:
           prompt: _(Choose a custom URL for this place:)
           placeholder: "my-new-featured-place"
           optional: true
+        - name: submit
+          type: commonFormElement
     - category: observation
       includeOnForm: true
       name: location_type
@@ -488,6 +490,8 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
     - category: question
       includeOnForm: true
       name: location_type
@@ -526,6 +530,8 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
     - category: idea
       includeOnForm: true
       name: location_type
@@ -565,6 +571,8 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -604,10 +612,13 @@ place:
           attrs:
             - key: accept
               value: image/*
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - type: submit
+    submit:
+      type: submit
       label: _(Submit)
 
   #### end dynamic form config ####

--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -253,6 +253,30 @@ place:
           display_prompt: _( )
           placeholder: _( )
           optional: true
+        - name: venue
+          type: commmonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: parks
       includeOnForm: true
       name: location_type
@@ -279,6 +303,30 @@ place:
           display_prompt: _( )
           placeholder: _( )
           optional: true
+        - name: venue
+          type: commmonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: streets
       includeOnForm: true
       name: location_type
@@ -304,7 +352,31 @@ place:
           prompt: _(Why is this important? What need in the community does this serve?:)
           display_prompt: _( )
           placeholder: _( )
-          optional: true    
+          optional: true
+        - name: venue
+          type: commmonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: housing
       includeOnForm: true
       name: location_type
@@ -331,10 +403,34 @@ place:
           display_prompt: _( )
           placeholder: _( )
           optional: true
+        - name: venue
+          type: commmonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: demographics-header
+          type: commonFormElement
+        - name: demographics-description
+          type: commonFormElement
+        - name: private-age
+          type: commonFormElement
+        - name: private-ethnicity
+          type: commonFormElement
+        - name: private-income
+          type: commonFormElement
+        - name: private-volunteer
+          type: commonFormElement
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: private-phone
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: venue
+    venue:
       type: dropdown
       optional: true
       admin_only: true
@@ -352,7 +448,7 @@ place:
           value: bella_vista
         - label: _(Other)
           value: other
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -360,21 +456,21 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - name: demographics-header
+    demographics-header:
       type: section_header
       horizontal_rule: false
       content: _(Demographic information)
-    - name: demographics-description
+    demographics-description:
       type: section_description
       content: _(This info is kept private, and is to ensure we are serving a diversity of people who best represent the needs of the community.)
-    - name: private-age
+    private-age:
       autocomplete: true
       type: text
       prompt: _(Your age:)
       display_prompt: _()
       placeholder: _(Your age will not appear on the map)
       optional: true
-    - name: private-ethnicity
+    private-ethnicity:
       autocomplete: true
       type: radio_big_buttons
       annotation: _(Your ethnicity will not appear on the map)
@@ -396,7 +492,7 @@ place:
         - label: _(Other)
           value: other
       optional: true
-    - name: private-income
+    private-income:
       autocomplete: true
       type: dropdown
       prompt: _(Your income:)
@@ -421,7 +517,7 @@ place:
         - label: _($150,000 or more)
           value: 150k-or-more
       optional: true
-    - name: private-volunteer
+    private-volunteer:
       autocomplete: true
       type: binary_toggle
       prompt: _(I want to volunteer:)
@@ -432,27 +528,28 @@ place:
         - label: _(No)
           value: "no"
       optional: true
-    - name: submitter_name
+    submitter_name:
       autocomplete: true
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       autocomplete: true
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your idea)
       optional: true
       sticky: true
-    - name: private-phone
+    private-phone:
       autocomplete: true
       type: text
       prompt: _(Your phone number:)
       display_prompt: _()
       placeholder: _(Your phone number will not appear on the map)
       optional: true
-    - type: submit
+    submit:
+      type: submit
       label: _(Submit!)
 
   #### end dynamic form config ####

--- a/src/flavors/pugetsound/config.yml
+++ b/src/flavors/pugetsound/config.yml
@@ -412,6 +412,14 @@ place:
           prompt: _(Choose a custom URL for this place:)
           placeholder: "my-new-featured-place"
           optional: true
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: observation
       includeOnForm: true
       name: location_type
@@ -448,6 +456,14 @@ place:
           display_prompt: _( )
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: question
       includeOnForm: true
       name: location_type
@@ -467,6 +483,14 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _( )
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: idea
       includeOnForm: true
       name: location_type
@@ -487,6 +511,14 @@ place:
           display_prompt: "_( )"
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -507,6 +539,14 @@ place:
           display_prompt: _( )
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: greenwall
       includeOnForm: false
       name: location_type
@@ -517,21 +557,29 @@ place:
       fields:
         - name: name
           type: text
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -539,7 +587,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/rail/config.yml
+++ b/src/flavors/rail/config.yml
@@ -290,6 +290,14 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: question
       includeOnForm: true
       name: location_type
@@ -309,6 +317,14 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: idea
       includeOnForm: true
       name: location_type
@@ -329,6 +345,14 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -349,21 +373,29 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -371,7 +403,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/raingardens/config.yml
+++ b/src/flavors/raingardens/config.yml
@@ -284,10 +284,14 @@ place:
           size: 30
           optional: false
           sticky: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -295,7 +299,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/snoqualmie/config.yml
+++ b/src/flavors/snoqualmie/config.yml
@@ -365,6 +365,14 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: question
       includeOnForm: true
       name: location_type
@@ -384,6 +392,14 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: idea
       includeOnForm: true
       name: location_type
@@ -404,6 +420,14 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -424,21 +448,29 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -446,7 +478,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/trees/config.yml
+++ b/src/flavors/trees/config.yml
@@ -487,10 +487,14 @@ place:
           prompt: _(ID Tag)
           placeholder: _(Leave blank if unknown)
           optional: true
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -498,7 +502,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/waterfront/config.yml
+++ b/src/flavors/waterfront/config.yml
@@ -351,6 +351,14 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: question
       includeOnForm: true
       name: location_type
@@ -370,6 +378,14 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: idea
       includeOnForm: true
       name: location_type
@@ -390,6 +406,14 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -410,21 +434,29 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -432,7 +464,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####

--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -318,6 +318,14 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: question
       includeOnForm: true
       name: location_type
@@ -337,6 +345,14 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: idea
       includeOnForm: true
       name: location_type
@@ -357,6 +373,14 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
     - category: complaint
       includeOnForm: true
       name: location_type
@@ -377,21 +401,29 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
+        - name: submitter_name
+          type: commonFormElement
+        - name: private-submitter_email
+          type: commonFormElement
+        - name: my_image
+          type: commonFormElement
+        - name: submit
+          type: commonFormElement
 
   # define form elements that appear on every form here
   common_form_elements:
-    - name: submitter_name
+    submitter_name:
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
-    - name: private-submitter_email
+    private-submitter_email:
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your report)
       optional: true
       sticky: true
-    - name: my_image
+    my_image:
       type: file
       prompt: _(Image)
       inputfile_label: _(Add an Image)
@@ -399,7 +431,8 @@ place:
       attrs:
         - key: accept
           value: image/*
-    - type: submit
+    submit:
+      type: submit
       label: _(Put it on the map!)
 
   #### end dynamic form config ####


### PR DESCRIPTION
Addresses: #784

Previously all form fields listed under the `common_form_elements` section of the config were automatically placed at the end of every form type. This commit allows arbitrary placement of common_form_elements within a given form config.

Note that this PR changes the way the `common_form_elements` section of the config works. Fields are now listed by key, e.g.:

```
common_form_elements:
  address:
    type: geocoding
    prompt: _(Your address:)
    placeholder: _(Address)
    optional: true
  title:
    ...
```

To incorporate a common form element, use the `commonFormElement` type in a form config:
```
- name: address
  type: commonFormElement
```

The `name` field must match the key used in the `common_form_elements` section of the config.

Also note that common form elements are **no longer appended automatically**. Each form config will need to include an explicit reference to each common form element it uses. This adds some additional configuration bulk, but it buys us the ability to freely mix common form elements in with different forms.

This PR also refactors all flavor configs to support the new `common_form_elements` handling.