### PR TITLE
Cluster enhancements

### DIFF
--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -381,8 +381,19 @@ module.exports = Backbone.View.extend({
           url += encodeURIComponent(source) + "&";
         });
       }
+      config.map = self.map;
       layer = L.argo(url, config);
-      self.layers[config.id] = layer;
+      if (self.options.cluster) {
+        layer.on("loaded", layer => {
+          let clusters = L.markerClusterGroup(self.options.cluster).addLayer(
+            layer.target,
+          );
+          self.layers[config.id] = clusters;
+          self.map.addLayer(clusters);
+        });
+      } else {
+        self.layers[config.id] = layer;
+      }
     } else if (config.type && config.type === "kml") {
       $.ajax(config.url).done(function(xml) {
         layer = L.argo(toGeoJSON.kml(xml), config);

--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -80,7 +80,7 @@ module.exports = Backbone.View.extend({
 
     // Bind shareabouts collections event listeners
     _.each(self.places, function(collection, collectionId) {
-      self.layers[collectionId] = self.getLayerGroups();
+      self.layers[collectionId] = self.getLayerGroups(collectionId);
       self.layerViews[collectionId] = {};
       collection.on("reset", self.render, self);
       collection.on("add", self.addLayerView(collectionId), self);
@@ -134,6 +134,16 @@ module.exports = Backbone.View.extend({
       }
     });
   }, // end initialize
+
+  isClusterable(layerId) {
+    // If no cluster config exists, we don't cluster any layers.
+    if (!this.options.cluster) return false;
+    // If a cluster config exists but no layer list is included, we cluster all
+    // layers.
+    if (!this.options.cluster.layers) return true;
+    // Otherwise, we only cluster a layer if it's listed in the cluster config.
+    return this.options.cluster.layers.includes(layerId);
+  },
 
   checkLayerZoom(maxZoom) {
     if (maxZoom && this.map.getZoom() > maxZoom) {
@@ -359,11 +369,11 @@ module.exports = Backbone.View.extend({
     });
   },
 
-  getLayerGroups: function() {
-    if (!this.options.cluster) {
-      return L.layerGroup();
+  getLayerGroups: function(collectionId) {
+    if (this.isClusterable(collectionId)) {
+      return L.markerClusterGroup(this.options.cluster)
     } else {
-      return L.markerClusterGroup(this.options.cluster);
+      return L.layerGroup();
     }
   },
 
@@ -383,7 +393,7 @@ module.exports = Backbone.View.extend({
       }
       config.map = self.map;
       layer = L.argo(url, config);
-      if (self.options.cluster) {
+      if (self.isClusterable(config.id)) {
         layer.on("loaded", layer => {
           let clusters = L.markerClusterGroup(self.options.cluster).addLayer(
             layer.target,

--- a/src/base/static/libs/leaflet.argo.js
+++ b/src/base/static/libs/leaflet.argo.js
@@ -8,7 +8,6 @@ L.Argo = L.GeoJSON.extend({
   initialize: function(geojson, options) {
     options.map.fire("layer:loading", { id: options.id });
 
-  initialize: function (geojson, options) {
     // Add options and function to L.Util
     L.Util.setOptions(this, options);
     L.Util.setOptions(this, {

--- a/src/base/static/libs/leaflet.argo.js
+++ b/src/base/static/libs/leaflet.argo.js
@@ -5,6 +5,8 @@
  */
 
 L.Argo = L.GeoJSON.extend({
+  initialize: function(geojson, options) {
+    options.map.fire("layer:loading", { id: options.id });
 
   initialize: function (geojson, options) {
     // Add options and function to L.Util
@@ -15,12 +17,13 @@ L.Argo = L.GeoJSON.extend({
     });
 
     var successHandler = L.Util.bind(function(geojson) {
-      this.addData(geojson);
-      this._map.fire('layer:loaded', {id: options.id});
-    }, this),
-    errorHandler = L.Util.bind(function() {
-      this._map.fire('layer:error', {id: options.id});
-    }, this);
+        this.addData(geojson);
+        this.fire("loaded");
+        options.map.fire("layer:loaded", { id: options.id });
+      }, this),
+      errorHandler = L.Util.bind(function() {
+        this._map.fire("layer:error", { id: options.id });
+      }, this);
 
     // Init layers
     this._layers = {};


### PR DESCRIPTION
Add the following enhancements to our marker cluster feature:

* clustering for geojson layers
* enable per-layer clustering (clustering was previously all or nothing)

To cluster individual layer(s), list the layer ids under the `layers` property of the `cluster` section of the config, e.g.:

```
cluster:
  layers:
    - cso
    - input
  animate: true
  animateAddingMarkers: false
  showCoverageOnHover: true
  spiderfyOnMaxZoom: true
  spiderfyDistanceMultiplier: 1.5
  spiderLegPolylineOptions:
    opacity: 0
```

Clustering will behave as follows:
* If a `cluster` config is present with no `layers` property, all layers will cluster.
* If a `layers` property is present, only the layers listed there will cluster.
* If no `cluster` config is present, no layers will cluster.