### PR TITLE
chore(package.json) lock package fork to git commit hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "accessible-autocomplete": {
-      "version": "git+https://github.com/mapseed/accessible-autocomplete.git#7e56b805ee7ce77bebae67f6454a5c3f5e4987a8",
+      "version": "github:mapseed/accessible-autocomplete#7e56b805ee7ce77bebae67f6454a5c3f5e4987a8",
       "requires": {
         "preact": "8.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettier": "prettier --write --trailing-comma all \"{src,scripts}/**/*.{js,jsx}\""
   },
   "dependencies": {
-    "accessible-autocomplete": "git+https://github.com/mapseed/accessible-autocomplete.git",
+    "accessible-autocomplete": "github:mapseed/accessible-autocomplete#7e56b805ee7ce77bebae67f6454a5c3f5e4987a8",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "bem-classnames": "^1.0.7",


### PR DESCRIPTION
Long-term, we should either publish our fork on npm, or send a PR get the changes from our fork into upstream.

For now, this PR locks the dep to a hash to ensure we are referencing the intended "release" of our forked package.