### PR TITLE
Add option to configure basemap used during reporting

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -714,6 +714,10 @@ module.exports = Backbone.View.extend({
     this.placeFormView.delegateEvents();
     this.showNewPin();
     this.setBodyClass("content-visible", "place-form-visible");
+
+    if (this.options.placeConfig.default_basemap) {
+      this.setLayerVisibility(this.options.placeConfig.default_basemap, true, true);
+    }
   },
 
   // If a model has a story object, set the appropriate layer

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -845,6 +845,7 @@ place:
   submit_button_label: _(Put it on the map!)
 
   location_item_name: location
+  default_basemap: satellite
 
 
   #### begin dynamic form config ####


### PR DESCRIPTION
Addresses #812 

Add the ability to configure the basemap when the "Add A Report" button is clicked.

Usage:
In the `place` section of the config add a `default_basemap` flag that references the id of the desired basemap layer. For example:
```
default_basemap: satellite
```