### PR TITLE
add cover image attachment button to mywater flavor

### DIFF
--- a/src/flavors/central-puget-sound/config.yml
+++ b/src/flavors/central-puget-sound/config.yml
@@ -870,6 +870,14 @@ place:
       value: featured_place
       label: _(Featured Site)
       fields:
+        - name: cover-image
+          type: file
+          prompt: _(Cover Image)
+          inputfile_label: _(Add a cover image)
+          optional: true
+          attrs:
+            - key: accept
+              value: image/*
         - name: published
           type: publishControl
         - name: geometry

--- a/src/flavors/central-puget-sound/jstemplates/place-detail.html
+++ b/src/flavors/central-puget-sound/jstemplates/place-detail.html
@@ -1,0 +1,120 @@
+<!-- Template for managing the place detail view, which might be rendered in
+  regular mode or in editor mode. -->
+
+{{> place-detail-edit-bar }}
+
+<div class="place-detail-spacer{{#if isEditable}} editing-toggled{{/if}}"></div>
+
+{{> place-detail-story-bar }}
+
+{{> place-detail-promotion-bar }}
+
+<header class="place-header clearfix">
+  {{>location-string location }}
+  <form id="update-place-model-title-form">
+    {{#if isEditingToggled}}
+      <input type="text" 
+             class="place-value place-value-title" 
+             name="title" 
+             value="{{#if fullTitle}}{{fullTitle}}{{else}}{{#if title}}{{title}}{{else}}{{name}}{{/if}}{{/if}}" />
+    {{else}}
+      <h1 class="place-header-title {{#if story}}is-visuallyhidden{{/if}}">
+        {{#if fullTitle}}
+          {{fullTitle}}
+        {{else}}
+          {{#if title}}
+            {{title}}
+          {{else}}
+            {{name}}
+          {{/if}}
+        {{/if}}
+      </h1>
+    {{/if}}
+  </form>
+  <span class="place-submission-details">
+    {{#is_not showMetadata false}}
+      {{#_}}<strong class="point-submitter">
+        {{#if submitter.avatar_url }}
+          <img src="{{ submitter.avatar_url }}" 
+               class="avatar" />
+        {{^}}
+          <img src="/static/css/images/user-50.png" 
+               class="avatar" />
+        {{/if}}
+        {{#if submitter.name }}
+          {{ submitter.name }}
+        {{^}}
+          {{#if submitter_name }}
+            {{ submitter_name }}
+          {{^}}
+            {{ anonymous_name }}
+          {{/if}}
+        {{/if}}
+      </strong> {{ action_text }} this {{ place_type_label location_type}}
+
+      {{#if region}}
+        in {{ region }}
+      {{/if}}{{/_}}
+
+      <time datetime="{{ created_datetime }}" 
+            class="response-date">
+        <a class="response-date-link" href="/{{ datasetSlug }}/{{ id }}">{{ fromnow created_datetime }}</a>
+      </time>
+
+      <span class="survey-count">{{ survey_count }} {{ survey_label_by_count }}</span>
+    {{/is_not}}
+
+  {{^if survey_config}}
+    <a rel="internal" 
+       href="/{{#if url-title}}{{url-title}}{{else}}{{ datasetSlug }}/{{ id }}{{/if}}" 
+       class="view-on-map-btn btn btn-small">{{#_}}View On Map{{/_}}</a>
+  {{/if}}
+
+  </span>
+</header>
+
+<section class="place-items">
+  <form id="update-place-model-form">
+    <!-- BEGIN FLAVOR-SPECIFIC CODE -->
+    {{#if suppressAttachments}}
+      {{#each attachments}}
+        {{#is name "cover-image"}}
+          <div class="place-item place-item-attachment place-attachment-{{ name }}">
+          <img src="{{ file }}" 
+               class="place-value place-value-{{ name }}" 
+               alt="{{ name }}" />
+        </div>   
+        {{/is}}
+      {{/each}}
+    {{/if}}
+    <!-- END FLAVOR-SPECIFIC CODE -->
+    {{#unless suppressAttachments}}
+      {{#each attachments }}
+        <div class="place-item place-item-attachment place-attachment-{{ name }}">
+          <img src="{{ file }}" 
+               class="place-value place-value-{{ name }}" 
+               alt="{{ name }}" />
+        </div>           
+      {{/each}}
+    {{/unless}}
+
+    {{#each fields}}
+      <div class="place-item place-item-{{ name }}">
+        {{#if ../isEditingToggled}}
+          {{> place-form-field-types}}
+        {{else}}
+          {{#unless hideFromDetailView}}
+            <div class="place-label place-label-{{ name }}">{{ display_prompt }}</div>
+            {{> place-detail-field-types}}
+          {{/unless}}
+        {{/if}}
+        <div style="clear:both"></div>
+      </div>
+    {{/each}}
+  </form>
+</section>
+
+{{#if survey_config}}
+  <section class="survey" 
+           id="survey"></section>
+{{/if}}


### PR DESCRIPTION
This is implemented as flavor-specific code since co-mingling attachment buttons and rich text image embeds is a little convoluted. This is something that we can rethink during the react port, but for now this is the easiest way to get a cover image button into mywater.world.