### PR TITLE
Improve dev server and incremental dev build performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,7 @@
     "type": "git",
     "url": "https://github.com/smartercleanup/platform.git"
   },
-  "keywords": [
-    "maps",
-    "crowdsourcing",
-    "engagement"
-  ],
+  "keywords": ["maps", "crowdsourcing", "engagement"],
   "author": "SmarterCleanup",
   "license": "GPL",
   "bugs": {
@@ -22,15 +18,18 @@
   },
   "homepage": "https://github.com/smartercleanup/platform",
   "scripts": {
-    "start": "npm run build-js && node scripts/static-build.js && npm run watch-js & webpack-dev-server",
+    "start": "node scripts/static-build.js && webpack-dev-server",
     "build-js": "webpack -d",
     "build-js-production": "NODE_ENV=production webpack -p",
     "watch-js": "webpack -d --watch",
-    "build": "NODE_ENV=production npm run build-js-production && NODE_ENV=production node scripts/static-build.js",
-    "prettier": "prettier --write --trailing-comma all \"{src,blah}/**/*.{js,jsx}\""
+    "build":
+      "NODE_ENV=production npm run build-js-production && NODE_ENV=production node scripts/static-build.js",
+    "prettier":
+      "prettier --write --trailing-comma all \"{src,blah}/**/*.{js,jsx}\""
   },
   "dependencies": {
-    "accessible-autocomplete": "git+https://github.com/mapseed/accessible-autocomplete.git",
+    "accessible-autocomplete":
+      "git+https://github.com/mapseed/accessible-autocomplete.git",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "bem-classnames": "^1.0.7",

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -32,7 +32,7 @@
   {{#if production}}
     <link rel="stylesheet" href="/dist/{{cssHashedBundleName}}">
   {{else}}
-    <link rel="stylesheet" href="/dist/bundle.css">
+    <link rel="stylesheet" href="/bundle.css">
   {{/if}}
   <link rel="profile" href="//gmpg.org/xfn/11" />
 
@@ -260,7 +260,7 @@
   {{#if production}}
     <script src="/dist/{{jsHashedBundleName}}"></script>
   {{else}}
-    <script src="/dist/bundle.js"></script>
+    <script src="/bundle.js"></script>
   {{/if}}
   <script src="{{config.app.api_root}}users/current?format=jsonp&callback=bootstrapCurrentUser"></script>
   <script src="{{config.app.api_root}}utils/session-key?format=jsonp&callback=setApiSessionCookie"></script>


### PR DESCRIPTION
I discovered that we're not using webpack dev server as intended: in development we've been serving bundles from the filesystem, but instead we should be serving dev server's in-memory bundles. This PR fixes that.

Doing so significantly improves incremental build times and serve time.

Overall, though, incremental build times are still on the slow side (5-10 seconds). I'm hoping that as we finish up the React port the overall project will simplify and build times will improve.