### PR TITLE
Support CORS ajax requests with credentials

### DIFF
--- a/src/base/static/js/models/place-model.js
+++ b/src/base/static/js/models/place-model.js
@@ -91,6 +91,11 @@ module.exports = Backbone.Model.extend({
     }
 
     options.ignoreAttachments = true;
+    options.beforeSend = function(xhr, options) {
+      options.xhrFields = {
+        withCredentials: true
+      };
+    };
     module.exports.__super__.save.call(this, attrs, options);
   },
 


### PR DESCRIPTION
**WAIT TO MERGE**

NOTE: This should be merged once https://github.com/mapseed/api/pull/91 is merged on the api. That PR enables pre-flight OPTIONS requests to return an appropriately scoped `Access-Control-Allow-Origin` header, enabling cross-origin ajax with credentials.

Now that we don't have a proxy server to attach cookies and forward them to the api, we need to allow the browser to send  cross-origin credentials (which includes cookies) to support session-based authentication. The proxy previously attached the `sessionid` cookie [here](https://github.com/mapseed/platform/blob/master/src/base/views.py#L397-L407).

See: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials

Note that until this PR is merged, all post submission and editor functionality is broken, as we previously used dataset keys (which have been stripped from the static site refactor) and session cookies (which won't work without this PR) to perform authentication. 

When we finally launch the static site, we'll need to remember to move POST permissions from the api key permissions section of the admin panel to the dataset permissions section for every dataset, otherwise POSTing will be broken.