### PR TITLE
Add option to limit max zoom by basemap layer

### DIFF
--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -110,6 +110,11 @@ module.exports = Backbone.View.extend({
       }
 
       if (isBasemap) {
+        self.checkLayerZoom(config.maxZoom);
+        self.map.options.maxZoom = (config.maxZoom)
+          ? config.maxZoom
+          : self.options.mapConfig.options.maxZoom;
+
         _.each(self.options.basemapConfigs, function(basemap) {
           if (basemap.id === id) {
             self.map.addLayer(layer);
@@ -129,6 +134,14 @@ module.exports = Backbone.View.extend({
       }
     });
   }, // end initialize
+
+  checkLayerZoom(maxZoom) {
+    if (maxZoom && this.map.getZoom() > maxZoom) {
+      _.defer(() => {
+        this.map.setZoom(parseInt(maxZoom, 10));
+      });
+    }
+  },
 
   onUserHideModel: function(collectionId) {
     return function(model) {

--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -87,6 +87,7 @@ map:
     - id: topo
       type: basemap
       url: //{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png
+      maxZoom: 13
 
     - id: landcover
       type: basemap


### PR DESCRIPTION
Addresses: #804 

Add per-basemap max zoom settings. If a basemap defines a max zoom that is less than the universal max zoom (set in `config.map.options.maxZoom`), the map will use this custom max zoom setting while the given basemap is active.

Upon basemap change, if the user was zoomed in farther than the zoom extent allowed by a basemap's custom zoom settings, the map will zoom out to the max zoom allowed by the basemap.

To set a basemap custom max zoom level, add a `maxZoom` flag to the `layer` config, e.g.:
```
- id: topo
  type: basemap
  url: //{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png
  maxZoom: 13
```