### PR TITLE
Static site: watch and rebuild config automatically during development

### DIFF
--- a/build-utils/config-loader.js
+++ b/build-utils/config-loader.js
@@ -21,28 +21,28 @@ Handlebars.registerHelper("serialize", function(json) {
 
 module.exports = function(source) {
 
-	source = source.substring(17);
+  source = source.substring(17);
 
   let datasetSiteUrls = {}
-      config = JSON.parse(source);
+    config = JSON.parse(source);
 
-	Object.keys(process.env).forEach(function(key) {
-	  if (key.endsWith("SITE_URL")) {
-	    datasetSiteUrls[key] = process.env[key];
-	  }
-	});
+  Object.keys(process.env).forEach(function(key) {
+    if (key.endsWith("SITE_URL")) {
+      datasetSiteUrls[key] = process.env[key];
+    }
+  });
 
-	// If we have dataset urls defined in the .env file, overwrite the default
-	// urls found in the config here.
-	config.map.layers.forEach((layer, i) => {
+  // If we have dataset urls defined in the .env file, overwrite the default
+  // urls found in the config here.
+  config.map.layers.forEach((layer, i) => {
     if (datasetSiteUrls[layer.id.toUpperCase() + "_SITE_URL"]) {
       config.map.layers[i].url =
         datasetSiteUrls[layer.id.toUpperCase() + "_SITE_URL"];
     }
   });
 
-	// Strip out gettext syntax; we don't perform any localization of the config
-	// in this loader. Full localization is performed by the production build.
+  // Strip out gettext syntax; we don't perform any localization of the config
+  // in this loader. Full localization is performed by the production build.
   walk(config, (val, prop, obj) => {
     if (typeof val === "string") {
       if (configGettextRegex.test(val)) {
@@ -55,15 +55,15 @@ module.exports = function(source) {
     obj[prop] = val;
   });
 
-	const templateSource = fs.readFileSync(
-	  path.resolve(
-	  	__dirname,
-	    "config-template.hbs"
-	  ),
-	  "utf8"
-	);
-	const template = Handlebars.compile(templateSource);
-	outputFile = template({
+  const templateSource = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "config-template.hbs"
+    ),
+    "utf8"
+  );
+  const template = Handlebars.compile(templateSource);
+  outputFile = template({
     config: config,
   });
 
@@ -73,5 +73,5 @@ module.exports = function(source) {
   );
   fs.writeFileSync(outputPath, outputFile);
 
-	return source;
+  return source;
 }

--- a/build-utils/config-loader.js
+++ b/build-utils/config-loader.js
@@ -1,10 +1,18 @@
-const Gettext = require("node-gettext");
-const gettextParser = require("gettext-parser");
-//const walk = require("object-walk");
+const walk = require("object-walk");
 const Handlebars = require("handlebars");
 const fs = require('fs-extra');
 const path = require('path');
 
+// This loader is used to listen to changes in the config file during development.
+// Any config changes will be detected and the config (but not the rest of the
+// static site) will be rebuilt. This loader only rebuilds the English version
+// of the config; to test other languages in development it will be necessary
+// to produce a full production build:
+//   npm run build
+// Or, to build in production mode and also start the dev server:
+//   NODE_ENV=production npm start
+
+const configGettextRegex = /^_\(/;
 
 Handlebars.registerHelper("serialize", function(json) {
   if (!json) return false;
@@ -13,9 +21,39 @@ Handlebars.registerHelper("serialize", function(json) {
 
 module.exports = function(source) {
 
-	// TODO: attach datasets object
-
 	source = source.substring(17);
+
+  let datasetSiteUrls = {}
+      config = JSON.parse(source);
+
+	Object.keys(process.env).forEach(function(key) {
+	  if (key.endsWith("SITE_URL")) {
+	    datasetSiteUrls[key] = process.env[key];
+	  }
+	});
+
+	// If we have dataset urls defined in the .env file, overwrite the default
+	// urls found in the config here.
+	config.map.layers.forEach((layer, i) => {
+    if (datasetSiteUrls[layer.id.toUpperCase() + "_SITE_URL"]) {
+      config.map.layers[i].url =
+        datasetSiteUrls[layer.id.toUpperCase() + "_SITE_URL"];
+    }
+  });
+
+	// Strip out gettext syntax; we don't perform any localization of the config
+	// in this loader. Full localization is performed by the production build.
+  walk(config, (val, prop, obj) => {
+    if (typeof val === "string") {
+      if (configGettextRegex.test(val)) {
+        val = val
+          .replace(configGettextRegex, "")
+          .replace(/\)$/, "");
+      }
+    }
+
+    obj[prop] = val;
+  });
 
 	const templateSource = fs.readFileSync(
 	  path.resolve(
@@ -26,7 +64,7 @@ module.exports = function(source) {
 	);
 	const template = Handlebars.compile(templateSource);
 	outputFile = template({
-    config: JSON.parse(source),
+    config: config,
   });
 
   outputPath = path.resolve(

--- a/build-utils/config-loader.js
+++ b/build-utils/config-loader.js
@@ -1,0 +1,39 @@
+const Gettext = require("node-gettext");
+const gettextParser = require("gettext-parser");
+//const walk = require("object-walk");
+const Handlebars = require("handlebars");
+const fs = require('fs-extra');
+const path = require('path');
+
+
+Handlebars.registerHelper("serialize", function(json) {
+  if (!json) return false;
+  return JSON.stringify(json);
+});
+
+module.exports = function(source) {
+
+	// TODO: attach datasets object
+
+	source = source.substring(17);
+
+	const templateSource = fs.readFileSync(
+	  path.resolve(
+	  	__dirname,
+	    "config-template.hbs"
+	  ),
+	  "utf8"
+	);
+	const template = Handlebars.compile(templateSource);
+	outputFile = template({
+    config: JSON.parse(source),
+  });
+
+  outputPath = path.resolve(
+    __dirname,
+    "../www/dist/config-en_US.js"
+  );
+  fs.writeFileSync(outputPath, outputFile);
+
+	return source;
+}

--- a/build-utils/config-template.hbs
+++ b/build-utils/config-template.hbs
@@ -1,0 +1,46 @@
+(function(S, $){
+  S.Config = {
+    defaultPlaceTypeName: '{{ default_place_type }}',
+    userToken: (
+      S.bootstrapped.currentUser ?
+      'user:' + S.bootstrapped.currentUser.id :
+      "{{ user_token_json }}"),
+    app:        {{#serialize config.app}}{{/serialize}},
+    place:      {{#serialize config.place}}{{/serialize}},
+    placeTypes: {{#serialize config.place_types}}{{/serialize}},
+    cluster:    {{#serialize config.cluster}}{{/serialize}},
+    survey:     {{#serialize config.survey}}{{/serialize}},
+    support:    {{#serialize config.support}}{{/serialize}},
+    map:        {{#serialize config.map}}{{/serialize}},
+    activity:   {{#serialize config.activity}}{{/serialize}},
+    sidebar:    {{#serialize config.sidebar}}{{/serialize}},
+    leaflet_sidebar: {{#serialize config.leaflet_sidebar}}{{/serialize}},
+    pages:           {{#serialize config.pages}}{{/serialize}},
+    story:           {{#serialize config.story}}{{/serialize}},
+    rightSidebar:    {{#serialize config.right_sidebar}}{{/serialize}},
+    filters:         {{#serialize config.filters}}{{/serialize}},
+    datasets:        {{#serialize config.datasets}}{{/serialize}}
+  };
+  $(function() {
+    // Ready set go!
+    window.app = new Shareabouts.App({
+      activity: [],
+      defaultPlaceTypeName: S.Config.defaultPlaceTypeName,
+      userToken: S.Config.userToken,
+      appConfig: S.Config.app,
+      placeConfig: S.Config.place,
+      placeTypes: S.Config.placeTypes,
+      cluster: S.Config.cluster,
+      sidebarConfig: S.Config.sidebar,
+      rightSidebarConfig: S.Config.rightSidebar,
+      surveyConfig: S.Config.survey,
+      supportConfig: S.Config.support,
+      mapConfig: S.Config.map,
+      storyConfig: S.Config.story,
+      activityConfig: S.Config.activity,
+      pagesConfig: S.Config.pages,
+      filters: S.Config.filters,
+      datasetsConfig: S.Config.datasets
+    });
+  });
+}(Shareabouts, jQuery));

--- a/package-lock.json
+++ b/package-lock.json
@@ -456,12 +456,914 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
+            "fsevents": "1.1.2",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
             "is-glob": "2.0.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+              "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "nan": "2.6.2",
+                "node-pre-gyp": "0.6.36"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ajv": {
+                  "version": "4.11.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  }
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "aproba": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.2.9"
+                  }
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "tweetnacl": "0.14.5"
+                  }
+                },
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "co": {
+                  "version": "4.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  }
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "deep-extend": {
+                  "version": "0.4.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
+                  }
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "1.1.1",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
+                  }
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "bundled": true,
+                  "dev": true
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
+                  }
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.0"
+                  }
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "once": "1.4.0",
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsonify": "0.0.0"
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "mime-db": {
+                  "version": "1.27.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true,
+                  "dev": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.36",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "mkdirp": "0.5.1",
+                    "nopt": "4.0.1",
+                    "npmlog": "4.1.0",
+                    "rc": "1.2.1",
+                    "request": "2.81.0",
+                    "rimraf": "2.6.1",
+                    "semver": "5.3.0",
+                    "tar": "2.2.1",
+                    "tar-pack": "3.4.0"
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "abbrev": "1.1.0",
+                    "osenv": "0.1.4"
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "osenv": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "bundled": true,
+                  "dev": true
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "rc": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "0.4.2",
+                    "ini": "1.3.4",
+                    "minimist": "1.2.0",
+                    "strip-json-comments": "2.0.1"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "1.0.1",
+                    "util-deprecate": "1.0.2"
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.6.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.5",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.15",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.0.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.2",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.0.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "2.6.8",
+                    "fstream": "1.0.11",
+                    "fstream-ignore": "1.0.5",
+                    "once": "1.4.0",
+                    "readable-stream": "2.2.9",
+                    "rimraf": "2.6.1",
+                    "tar": "2.2.1",
+                    "uid-number": "0.0.6"
+                  }
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "extsprintf": "1.0.2"
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "concat-map": {
@@ -14936,6 +15838,7 @@
           "requires": {
             "anymatch": "1.3.0",
             "async-each": "1.0.0",
+            "fsevents": "1.1.2",
             "glob-parent": "2.0.0",
             "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "is-binary-path": "1.0.1",
@@ -14949,6 +15852,905 @@
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
               "integrity": "sha1-tTGSJsKdmSd99jyK7gQJOqXx058=",
               "dev": true
+            },
+            "fsevents": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+              "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "nan": "2.6.2",
+                "node-pre-gyp": "0.6.36"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ajv": {
+                  "version": "4.11.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  }
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "aproba": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.2.9"
+                  }
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "tweetnacl": "0.14.5"
+                  }
+                },
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "co": {
+                  "version": "4.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  }
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "deep-extend": {
+                  "version": "0.4.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
+                  }
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "1.1.1",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
+                  }
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "bundled": true,
+                  "dev": true
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
+                  }
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.0"
+                  }
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "once": "1.4.0",
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsonify": "0.0.0"
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "mime-db": {
+                  "version": "1.27.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true,
+                  "dev": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.36",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "mkdirp": "0.5.1",
+                    "nopt": "4.0.1",
+                    "npmlog": "4.1.0",
+                    "rc": "1.2.1",
+                    "request": "2.81.0",
+                    "rimraf": "2.6.1",
+                    "semver": "5.3.0",
+                    "tar": "2.2.1",
+                    "tar-pack": "3.4.0"
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "abbrev": "1.1.0",
+                    "osenv": "0.1.4"
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "osenv": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "bundled": true,
+                  "dev": true
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "rc": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "0.4.2",
+                    "ini": "1.3.4",
+                    "minimist": "1.2.0",
+                    "strip-json-comments": "2.0.1"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "1.0.1",
+                    "util-deprecate": "1.0.2"
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.6.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.5",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.15",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.0.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.2",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.0.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "2.6.8",
+                    "fstream": "1.0.11",
+                    "fstream-ignore": "1.0.5",
+                    "once": "1.4.0",
+                    "readable-stream": "2.2.9",
+                    "rimraf": "2.6.1",
+                    "tar": "2.2.1",
+                    "uid-number": "0.0.6"
+                  }
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "extsprintf": "1.0.2"
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
             },
             "glob-parent": {
               "version": "2.0.0",
@@ -15300,12 +17102,800 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
+            "fsevents": "1.1.2",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
             "is-glob": "2.0.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+              "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+              "optional": true,
+              "requires": {
+                "nan": "2.6.2",
+                "node-pre-gyp": "0.6.36"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "ajv": {
+                  "version": "4.11.8",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  }
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "aproba": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.2.9"
+                  }
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "optional": true
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "bundled": true
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "tweetnacl": "0.14.5"
+                  }
+                },
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "co": {
+                  "version": "4.6.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  }
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "deep-extend": {
+                  "version": "0.4.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
+                  }
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "1.1.1",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
+                  }
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "bundled": true
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "optional": true
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
+                  }
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "bundled": true
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.0"
+                  }
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0",
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "bundled": true,
+                  "optional": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "optional": true
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "jsonify": "0.0.0"
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "mime-db": {
+                  "version": "1.27.0",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.36",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "mkdirp": "0.5.1",
+                    "nopt": "4.0.1",
+                    "npmlog": "4.1.0",
+                    "rc": "1.2.1",
+                    "request": "2.81.0",
+                    "rimraf": "2.6.1",
+                    "semver": "5.3.0",
+                    "tar": "2.2.1",
+                    "tar-pack": "3.4.0"
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "abbrev": "1.1.0",
+                    "osenv": "0.1.4"
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "osenv": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "bundled": true
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "rc": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "0.4.2",
+                    "ini": "1.3.4",
+                    "minimist": "1.2.0",
+                    "strip-json-comments": "2.0.1"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.9",
+                  "bundled": true,
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "1.0.1",
+                    "util-deprecate": "1.0.2"
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.6.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.5",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.15",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.0.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.2",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.0.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true,
+                  "optional": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.4.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "2.6.8",
+                    "fstream": "1.0.11",
+                    "fstream-ignore": "1.0.5",
+                    "once": "1.4.0",
+                    "readable-stream": "2.2.9",
+                    "rimraf": "2.6.1",
+                    "tar": "2.2.1",
+                    "uid-number": "0.0.6"
+                  }
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "bundled": true,
+                  "optional": true
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "bundled": true,
+                  "optional": true
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "extsprintf": "1.0.2"
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true
+                }
+              }
+            }
           }
         },
         "concat-map": {
@@ -16367,6 +18957,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yaml-loader": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.5.0.tgz",
+      "integrity": "sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.9.1"
+      }
     },
     "yargs": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "gettext-parser": "^1.2.2",
     "handlebars": "^4.0.10",
     "js-yaml": "^3.9.0",
+    "json-loader": "^0.5.7",
     "mv": "^2.1.1",
     "node-gettext": "^2.0.0",
     "object-walk": "^0.1.1",
@@ -75,6 +76,7 @@
     "style-loader": "^0.18.2",
     "watchify": "^3.4.0",
     "wax-on": "^1.2.0",
-    "webpack-dev-server": "^2.6.1"
+    "webpack-dev-server": "^2.6.1",
+    "yaml-loader": "^0.5.0"
   }
 }

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -279,54 +279,7 @@
   </script>
   <![endif]-->
 
-  <script type="text/javascript">
-  (function(S, $){
-    S.Config = {
-      defaultPlaceTypeName: '{{ default_place_type }}',
-      userToken: (
-        S.bootstrapped.currentUser ?
-        'user:' + S.bootstrapped.currentUser.id :
-        "{{ user_token_json }}"),
-      app:        {{#serialize config.app}}{{/serialize}},
-      place:      {{#serialize config.place}}{{/serialize}},
-      placeTypes: {{#serialize config.place_types}}{{/serialize}},
-      cluster:    {{#serialize config.cluster}}{{/serialize}},
-      survey:     {{#serialize config.survey}}{{/serialize}},
-      support:    {{#serialize config.support}}{{/serialize}},
-      map:        {{#serialize config.map}}{{/serialize}},
-      activity:   {{#serialize config.activity}}{{/serialize}},
-      sidebar:    {{#serialize config.sidebar}}{{/serialize}},
-      leaflet_sidebar: {{#serialize config.leaflet_sidebar}}{{/serialize}},
-      pages:           {{#serialize config.pages}}{{/serialize}},
-      story:           {{#serialize config.story}}{{/serialize}},
-      rightSidebar:    {{#serialize config.right_sidebar}}{{/serialize}},
-      filters:         {{#serialize config.filters}}{{/serialize}},
-      datasets:        {{#serialize config.datasets}}{{/serialize}}
-    };
-    $(function() {
-      // Ready set go!
-      window.app = new Shareabouts.App({
-        activity: [],
-        defaultPlaceTypeName: S.Config.defaultPlaceTypeName,
-        userToken: S.Config.userToken,
-        appConfig: S.Config.app,
-        placeConfig: S.Config.place,
-        placeTypes: S.Config.placeTypes,
-        cluster: S.Config.cluster,
-        sidebarConfig: S.Config.sidebar,
-        rightSidebarConfig: S.Config.rightSidebar,
-        surveyConfig: S.Config.survey,
-        supportConfig: S.Config.support,
-        mapConfig: S.Config.map,
-        storyConfig: S.Config.story,
-        activityConfig: S.Config.activity,
-        pagesConfig: S.Config.pages,
-        filters: S.Config.filters,
-        datasetsConfig: S.Config.datasets
-      });
-    });
-  }(Shareabouts, jQuery));
-  </script>
+  <script src="/dist/config-en_US.js" type="text/javascript"></script>
 
   {{#if settings.googleAnalyticsId}}
   <script>

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -279,7 +279,58 @@
   </script>
   <![endif]-->
 
-  <script src="/dist/config-en_US.js" type="text/javascript"></script>
+  {{#if production}}
+    <script>
+      (function(S, $){
+        S.Config = {
+          defaultPlaceTypeName: '{{ default_place_type }}',
+          userToken: (
+            S.bootstrapped.currentUser ?
+            'user:' + S.bootstrapped.currentUser.id :
+            "{{ user_token_json }}"),
+          app:        {{#serialize config.app}}{{/serialize}},
+          place:      {{#serialize config.place}}{{/serialize}},
+          placeTypes: {{#serialize config.place_types}}{{/serialize}},
+          cluster:    {{#serialize config.cluster}}{{/serialize}},
+          survey:     {{#serialize config.survey}}{{/serialize}},
+          support:    {{#serialize config.support}}{{/serialize}},
+          map:        {{#serialize config.map}}{{/serialize}},
+          activity:   {{#serialize config.activity}}{{/serialize}},
+          sidebar:    {{#serialize config.sidebar}}{{/serialize}},
+          leaflet_sidebar: {{#serialize config.leaflet_sidebar}}{{/serialize}},
+          pages:           {{#serialize config.pages}}{{/serialize}},
+          story:           {{#serialize config.story}}{{/serialize}},
+          rightSidebar:    {{#serialize config.right_sidebar}}{{/serialize}},
+          filters:         {{#serialize config.filters}}{{/serialize}},
+          datasets:        {{#serialize config.datasets}}{{/serialize}}
+        };
+        $(function() {
+          // Ready set go!
+          window.app = new Shareabouts.App({
+            activity: [],
+            defaultPlaceTypeName: S.Config.defaultPlaceTypeName,
+            userToken: S.Config.userToken,
+            appConfig: S.Config.app,
+            placeConfig: S.Config.place,
+            placeTypes: S.Config.placeTypes,
+            cluster: S.Config.cluster,
+            sidebarConfig: S.Config.sidebar,
+            rightSidebarConfig: S.Config.rightSidebar,
+            surveyConfig: S.Config.survey,
+            supportConfig: S.Config.support,
+            mapConfig: S.Config.map,
+            storyConfig: S.Config.story,
+            activityConfig: S.Config.activity,
+            pagesConfig: S.Config.pages,
+            filters: S.Config.filters,
+            datasetsConfig: S.Config.datasets
+          });
+        });
+      }(Shareabouts, jQuery));
+    </script>
+  {{else}}
+    <script src="/dist/config-en_US.js" type="text/javascript"></script>
+  {{/if}}
 
   {{#if settings.googleAnalyticsId}}
   <script>

--- a/static-build.js
+++ b/static-build.js
@@ -383,14 +383,7 @@ activeLanguages.forEach((language) => {
     languageCode: language.code,
 
     // TODO: fix this...
-    userTokenJson: "",
-
-    // TODO: user agent identification needs to be moved client-side
-    userAgentJson: {
-      browser: {
-        name: "some browser name"
-      }
-    }
+    userTokenJson: ""
   });
 
   // Write out final index-xx.html file


### PR DESCRIPTION
Addresses: #802 

This PR adds a custom webpack loader which will watch and rebuild changes made to the config during development. The loader will only rebuild the config in English; localization is not supported. To test localization for a given language, it will be necessary to run a production build:
```
npm run build
```
Alternatively, to run a production build and also start the dev server (which is probably more useful):
```
NODE_ENV=production npm start
```