### PR TITLE
Enforce Prettier formatting for unit tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/base/static/libs/**/*.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,21 @@
 module.exports = {
-  displayName: "mapseed-platform-test",
-  moduleNameMapper: {
-    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
-      "<rootDir>/__mocks__/file-mock.js",
-    "\\.(css|less|scss)$": "<rootDir>/__mocks__/style-mock.js",
-  },
-  setupFiles: ["<rootDir>/jest-setup.js"],
-  snapshotSerializers: ["enzyme-to-json/serializer"],
-  testMatch: ["**/*.test.js"],
+  projects: [
+    {
+      displayName: "jest-prettier",
+      runner: "jest-runner-prettier",
+      moduleFileExtensions: ["js"],
+      testMatch: ["<rootDir>/src/**/*.js", "<rootDir>/scripts/**/*.js"],
+    },
+    {
+      displayName: "mapseed-platform-test",
+      moduleNameMapper: {
+        "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+          "<rootDir>/__mocks__/file-mock.js",
+        "\\.(css|less|scss)$": "<rootDir>/__mocks__/style-mock.js",
+      },
+      setupFiles: ["<rootDir>/jest-setup.js"],
+      snapshotSerializers: ["enzyme-to-json/serializer"],
+      testMatch: ["**/*.test.js"],
+    },
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,10 @@ module.exports = {
       runner: "jest-runner-prettier",
       moduleFileExtensions: ["js"],
       testMatch: ["<rootDir>/src/**/*.js", "<rootDir>/scripts/**/*.js"],
+      testPathIgnorePatterns: [
+        "<rootDir>/src/base/static/libs/",
+        "<rootDir>/node_modules/",
+      ],
     },
     {
       displayName: "mapseed-platform-test",

--- a/jest.watch.config.js
+++ b/jest.watch.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  displayName: "mapseed-platform-test",
+  moduleNameMapper: {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+      "<rootDir>/__mocks__/file-mock.js",
+    "\\.(css|less|scss)$": "<rootDir>/__mocks__/style-mock.js",
+  },
+  setupFiles: ["<rootDir>/jest-setup.js"],
+  snapshotSerializers: ["enzyme-to-json/serializer"],
+  testMatch: ["**/*.test.js"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,12 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -1743,6 +1749,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "browserify": {
       "version": "16.1.1",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.1.1.tgz",
@@ -2364,6 +2376,153 @@
         "restore-cursor": "1.0.1"
       }
     },
+    "cli-highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-1.2.3.tgz",
+      "integrity": "sha512-cmc4Y2kJuEpT2KZd9pgWWskpDMMfJu2roIcY1Ya/aIItufF5FKsV/NtA6vvdhSUllR8KJfvQDNmIcskU+MKLDg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.2",
+        "highlight.js": "9.12.0",
+        "mz": "2.7.0",
+        "parse5": "3.0.3",
+        "yargs": "10.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -2806,6 +2965,67 @@
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
         "sha.js": "2.4.10"
+      }
+    },
+    "create-jest-runner": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-jest-runner/-/create-jest-runner-0.3.0.tgz",
+      "integrity": "sha512-PqmLUoVfb+KY8r7Q0yxwr3zfZQ4SyDWPIXE0e483vgPU+oatPOT6IQIX6i/O5pKUAZTG9+5Y4kLvwmnTwsU50w==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-istanbul": "4.1.4",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "jest-worker": "21.3.0-beta.9",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mocha": "3.5.0",
+        "pify": "3.0.0",
+        "throat": "4.1.0",
+        "worker-farm": "1.5.0"
+      },
+      "dependencies": {
+        "babel-plugin-istanbul": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
+          "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "istanbul-lib-instrument": "1.10.1",
+            "test-exclude": "4.2.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "jest-worker": {
+          "version": "21.3.0-beta.9",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-21.3.0-beta.9.tgz",
+          "integrity": "sha512-dID+zcYsO2oaOF+Fr5g8c2NjPKDs7DwKTQOemWJZDvVyXbhNDzP+Lmd5EoCe3Wa8LkF7Z3WI67k3EXC8y9I3Pw==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "1.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "create-react-class": {
@@ -5731,6 +5951,18 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -5869,6 +6101,12 @@
         "hoek": "2.16.3",
         "sntp": "1.0.9"
       }
+    },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -7936,6 +8174,18 @@
         "throat": "4.1.0"
       }
     },
+    "jest-runner-prettier": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/jest-runner-prettier/-/jest-runner-prettier-0.2.2.tgz",
+      "integrity": "sha512-4U1NhVzHvP6nLO58mOnIuHtL9Jv3/Fi9RQogURvi/gF06QJDmwbgfKaajVI4hts7jej/pazGPqdgxk7+PUn6UQ==",
+      "dev": true,
+      "requires": {
+        "cli-highlight": "1.2.3",
+        "create-jest-runner": "0.3.0",
+        "jest-diff": "22.4.3",
+        "prettier": "1.11.1"
+      }
+    },
     "jest-runtime": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
@@ -8852,6 +9102,28 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
     "lodash._basedifference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
@@ -8894,6 +9166,12 @@
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -8909,6 +9187,17 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.difference": {
       "version": "3.2.2",
@@ -9353,6 +9642,80 @@
         }
       }
     },
+    "mocha": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
     "module-deps": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.0.0.tgz",
@@ -9474,6 +9837,17 @@
             "glob": "6.0.4"
           }
         }
+      }
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
       }
     },
     "nan": {
@@ -16997,6 +17371,24 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": "3.3.0"
+      }
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -18172,6 +18564,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "worker-farm": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
+      "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.7",
+        "xtend": "4.0.1"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "node scripts/static-build.js && webpack-dev-server",
     "test": "jest --verbose --config ./jest.config.js",
-    "test:watch": "jest --watch --verbose --config ./jest.config.js",
+    "test:watch": "jest --watch --verbose --config ./jest.watch.config.js",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
     "build-js": "webpack -d",
     "build-js-production": "NODE_ENV=production webpack -p",
@@ -90,6 +90,7 @@
     "handlebars": "^4.0.10",
     "i18next-resource-store-loader": "^0.1.2",
     "jest": "^22.4.2",
+    "jest-runner-prettier": "^0.2.2",
     "js-yaml": "^3.9.0",
     "json-loader": "^0.5.7",
     "mv": "^2.1.1",

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -61,7 +61,7 @@ module.exports = function(source) {
 
   const templateSource = fs.readFileSync(
     path.resolve(__dirname, "../build-utils/config-template.hbs"),
-    "utf8"
+    "utf8",
   );
   const template = Handlebars.compile(templateSource);
   outputFile = template({

--- a/scripts/make-base-messages.js
+++ b/scripts/make-base-messages.js
@@ -1,183 +1,161 @@
-require('dotenv').config({path: 'src/.env'});
-const fs = require('fs-extra');
-const path = require('path');
+require("dotenv").config({ path: "src/.env" });
+const fs = require("fs-extra");
+const path = require("path");
 const walk = require("object-walk");
 const exec = require("child_process").exec;
-const yaml = require('js-yaml');
-const shell = require('shelljs');
-const colors = require('colors');
+const yaml = require("js-yaml");
+const shell = require("shelljs");
+const colors = require("colors");
 const args = require("optimist").argv;
 
-const help = "Usage:\n" +
-						 "Update all existing base project locale po files: node make-base-messages.js\n" +
-						 "Add a new base project locale: node make-base-messages.js --set-new-locale=<locale_code>";
+const help =
+  "Usage:\n" +
+  "Update all existing base project locale po files: node make-base-messages.js\n" +
+  "Add a new base project locale: node make-base-messages.js --set-new-locale=<locale_code>";
 
 if (args.h || args.help) {
-	console.log(help);
-	process.exit(0);
+  console.log(help);
+  process.exit(0);
 }
 
 // Logging
-const logError = (msg) => {
- 	console.error("(MAKEMESSAGES)", colors.red("(ERROR!)"), msg);
+const logError = msg => {
+  console.error("(MAKEMESSAGES)", colors.red("(ERROR!)"), msg);
 };
 
 const jsTemplatesRegexObj = new RegExp(/{{#_}}([\s\S]*?){{\/_}}/, "g");
 
-const basePath = path.resolve(
-	__dirname,
-	"../src/base"
-);
-const baseLocalePath = path.resolve(
-	basePath,
-	"locale"
-);
-const potFilePath = path.resolve(
-	basePath,
-	"messages.pot"
-);
-const baseJSTemplatesPath = path.resolve(
-	basePath,
-	"jstemplates"
-);
-const messagesCatalogTempPath = path.resolve(
-	__dirname,
-	"../temp-messages"
-);
-shell.mkdir('-p', messagesCatalogTempPath);
+const basePath = path.resolve(__dirname, "../src/base");
+const baseLocalePath = path.resolve(basePath, "locale");
+const potFilePath = path.resolve(basePath, "messages.pot");
+const baseJSTemplatesPath = path.resolve(basePath, "jstemplates");
+const messagesCatalogTempPath = path.resolve(__dirname, "../temp-messages");
+shell.mkdir("-p", messagesCatalogTempPath);
 
-let templatePath,
-		foundMessages,
-		jsTemplatesMessagesOutput;
+let templatePath, foundMessages, jsTemplatesMessagesOutput;
 const extractTemplateMessages = (jsTemplateName, jsTemplatePath) => {
-	if (jsTemplateName.endsWith("html") || jsTemplateName.endsWith("hbs")) {
-		foundMessages = [];
+  if (jsTemplateName.endsWith("html") || jsTemplateName.endsWith("hbs")) {
+    foundMessages = [];
 
-		// NOTE: we save these temp files as python files, so we can take 
-		// advantage of Python's multiline string quoting capabilities. The JS 
-		// equivalent (backticks) causes problems for xgettext.
-		jsTemplatesMessagesOutput = fs.createWriteStream(
-			path.resolve(
-				messagesCatalogTempPath,
-				jsTemplateName + "-messages.temp.py"
-			)
-		);
-		templateString = fs.readFileSync(
-			path.resolve(jsTemplatePath, jsTemplateName),
-			"utf8"
-		);
-		while (foundMessage = jsTemplatesRegexObj.exec(templateString)) {
+    // NOTE: we save these temp files as python files, so we can take
+    // advantage of Python's multiline string quoting capabilities. The JS
+    // equivalent (backticks) causes problems for xgettext.
+    jsTemplatesMessagesOutput = fs.createWriteStream(
+      path.resolve(
+        messagesCatalogTempPath,
+        jsTemplateName + "-messages.temp.py",
+      ),
+    );
+    templateString = fs.readFileSync(
+      path.resolve(jsTemplatePath, jsTemplateName),
+      "utf8",
+    );
+    while ((foundMessage = jsTemplatesRegexObj.exec(templateString))) {
+      // The second item in foundMessage represents the capture group
+      foundMessages.push(foundMessage[1]);
+    }
 
-			// The second item in foundMessage represents the capture group
-			foundMessages.push(foundMessage[1]);
-		}
+    foundMessages.forEach(message => {
+      jsTemplatesMessagesOutput.write(
+        '_("""' + escapeQuotes(message) + '""");\n',
+      );
+    });
 
-		foundMessages.forEach((message) => {
-			jsTemplatesMessagesOutput.write('_("""' + escapeQuotes(message) + '""");\n');
-		});
-
-		jsTemplatesMessagesOutput.end();
-  }			
+    jsTemplatesMessagesOutput.end();
+  }
 };
 
 const cleanup = () => {
-	shell.rm('-rf', messagesCatalogTempPath);
-	fs.existsSync(potFilePath) && shell.rm(potFilePath);
+  shell.rm("-rf", messagesCatalogTempPath);
+  fs.existsSync(potFilePath) && shell.rm(potFilePath);
 };
 
-let basePOPath,
-		mergedBasePOPath;
+let basePOPath, mergedBasePOPath;
 const mergeExistingLocales = () => {
-	const locales = fs.readdirSync(baseLocalePath)
-		.filter((locale) => {
+  const locales = fs.readdirSync(baseLocalePath).filter(locale => {
+    // filter out any hidden system files, like .DS_Store
+    return !locale.startsWith(".");
+  });
+  let numFinishedLocales = 0;
+  locales.forEach(locale => {
+    basePOPath = path.resolve(
+      baseLocalePath,
+      locale,
+      "LC_MESSAGES/messages.po",
+    );
 
-			// filter out any hidden system files, like .DS_Store
-			return !locale.startsWith("\.");
-		});
-	let numFinishedLocales = 0;
-	locales.forEach((locale) => {
-		basePOPath = path.resolve(
-			baseLocalePath,
-			locale,
-			"LC_MESSAGES/messages.po"
-		);
+    exec(
+      "msgmerge" +
+        " --no-location" +
+        " --no-fuzzy-matching" +
+        " --update " +
+        basePOPath +
+        " " +
+        potFilePath,
+      err => {
+        if (err) {
+          logError("Error merging po files for " + locale + ": " + err);
+          logError("Aborting");
 
-		exec(
-			"msgmerge" + 
-			" --no-location" +
-			" --no-fuzzy-matching" +
-			" --update " +
-			basePOPath + " " +
-			potFilePath,
-			(err) => {
-				if (err) {
-					logError("Error merging po files for " + locale + ": " + err);
-					logError("Aborting");
+          process.exit(1);
+        }
+        numFinishedLocales++;
 
-					process.exit(1);
-				}
-				numFinishedLocales++;
-
-				// If we're all done, remove temporary files.
-				if (numFinishedLocales === locales.length) {
-					cleanup();
-				}
-			}
-		);
-	});
+        // If we're all done, remove temporary files.
+        if (numFinishedLocales === locales.length) {
+          cleanup();
+        }
+      },
+    );
+  });
 };
 
 const generateCatalog = (merge, outputPath) => {
-	exec(
-		"xgettext" + 
-		" --from-code=UTF-8" +
-		" --no-location" +
-		" -o " + outputPath + " " +
-		messagesCatalogTempPath + "/*",
-		(err) => {
-			if (err) {
-				logError("Error generating po template file: " + err);
-				logError("Aborting");
+  exec(
+    "xgettext" +
+      " --from-code=UTF-8" +
+      " --no-location" +
+      " -o " +
+      outputPath +
+      " " +
+      messagesCatalogTempPath +
+      "/*",
+    err => {
+      if (err) {
+        logError("Error generating po template file: " + err);
+        logError("Aborting");
 
-				process.exit(1);
-			}
+        process.exit(1);
+      }
 
-			(merge)
-				? mergeExistingLocales()
-				: cleanup();
-		}
-	);	
+      merge ? mergeExistingLocales() : cleanup();
+    },
+  );
 };
 
-const escapeQuotes = (message) => {
-	return message
-		.split('"')
-		.join('\\"')
-		.split("'")
-		.join("\\'");
+const escapeQuotes = message => {
+  return message
+    .split('"')
+    .join('\\"')
+    .split("'")
+    .join("\\'");
 };
 
 // Extract trasnslatable strings from base project jstemplates
-fs.readdirSync(baseJSTemplatesPath).forEach((jsTemplateName) => {
-	extractTemplateMessages(jsTemplateName, baseJSTemplatesPath);
+fs.readdirSync(baseJSTemplatesPath).forEach(jsTemplateName => {
+  extractTemplateMessages(jsTemplateName, baseJSTemplatesPath);
 });
 
 // Extract translatable strings from base.hbs
 extractTemplateMessages("base.hbs", path.resolve(basePath, "templates"));
 
 if (args["set-new-locale"]) {
-
-	// Create a new locale
-	let locale = args["set-new-locale"],
-			localePath = path.resolve(
-				baseLocalePath,
-				locale,
-				"LC_MESSAGES"
-			);
-	shell.mkdir("-p", localePath);
-	generateCatalog(false, localePath + "/messages.po");	
+  // Create a new locale
+  let locale = args["set-new-locale"],
+    localePath = path.resolve(baseLocalePath, locale, "LC_MESSAGES");
+  shell.mkdir("-p", localePath);
+  generateCatalog(false, localePath + "/messages.po");
 } else {
-
-	// Update existing locales
-	generateCatalog(true, potFilePath);
+  // Update existing locales
+  generateCatalog(true, potFilePath);
 }

--- a/scripts/make-flavor-messages.js
+++ b/scripts/make-flavor-messages.js
@@ -1,228 +1,196 @@
-require('dotenv').config({path: 'src/.env'});
-const fs = require('fs-extra');
-const path = require('path');
+require("dotenv").config({ path: "src/.env" });
+const fs = require("fs-extra");
+const path = require("path");
 const walk = require("object-walk");
 const exec = require("child_process").exec;
-const yaml = require('js-yaml');
-const shell = require('shelljs');
-const colors = require('colors');
+const yaml = require("js-yaml");
+const shell = require("shelljs");
+const colors = require("colors");
 const args = require("optimist").argv;
 
-const help = "Usage:\n" +
-			 "Update all existing flavor locale po files for flavor the flavor set in the FLAVOR environment variable: node make-flavor-messages.js\n" +
-			 "Add a new flavor locale: node make-flavor-messages.js --set-new-locale=<locale_code>";
+const help =
+  "Usage:\n" +
+  "Update all existing flavor locale po files for flavor the flavor set in the FLAVOR environment variable: node make-flavor-messages.js\n" +
+  "Add a new flavor locale: node make-flavor-messages.js --set-new-locale=<locale_code>";
 
 if (args.h || args.help) {
-	console.log(help);
-	process.exit(0);
+  console.log(help);
+  process.exit(0);
 }
 
 const flavor = process.env.FLAVOR;
 
 // Logging
-const logError = (msg) => {
-	console.error("(MAKEMESSAGES)", colors.red("(ERROR!)"), msg);
+const logError = msg => {
+  console.error("(MAKEMESSAGES)", colors.red("(ERROR!)"), msg);
 };
 
 // Generate message catalog for the given flavor's config.yml file.
-const flavorBasePath = path.resolve(
-	__dirname,
-	"../src/flavors",
-	flavor
-);
+const flavorBasePath = path.resolve(__dirname, "../src/flavors", flavor);
 const messagesCatalogTempPath = path.resolve(
-	__dirname,
-	"../src/flavors",
-	flavor,
-	"temp-messages"
+  __dirname,
+  "../src/flavors",
+  flavor,
+  "temp-messages",
 );
-const flavorConfigPath = path.resolve(
-	flavorBasePath,
-	"config.yml"
-);
+const flavorConfigPath = path.resolve(flavorBasePath, "config.yml");
 const config = yaml.safeLoad(fs.readFileSync(flavorConfigPath));
-shell.mkdir('-p', messagesCatalogTempPath);
+shell.mkdir("-p", messagesCatalogTempPath);
 
-const escapeQuotes = (message) => {
-	return message
-		.split('"')
-		.join('\\"')
-		.split("'")
-		.join("\\'");
+const escapeQuotes = message => {
+  return message
+    .split('"')
+    .join('\\"')
+    .split("'")
+    .join("\\'");
 };
 
 const jsTemplatesRegexObj = new RegExp(/{{#_}}([\s\S]*?){{\/_}}/, "g");
-let templatePath,
-	foundMessages,
-	jsTemplatesMessagesOutput;
+let templatePath, foundMessages, jsTemplatesMessagesOutput;
 const extractTemplateMessages = (jsTemplate, outputPath) => {
-	foundMessages = [];
+  foundMessages = [];
 
-	// NOTE: we save these temp files as python files, so we can take 
-	// advantage of Python's multiline string quoting capabilities. The JS 
-	// equivalent (backticks) causes problems for xgettext.
-	jsTemplatesMessagesOutput = fs.createWriteStream(
-		path.resolve(
-			messagesCatalogTempPath,
-			jsTemplate + "-messages.temp.py"
-		)
-	);
-	templateString = fs.readFileSync(
-		path.resolve(outputPath, jsTemplate),
-		"utf8"
-	);
-	while (foundMessage = jsTemplatesRegexObj.exec(templateString)) {
+  // NOTE: we save these temp files as python files, so we can take
+  // advantage of Python's multiline string quoting capabilities. The JS
+  // equivalent (backticks) causes problems for xgettext.
+  jsTemplatesMessagesOutput = fs.createWriteStream(
+    path.resolve(messagesCatalogTempPath, jsTemplate + "-messages.temp.py"),
+  );
+  templateString = fs.readFileSync(
+    path.resolve(outputPath, jsTemplate),
+    "utf8",
+  );
+  while ((foundMessage = jsTemplatesRegexObj.exec(templateString))) {
+    // The second item in foundMessage represents the capture group
+    foundMessages.push(foundMessage[1]);
+  }
 
-		// The second item in foundMessage represents the capture group
-		foundMessages.push(foundMessage[1]);
-	}
+  foundMessages.forEach(message => {
+    jsTemplatesMessagesOutput.write(
+      '_("""' + escapeQuotes(message) + '""");\n',
+    );
+  });
 
-	foundMessages.forEach((message) => {
-		jsTemplatesMessagesOutput.write('_("""' + escapeQuotes(message) + '""");\n');
-	});
-
-	jsTemplatesMessagesOutput.end();
+  jsTemplatesMessagesOutput.end();
 };
 
 const cleanup = () => {
-	shell.rm('-rf', messagesCatalogTempPath);
-	fs.existsSync(potFilePath) && shell.rm(potFilePath);
+  shell.rm("-rf", messagesCatalogTempPath);
+  fs.existsSync(potFilePath) && shell.rm(potFilePath);
 };
 
-const flavorLocalePath = path.resolve(
-	flavorBasePath,
-	"locale"
-);
-let flavorPOPath,
-	mergedFlavorPOPath;
+const flavorLocalePath = path.resolve(flavorBasePath, "locale");
+let flavorPOPath, mergedFlavorPOPath;
 const mergeExistingLocales = () => {
-	const locales = fs.readdirSync(flavorLocalePath)
-		.filter((locale) => {
+  const locales = fs.readdirSync(flavorLocalePath).filter(locale => {
+    // filter out any hidden system files, like .DS_Store
+    return !locale.startsWith(".");
+  });
+  let numFinishedLocales = 0;
+  locales.forEach(locale => {
+    flavorPOPath = path.resolve(
+      flavorLocalePath,
+      locale,
+      "LC_MESSAGES/messages.po",
+    );
 
-			// filter out any hidden system files, like .DS_Store
-			return !locale.startsWith("\.");
-		});
-	let numFinishedLocales = 0;
-	locales.forEach((locale) => {
-		flavorPOPath = path.resolve(
-			flavorLocalePath,
-			locale,
-			"LC_MESSAGES/messages.po"
-		);
+    exec(
+      "msgmerge" +
+        " --no-location" +
+        " --no-fuzzy-matching" +
+        " --update " +
+        flavorPOPath +
+        " " +
+        potFilePath,
+      e => {
+        if (e) {
+          logError("Error merging po files for " + locale + ":" + e);
+          logError("Aborting");
 
-		exec(
-			"msgmerge" + 
-			" --no-location" +
-			" --no-fuzzy-matching" +
-			" --update " +
-			flavorPOPath + " " +
-			potFilePath,
-			(e) => {
-				if (e) {
-					logError("Error merging po files for " + locale + ":" + e);
-					logError("Aborting");
+          process.exit(1);
+        }
+        numFinishedLocales++;
 
-					process.exit(1);
-      			}
-				numFinishedLocales++;
-
-				// If we're all done, remove temporary files.
-				if (numFinishedLocales === locales.length) {
-					cleanup();
-				}
-			}
-		);
-	});
+        // If we're all done, remove temporary files.
+        if (numFinishedLocales === locales.length) {
+          cleanup();
+        }
+      },
+    );
+  });
 };
 
 const generateCatalog = (merge, outputPath) => {
-	exec(
-		"xgettext" + 
-		" --from-code=UTF-8" +
-		" --no-location" +
-		" -o " + outputPath + " " +
-		messagesCatalogTempPath + "/*",
-		(err) => {
-			if (err) {
-				logError("Error generating po template file: " + err);
-				logError("Aborting");
+  exec(
+    "xgettext" +
+      " --from-code=UTF-8" +
+      " --no-location" +
+      " -o " +
+      outputPath +
+      " " +
+      messagesCatalogTempPath +
+      "/*",
+    err => {
+      if (err) {
+        logError("Error generating po template file: " + err);
+        logError("Aborting");
 
-				process.exit(1);
-			}
+        process.exit(1);
+      }
 
-			(merge)
-				? mergeExistingLocales()
-				: cleanup();
-		}
-	);
-}
+      merge ? mergeExistingLocales() : cleanup();
+    },
+  );
+};
 
 // Extract translatable messages for the config
 let configMessagesOutput = fs.createWriteStream(
-	path.resolve(
-		messagesCatalogTempPath,
-		"config-messages.temp.py"
-	)
+  path.resolve(messagesCatalogTempPath, "config-messages.temp.py"),
 );
 let foundMessage;
 walk(config, (val, prop, obj) => {
-	if (typeof val === "string") {
-		foundMessage = /^_\(([\s\S]*?)\)$/g.exec(val);
- 		foundMessage && configMessagesOutput.write('_("""' + escapeQuotes(foundMessage[1]) + '""");\n');
-	}
+  if (typeof val === "string") {
+    foundMessage = /^_\(([\s\S]*?)\)$/g.exec(val);
+    foundMessage &&
+      configMessagesOutput.write(
+        '_("""' + escapeQuotes(foundMessage[1]) + '""");\n',
+      );
+  }
 });
 configMessagesOutput.end();
 
 // Extract translatable messages for flavor-defined jstemplates
-const flavorJSTemplatesPath = path.resolve(
-	flavorBasePath,
-	"jstemplates"
-);
-fs.readdirSync(flavorJSTemplatesPath).forEach((jsTemplate) => {
-	if (jsTemplate.endsWith("html")) {
-		extractTemplateMessages(jsTemplate, flavorJSTemplatesPath);
-	}
+const flavorJSTemplatesPath = path.resolve(flavorBasePath, "jstemplates");
+fs.readdirSync(flavorJSTemplatesPath).forEach(jsTemplate => {
+  if (jsTemplate.endsWith("html")) {
+    extractTemplateMessages(jsTemplate, flavorJSTemplatesPath);
+  }
 });
 
 // Extract translatable messages for flavor pages
-const flavorPagesPath = path.resolve(
-	flavorBasePath,
-	"jstemplates/pages"
-);
-fs.readdirSync(flavorPagesPath).forEach((jsTemplate) => {
-	if (jsTemplate.endsWith("html")) {
-		extractTemplateMessages(jsTemplate, flavorPagesPath);
-	}
+const flavorPagesPath = path.resolve(flavorBasePath, "jstemplates/pages");
+fs.readdirSync(flavorPagesPath).forEach(jsTemplate => {
+  if (jsTemplate.endsWith("html")) {
+    extractTemplateMessages(jsTemplate, flavorPagesPath);
+  }
 });
 
 // Extract translatable messages for email templates
-const emailTemplatesPath = path.resolve(
-	flavorBasePath,
-	"templates"
-);
-fs.readdirSync(emailTemplatesPath).forEach((emailTemplate) => {
-	if (emailTemplate.endsWith("txt")) {
-		extractTemplateMessages(emailTemplate, emailTemplatesPath);
-	}
+const emailTemplatesPath = path.resolve(flavorBasePath, "templates");
+fs.readdirSync(emailTemplatesPath).forEach(emailTemplate => {
+  if (emailTemplate.endsWith("txt")) {
+    extractTemplateMessages(emailTemplate, emailTemplatesPath);
+  }
 });
 
-const potFilePath = path.resolve(
-	flavorBasePath,
-	"messages.pot"
-);
+const potFilePath = path.resolve(flavorBasePath, "messages.pot");
 if (args["set-new-locale"]) {
-
-	// Create a new locale
-	let locale = args["set-new-locale"],
-			localePath = path.resolve(
-				flavorLocalePath,
-				locale,
-				"LC_MESSAGES"
-			);
-	shell.mkdir("-p", localePath);
-	generateCatalog(false, localePath + "/messages.po");	
+  // Create a new locale
+  let locale = args["set-new-locale"],
+    localePath = path.resolve(flavorLocalePath, locale, "LC_MESSAGES");
+  shell.mkdir("-p", localePath);
+  generateCatalog(false, localePath + "/messages.po");
 } else {
-
-	// Update existing locales
-	generateCatalog(true, potFilePath);
+  // Update existing locales
+  generateCatalog(true, potFilePath);
 }

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -1,7 +1,7 @@
-require('dotenv').config({path: 'src/.env'});
-const path = require('path');
-const fs = require('fs-extra');
-const yaml = require('js-yaml');
+require("dotenv").config({ path: "src/.env" });
+const path = require("path");
+const fs = require("fs-extra");
+const yaml = require("js-yaml");
 const Gettext = require("node-gettext");
 const gettextParser = require("gettext-parser");
 const walk = require("object-walk"); // object-walk supports traversal of JS objects
@@ -9,9 +9,9 @@ const Handlebars = require("handlebars");
 const wax = require("wax-on"); // wax-on adds template inheritance to Handlebars
 const execSync = require("child_process").execSync;
 const mv = require("mv");
-const shell = require('shelljs');
-const glob = require('glob');
-const colors = require('colors');
+const shell = require("shelljs");
+const glob = require("glob");
+const colors = require("colors");
 
 // =============================================================================
 // BEGIN STATIC SITE BUILD
@@ -30,7 +30,6 @@ const colors = require('colors');
 //   - Asynchronous processing!
 // =============================================================================
 
-
 // (1) Set up paths to certain files and directories needed for the build, as
 //     well as utilities
 // -----------------------------------------------------------------------------
@@ -38,36 +37,26 @@ const colors = require('colors');
 // Control logging output
 const verbose = true;
 
-const outputBasePath = path.resolve(
-  __dirname,
-  "../www"
-);
-const distPath = path.resolve(
-  outputBasePath,
-  "dist"
-);
+const outputBasePath = path.resolve(__dirname, "../www");
+const distPath = path.resolve(outputBasePath, "dist");
 
-let jsHashedBundleName,
-    cssHashedBundleName;
-glob.sync(
-  distPath +
-  "/+(*.bundle.js|*.bundle.css)"
-).forEach((path) => {
+let jsHashedBundleName, cssHashedBundleName;
+glob.sync(distPath + "/+(*.bundle.js|*.bundle.css)").forEach(path => {
   path = path.split("/");
   if (path[path.length - 1].endsWith("js")) {
     jsHashedBundleName = path[path.length - 1] + ".gz";
   } else if (path[path.length - 1].endsWith("css")) {
-    cssHashedBundleName = path[path.length - 1] + ".gz" ;
+    cssHashedBundleName = path[path.length - 1] + ".gz";
   }
 });
 
 // Logging
-const log = (msg) => {
+const log = msg => {
   if (verbose) {
     console.log("(STATIC SITE BUILD)", colors.green("(SUCCESS)"), msg);
   }
 };
-const logError = (msg) => {
+const logError = msg => {
   console.error("(STATIC SITE BUILD)", colors.red("(ERROR!)"), msg);
 };
 
@@ -82,11 +71,7 @@ if (!flavor) {
   process.exit();
 }
 
-const flavorBasePath = path.resolve(
-  __dirname,
-  "../src/flavors",
-  flavor
-);
+const flavorBasePath = path.resolve(__dirname, "../src/flavors", flavor);
 
 // Pull out dataset urls from the .env file. We ignore the keys, as they're no
 // longer needed.
@@ -96,7 +81,6 @@ Object.keys(process.env).forEach(function(key) {
     datasetSiteUrls[key] = process.env[key];
   }
 });
-
 
 // (2) Register Handlebars helpers and resolve template inheritances
 // -----------------------------------------------------------------------------
@@ -111,7 +95,7 @@ Handlebars.registerHelper("serialize", function(json) {
 // Helper for injecting precompiled templates to the index.html file
 const compiledTemplatesOutputPath = path.resolve(
   outputBasePath,
-  "templates.js"
+  "templates.js",
 );
 Handlebars.registerHelper("precompile_jstemplates", function() {
   return fs.readFileSync(compiledTemplatesOutputPath);
@@ -121,29 +105,20 @@ Handlebars.registerHelper("precompile_jstemplates", function() {
 wax.on(Handlebars);
 wax.setLayoutPath(path.resolve(flavorBasePath, "templates"));
 
-
 // (3) Convert the config yaml to json
 // -----------------------------------------------------------------------------
 
-const flavorConfigPath = path.resolve(
-  flavorBasePath,
-  "config.yml"
-);
+const flavorConfigPath = path.resolve(flavorBasePath, "config.yml");
 const config = yaml.safeLoad(fs.readFileSync(flavorConfigPath));
-
 
 // (4) Compile base.hbs and index.html templates for the current flavor
 // -----------------------------------------------------------------------------
 
 const source = fs.readFileSync(
-  path.resolve(
-    flavorBasePath,
-    "templates/index.html"
-  ),
-  "utf8"
+  path.resolve(flavorBasePath, "templates/index.html"),
+  "utf8",
 );
 const indexTemplate = Handlebars.compile(source);
-
 
 // (5) Localize the config for each language for the current flavor, precompile
 //     localized jstemplates Handlebars templates, and inject all localized
@@ -153,43 +128,24 @@ const indexTemplate = Handlebars.compile(source);
 // Constants and variables to use inside the localization loop below
 const handlebarsExec = path.resolve(
   __dirname,
-  "../node_modules/handlebars/bin/handlebars"
+  "../node_modules/handlebars/bin/handlebars",
 );
-const baseJSTemplatesPath = path.resolve(
-  __dirname,
-  "../src/base/jstemplates"
-);
-const flavorJSTemplatesPath = path.resolve(
+const baseJSTemplatesPath = path.resolve(__dirname, "../src/base/jstemplates");
+const flavorJSTemplatesPath = path.resolve(flavorBasePath, "jstemplates");
+const flavorPagesPath = path.resolve(
+  // NOTE: pages are a flavor-only concept,
+  // so there's no basePagesPath
   flavorBasePath,
-  "jstemplates"
+  "jstemplates/pages",
 );
-const flavorPagesPath = path.resolve(  // NOTE: pages are a flavor-only concept,
-                                       // so there's no basePagesPath
-  flavorBasePath,
-  "jstemplates/pages"
-);
-const outputJSTemplatesPath = path.resolve(
-  outputBasePath,
-  "jstemplates"
-);
-const baseLocaleDir = path.resolve(
-  __dirname,
-  "../src/base/locale"
-);
-const flavorLocaleDir = path.resolve(
-  flavorBasePath,
-  "locale"
-);
-const mergedPOFileOutputPath = path.resolve(
-  outputBasePath,
-  "messages.po"
-);
+const outputJSTemplatesPath = path.resolve(outputBasePath, "jstemplates");
+const baseLocaleDir = path.resolve(__dirname, "../src/base/locale");
+const flavorLocaleDir = path.resolve(flavorBasePath, "locale");
+const mergedPOFileOutputPath = path.resolve(outputBasePath, "messages.po");
 
 let activeLanguages;
 if (process.env.NODE_ENV == "production") {
-  activeLanguages = (config.languages)
-    ? config.languages
-    : [{ code: "en_US" }];
+  activeLanguages = config.languages ? config.languages : [{ code: "en_US" }];
 } else {
   activeLanguages = [{ code: "en_US" }];
 }
@@ -201,22 +157,21 @@ const configGettextRegex = /^_\(/;
 // Gettext object
 const gt = new Gettext();
 let thisConfig,
-    flavorPOPath,
-    mergedPOFile,
-    rootComponents,
-    protocol,
-    outputIndexFilename;
+  flavorPOPath,
+  mergedPOFile,
+  rootComponents,
+  protocol,
+  outputIndexFilename;
 
 // Loop over all languages defined in a given flavor's config file and
 // generate fully localized output.
-activeLanguages.forEach((language) => {
-
+activeLanguages.forEach(language => {
   // Quick and dirty config clone
-  thisConfig =  JSON.parse(JSON.stringify(config));
+  thisConfig = JSON.parse(JSON.stringify(config));
   flavorPOPath = path.resolve(
     flavorLocaleDir,
     language.code,
-    "LC_MESSAGES/messages.po"
+    "LC_MESSAGES/messages.po",
   );
 
   // Merge the current language .po with the base project .po of the same
@@ -224,26 +179,25 @@ activeLanguages.forEach((language) => {
   try {
     execSync(
       "msgcat" + // NOTE: msgcat is a gettext command line program that merges
-                 // two .po files.
-      " --no-location " +
-      " -o " + mergedPOFileOutputPath + " " +
-      flavorPOPath + " " +
-      path.resolve(
-        baseLocaleDir,
-        language.code,
-        "LC_MESSAGES/messages.po"
-      )
+        // two .po files.
+        " --no-location " +
+        " -o " +
+        mergedPOFileOutputPath +
+        " " +
+        flavorPOPath +
+        " " +
+        path.resolve(baseLocaleDir, language.code, "LC_MESSAGES/messages.po"),
     );
     mergedPOFile = fs.readFileSync(mergedPOFileOutputPath);
     log("Finished merging .po file for " + language.code);
-  } catch(e) {
+  } catch (e) {
     logError("Error merging .po file for " + language.code);
   }
 
   gt.addTranslations(
     language.code,
     "messages",
-    gettextParser.po.parse(mergedPOFile)
+    gettextParser.po.parse(mergedPOFile),
   );
   gt.setTextDomain("messages");
   gt.setLocale(language.code);
@@ -252,9 +206,7 @@ activeLanguages.forEach((language) => {
   walk(thisConfig, (val, prop, obj) => {
     if (typeof val === "string") {
       if (configGettextRegex.test(val)) {
-        val = val
-          .replace(configGettextRegex, "")
-          .replace(/\)$/, "");
+        val = val.replace(configGettextRegex, "").replace(/\)$/, "");
         obj[prop] = gt.gettext(val);
       }
     }
@@ -273,7 +225,7 @@ activeLanguages.forEach((language) => {
     }
   });
 
-  // The API root is defined in the config. In most cases this will be set to 
+  // The API root is defined in the config. In most cases this will be set to
   // point to the dev API. If the .env defines a different API root, use that
   // value here. Use the API_ROOT key in the .env to set a new API root. Note
   // that this replaces the old SITE_URL key.
@@ -287,28 +239,19 @@ activeLanguages.forEach((language) => {
   // ---------------------------------------------------------------------------
 
   try {
-    fs.copySync(
-      baseJSTemplatesPath,
-      outputJSTemplatesPath
-    );
+    fs.copySync(baseJSTemplatesPath, outputJSTemplatesPath);
   } catch (e) {
     logError("Error copying base jstemplates assets: " + e);
   }
 
   try {
-    fs.copySync(
-      flavorJSTemplatesPath,
-      outputJSTemplatesPath
-    );
+    fs.copySync(flavorJSTemplatesPath, outputJSTemplatesPath);
   } catch (e) {
     logError("Error copying flavor jstemplates assets: " + e);
   }
 
   try {
-    fs.copySync(
-      flavorPagesPath,
-      outputJSTemplatesPath
-    );
+    fs.copySync(flavorPagesPath, outputJSTemplatesPath);
   } catch (e) {
     logError("Error copying flavor pages assets: " + e);
   }
@@ -316,74 +259,67 @@ activeLanguages.forEach((language) => {
   log("Finished copying jstemplates assets");
 
   // Localize jstemplates
-  let templatePath,
-      localizedTemplate;
-  fs.readdirSync(outputJSTemplatesPath).forEach((jsTemplate) => {
+  let templatePath, localizedTemplate;
+  fs.readdirSync(outputJSTemplatesPath).forEach(jsTemplate => {
     if (jsTemplate.endsWith("html")) {
       templatePath = path.resolve(outputJSTemplatesPath, jsTemplate);
-      localizedTemplate = fs.readFileSync(
-        templatePath,
-        "utf8"
-      ).replace(
-        jsTemplatesGettextRegex,
-        (match, capture) => {
+      localizedTemplate = fs
+        .readFileSync(templatePath, "utf8")
+        .replace(jsTemplatesGettextRegex, (match, capture) => {
           return gt.gettext(capture);
-        }
-      );
+        });
 
-      fs.writeFileSync(
-        templatePath,
-        localizedTemplate,
-        "utf8"
-      );
+      fs.writeFileSync(templatePath, localizedTemplate, "utf8");
     }
   });
 
   // Precompile jstemplates and pages Handlebars templates
   execSync(
     handlebarsExec +
-    " -m -e 'html' " + outputJSTemplatesPath +
-    " -f " + compiledTemplatesOutputPath +
-    // List known template helpers. This is a precompilation optimization.
-    " -k current_url" +
-    " -k permalink" +
-    " -k is" +
-    " -k is_not" +
-    " -k if_fileinput_not_supported" +
-    " -k if_not_authenticated" +
-    " -k property" +
-    " -k is_authenticated" +
-    " -k current_user" +
-    " -k formatdatetime" +
-    " -k fromnow" +
-    " -k truncatechars" +
-    " -k is_submitter_name" +
-    " -k action_text" +
-    " -k place_type_label" +
-    " -k survey_label_by_count" +
-    " -k survey_label" +
-    " -k survey_label_plural" +
-    " -k support_label" +
-    " -k support_label_plural" +
-    " -k survey_count" +
-    " -k get_value" +
-    " -k select_item_value" +
-    " -k contains" +
-    " -k place_url" +
-    " -k windowLocation" +
-    " -k nlToBr" +
-    " -k formatDateTime" +
-    " -k fromNow" +
-    " -k times" +
-    " -k range" +
-    " -k select" +
-    " -k ifAnd"
+      " -m -e 'html' " +
+      outputJSTemplatesPath +
+      " -f " +
+      compiledTemplatesOutputPath +
+      // List known template helpers. This is a precompilation optimization.
+      " -k current_url" +
+      " -k permalink" +
+      " -k is" +
+      " -k is_not" +
+      " -k if_fileinput_not_supported" +
+      " -k if_not_authenticated" +
+      " -k property" +
+      " -k is_authenticated" +
+      " -k current_user" +
+      " -k formatdatetime" +
+      " -k fromnow" +
+      " -k truncatechars" +
+      " -k is_submitter_name" +
+      " -k action_text" +
+      " -k place_type_label" +
+      " -k survey_label_by_count" +
+      " -k survey_label" +
+      " -k survey_label_plural" +
+      " -k support_label" +
+      " -k support_label_plural" +
+      " -k survey_count" +
+      " -k get_value" +
+      " -k select_item_value" +
+      " -k contains" +
+      " -k place_url" +
+      " -k windowLocation" +
+      " -k nlToBr" +
+      " -k formatDateTime" +
+      " -k fromNow" +
+      " -k times" +
+      " -k range" +
+      " -k select" +
+      " -k ifAnd",
   );
   log("Finished jstemplates compilation for " + language.code);
 
   // Build the index-xx.html file for this language
   outputIndexFile = indexTemplate({
-    production: (process.env.NODE_ENV === "production" ? true : false),
+    production: process.env.NODE_ENV === "production" ? true : false,
     jsHashedBundleName: jsHashedBundleName,
     cssHashedBundleName: cssHashedBundleName,
     config: thisConfig,
@@ -392,22 +328,21 @@ activeLanguages.forEach((language) => {
       clickyAnalyticsId: process.env.CLICKY_ANALYTICS_ID || "",
       mapQuestKey: process.env.MAPQUEST_KEY || "",
       googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID || "",
-      googleAnalyticsDomain: process.env.GOOGLE_ANALYTICS_DOMAIN || "auto"
+      googleAnalyticsDomain: process.env.GOOGLE_ANALYTICS_DOMAIN || "auto",
     },
     languageCode: language.code,
 
     // TODO: fix this...
-    userTokenJson: ""
+    userTokenJson: "",
   });
 
   // Write out final index-xx.html file
   outputIndexFilename = path.resolve(
     outputBasePath,
-    (language.code == "en_US" ? "index" : language.code) + ".html"
+    (language.code == "en_US" ? "index" : language.code) + ".html",
   );
   fs.writeFileSync(outputIndexFilename, outputIndexFile);
 });
-
 
 // (6) Move static image assets to the dist/ folder. Copy base project assets
 //     first, then copy flavor assets, overriding base assets as needed
@@ -416,62 +351,43 @@ activeLanguages.forEach((language) => {
 // Copy base project static image assets to src/base/static/dist/images
 const baseImageAssetsPath = path.resolve(
   __dirname,
-  "../src/base/static/css/images"
+  "../src/base/static/css/images",
 );
-const outputImageAssetsPath = path.resolve(
-  outputBasePath,
-  "static/css/images"
-);
+const outputImageAssetsPath = path.resolve(outputBasePath, "static/css/images");
 
 try {
-  fs.copySync(
-    baseImageAssetsPath,
-    outputImageAssetsPath
-  );
+  fs.copySync(baseImageAssetsPath, outputImageAssetsPath);
 } catch (e) {
   logError("Error copying base image assets: " + e);
 }
 
 // Copy flavor static image assets to www/images, replacing base assets as
 // necessary
-const flavorImageAssetsPath = path.resolve(
-  flavorBasePath,
-  "static/css/images"
-);
+const flavorImageAssetsPath = path.resolve(flavorBasePath, "static/css/images");
 
 try {
-  fs.copySync(
-    flavorImageAssetsPath,
-    outputImageAssetsPath
-  );
+  fs.copySync(flavorImageAssetsPath, outputImageAssetsPath);
 } catch (e) {
   logError("Error copying flavor image assets: " + e);
 }
 
 // Copy font files
-const baseFontsDir = path.resolve(
-  __dirname,
-  "../src/base"
-);
-let fontPaths = glob.sync(
-  flavorBasePath +
-  "/static/css/+(*.ttf|*.otf|*.woff|*.woff2)"
-).concat(
-  glob.sync(
-    baseFontsDir +
-    "/static/css/+(*.ttf|*.otf|*.woff|*.woff2)"
-  )
-);
+const baseFontsDir = path.resolve(__dirname, "../src/base");
+let fontPaths = glob
+  .sync(flavorBasePath + "/static/css/+(*.ttf|*.otf|*.woff|*.woff2)")
+  .concat(
+    glob.sync(baseFontsDir + "/static/css/+(*.ttf|*.otf|*.woff|*.woff2)"),
+  );
 
-fontPaths.forEach((fontPath) => {
+fontPaths.forEach(fontPath => {
   try {
     fs.copySync(
       fontPath,
       path.resolve(
         outputBasePath,
         "static/css",
-        fontPath.split("/").slice(-1)[0]
-      )
+        fontPath.split("/").slice(-1)[0],
+      ),
     );
   } catch (e) {
     logError("Error copying font file: " + e);
@@ -480,14 +396,8 @@ fontPaths.forEach((fontPath) => {
 
 try {
   fs.copySync(
-    path.resolve(
-      __dirname,
-      "../src/base/static/libs"
-    ),
-    path.resolve(
-      outputBasePath,
-      "libs"
-    )
+    path.resolve(__dirname, "../src/base/static/libs"),
+    path.resolve(outputBasePath, "libs"),
   );
 } catch (e) {
   logError("Error copying flavor libs files: " + e);

--- a/src/base/static/components/form-fields/response-field.js
+++ b/src/base/static/components/form-fields/response-field.js
@@ -19,7 +19,7 @@ const getCheckboxLabels = (fieldValue, fieldConfig) => {
   }
 
   return fieldValue.map(
-    value => fieldConfig.content.find(option => option.value === value).label
+    value => fieldConfig.content.find(option => option.value === value).label,
   );
 };
 

--- a/src/base/static/components/form-fields/types/add-attachment-button.js
+++ b/src/base/static/components/form-fields/types/add-attachment-button.js
@@ -47,7 +47,7 @@ class AddAttachmentButton extends Component {
           maxWidth: 800,
           maxHeight: 800,
           canvas: true,
-        }
+        },
       );
     }
   }

--- a/src/base/static/components/form-fields/types/autocomplete-combobox-field.js
+++ b/src/base/static/components/form-fields/types/autocomplete-combobox-field.js
@@ -12,7 +12,7 @@ class AutocompleteComboboxField extends Component {
       const filteredResults = this.props.options
         .map(option => option.label)
         .filter(
-          result => result.toLowerCase().indexOf(query.toLowerCase()) !== -1
+          result => result.toLowerCase().indexOf(query.toLowerCase()) !== -1,
         );
       populateResults(filteredResults);
     };
@@ -39,7 +39,7 @@ class AutocompleteComboboxField extends Component {
           defaultValue={
             this.props.value
               ? this.props.options.find(
-                  option => option.value === this.props.value
+                  option => option.value === this.props.value,
                 ).label
               : ""
           }
@@ -62,7 +62,7 @@ AutocompleteComboboxField.propTypes = {
     PropTypes.shape({
       value: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
-    })
+    }),
   ).isRequired,
   placeholder: PropTypes.string,
   value: PropTypes.string,

--- a/src/base/static/components/form-fields/types/rich-textarea-field.js
+++ b/src/base/static/components/form-fields/types/rich-textarea-field.js
@@ -17,7 +17,7 @@ const Util = require("../../../js/utils.js");
 const extractVideoUrl = url => {
   let match =
     url.match(
-      /^(?:(https?):\/\/)?(?:(?:www|m)\.)?youtube\.com\/watch.*v=([a-zA-Z0-9_-]+)/
+      /^(?:(https?):\/\/)?(?:(?:www|m)\.)?youtube\.com\/watch.*v=([a-zA-Z0-9_-]+)/,
     ) ||
     url.match(/^(?:(https?):\/\/)?(?:(?:www|m)\.)?youtu\.be\/([a-zA-Z0-9_-]+)/);
   if (match) {
@@ -150,7 +150,7 @@ class RichTextareaField extends Component {
           editor.getSelection().index,
           "wrappedVideo",
           url,
-          "user"
+          "user",
         );
         this.snowTheme.tooltip.root.className += " ql-hidden";
       });
@@ -189,7 +189,7 @@ class RichTextareaField extends Component {
             editor.getSelection().index,
             "imageWithName",
             data,
-            "user"
+            "user",
           );
         },
         {
@@ -197,7 +197,7 @@ class RichTextareaField extends Component {
           maxWidth: 800,
           maxHeight: 800,
           canvas: true,
-        }
+        },
       );
     }
 
@@ -211,7 +211,7 @@ class RichTextareaField extends Component {
       }),
       quillFileInput: classNames(
         "rich-textarea-field__quill-file-input",
-        "rich-textarea-field__quill-file-input--hidden"
+        "rich-textarea-field__quill-file-input--hidden",
       ),
     };
 

--- a/src/base/static/components/form-fields/validators.js
+++ b/src/base/static/components/form-fields/validators.js
@@ -29,8 +29,8 @@ const isWithUniqueUrl = ({ value, places, modelId }) => {
       placeCollection.find(
         model =>
           model.get(constants.CUSTOM_URL_PROPERTY_NAME) === value &&
-          model.get(constants.MODEL_ID_PROPERTY_NAME) !== modelId
-      )
+          model.get(constants.MODEL_ID_PROPERTY_NAME) !== modelId,
+      ),
     )
   );
 };

--- a/src/base/static/components/input-explorer/index.js
+++ b/src/base/static/components/input-explorer/index.js
@@ -23,10 +23,10 @@ class InputExplorer extends Component {
     this.subcategoryNames = this.props.placeConfig
       .find(
         category =>
-          category.category === constants.COMMUNITY_INPUT_CATEGORY_NAME
+          category.category === constants.COMMUNITY_INPUT_CATEGORY_NAME,
       )
       .fields.find(
-        field => field.name === constants.INPUT_SUBCATEGORY_FIELDNAME
+        field => field.name === constants.INPUT_SUBCATEGORY_FIELDNAME,
       ).content;
 
     // Get unique input category names.
@@ -56,7 +56,7 @@ class InputExplorer extends Component {
     const { selectedCategory, selectedSubcategory } = this.state;
     const { communityInput, placeConfig } = this.props;
     const config = placeConfig.find(
-      category => category.category === constants.COMMUNITY_INPUT_CATEGORY_NAME
+      category => category.category === constants.COMMUNITY_INPUT_CATEGORY_NAME,
     );
     const isAdmin = Util.getAdminStatus(config.dataset, config.admin_groups);
     const communityInputToRender = communityInput
@@ -71,7 +71,7 @@ class InputExplorer extends Component {
         }
 
         let inputSubcategory = normalizeCheckboxData(
-          model.get(constants.INPUT_SUBCATEGORY_FIELDNAME)
+          model.get(constants.INPUT_SUBCATEGORY_FIELDNAME),
         );
 
         if (inputSubcategory.includes(selectedSubcategory)) {

--- a/src/base/static/components/input-explorer/input-explorer-input-item.js
+++ b/src/base/static/components/input-explorer/input-explorer-input-item.js
@@ -35,7 +35,7 @@ class InputExplorerInputItem extends Component {
           error: (model, response) => {
             console.error("Error saving sticky state:", response);
           },
-        }
+        },
       );
     }
 

--- a/src/base/static/components/input-explorer/input-explorer-input-list-header.js
+++ b/src/base/static/components/input-explorer/input-explorer-input-list-header.js
@@ -45,7 +45,7 @@ const InputExplorerInputListHeader = props => {
             {
               "input-explorer-input-list-header__label--active":
                 props.selectedSubcategory === subcategory.value,
-            }
+            },
           );
 
           return (

--- a/src/base/static/components/input-explorer/input-explorer-summary.js
+++ b/src/base/static/components/input-explorer/input-explorer-summary.js
@@ -37,7 +37,7 @@ const InputExplorerSummary = props => {
     });
 
     modelsFilteredBySubcategory = new Backbone.Collection(
-      modelsFilteredBySubcategory
+      modelsFilteredBySubcategory,
     );
     info.total = modelsFilteredBySubcategory.length;
     info.label = subcategory.label;
@@ -78,7 +78,8 @@ const InputExplorerSummary = props => {
             {numRecommendations + numConcerns} Community comments submitted
           </span>
           <span className="input-explorer-summary__num-recommendations">
-            {numRecommendations} {messages("inputExplorer:recommendationsLabel")}
+            {numRecommendations}{" "}
+            {messages("inputExplorer:recommendationsLabel")}
           </span>
           <span className="input-explorer-summary__num-concerns">
             {numConcerns} {messages("inputExplorer:concernsLabel")}

--- a/src/base/static/components/input-form/form-category-menu-wrapper.js
+++ b/src/base/static/components/input-form/form-category-menu-wrapper.js
@@ -27,7 +27,7 @@ class FormCategoryMenuWrapper extends Component {
   onCategoryChange(selectedCategory) {
     this.setState({
       selectedCategoryConfig: this.visibleCategoryConfigs.find(
-        config => config.category === selectedCategory
+        config => config.category === selectedCategory,
       ),
     });
   }
@@ -70,7 +70,7 @@ FormCategoryMenuWrapper.propTypes = {
         url: PropTypes.string.isRequired,
         attribution: PropTypes.string,
         type: PropTypes.string,
-      })
+      }),
     ),
   }),
   hideSpotlightMask: PropTypes.func.isRequired,
@@ -117,9 +117,9 @@ FormCategoryMenuWrapper.propTypes = {
             display_prompt: PropTypes.string,
             placeholder: PropTypes.string,
             optional: PropTypes.bool,
-          })
+          }),
         ),
-      })
+      }),
     ),
   }).isRequired,
 };

--- a/src/base/static/components/input-form/input-form-category-button.js
+++ b/src/base/static/components/input-form/input-form-category-button.js
@@ -20,7 +20,7 @@ const InputFormCategoryButton = props => {
       {
         "input-form-category-button__expand-categories-button--hidden":
           props.isSingleCategory || !props.isSelected,
-      }
+      },
     ),
   };
 

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -19,7 +19,7 @@ import { scrollTo } from "../../utils/scroll-helpers";
 
 const Util = require("../../js/utils.js");
 
-import { translate } from "react-i18next"
+import { translate } from "react-i18next";
 import "./index.scss";
 
 const serializeBackboneCollection = collection => {

--- a/src/base/static/components/place-detail/promotion-bar.js
+++ b/src/base/static/components/place-detail/promotion-bar.js
@@ -22,23 +22,21 @@ class PromotionBar extends Component {
             "USER",
             "place",
             "successfully-unsupport",
-            this.props.getLoggingDetails()
+            this.props.getLoggingDetails(),
           );
-          this.props.onModelIO(
-            constants.SUPPORT_MODEL_IO_END_SUCCESS_ACTION
-          );
+          this.props.onModelIO(constants.SUPPORT_MODEL_IO_END_SUCCESS_ACTION);
         },
         error: model => {
           this.props.onModelIO(
             constants.SUPPORT_MODEL_IO_END_ERROR_ACTION,
-            model.collection
+            model.collection,
           );
           alert("Oh dear. It looks like that didn't save.");
           Util.log(
             "USER",
             "place",
             "fail-to-unsupport",
-            this.props.getLoggingDetails()
+            this.props.getLoggingDetails(),
           );
         },
       });
@@ -57,13 +55,13 @@ class PromotionBar extends Component {
           success: model => {
             this.props.onModelIO(
               constants.SUPPORT_MODEL_IO_END_SUCCESS_ACTION,
-              model.collection
+              model.collection,
             );
             Util.log(
               "USER",
               "place",
               "successfully-support",
-              this.props.getLoggingDetails()
+              this.props.getLoggingDetails(),
             );
           },
           error: () => {
@@ -73,10 +71,10 @@ class PromotionBar extends Component {
               "USER",
               "place",
               "fail-to-support",
-              this.props.getLoggingDetails()
+              this.props.getLoggingDetails(),
             );
           },
-        }
+        },
       );
     }
   }

--- a/src/base/static/components/ui-elements/primary-button.js
+++ b/src/base/static/components/ui-elements/primary-button.js
@@ -8,7 +8,7 @@ const PrimaryButton = props => {
   const cn = classNames(
     "primary-button",
     "primary-button--hoverable",
-    props.className
+    props.className,
   );
 
   return (

--- a/src/base/static/js/models/place-model.js
+++ b/src/base/static/js/models/place-model.js
@@ -93,7 +93,7 @@ module.exports = Backbone.Model.extend({
     options.ignoreAttachments = true;
     options.beforeSend = function(xhr, options) {
       options.xhrFields = {
-        withCredentials: true
+        withCredentials: true,
       };
     };
     module.exports.__super__.save.call(this, attrs, options);

--- a/src/base/static/js/models/submission-collection.js
+++ b/src/base/static/js/models/submission-collection.js
@@ -26,7 +26,11 @@ module.exports = PaginatedCollection.extend({
     }
 
     return (
-      this.options.placeModel.collection.url + "/" + placeId + "/" + submissionType
+      this.options.placeModel.collection.url +
+      "/" +
+      placeId +
+      "/" +
+      submissionType
     );
   },
 

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -103,7 +103,7 @@ Shareabouts.Util = Util;
             this.clearLocationTypeFilter();
           }
         },
-        this
+        this,
       );
 
       this.loading = true;
@@ -271,7 +271,7 @@ Shareabouts.Util = Util;
       var $filterIndicator = $("#current-filter-type");
       if ($filterIndicator.length === 0) {
         $filterIndicator = $('<div id="current-filter-type"/>').insertAfter(
-          $(".menu-item-filter-type > a:first-child")
+          $(".menu-item-filter-type > a:first-child"),
         );
       }
 

--- a/src/base/static/js/template-helpers.js
+++ b/src/base/static/js/template-helpers.js
@@ -28,9 +28,9 @@ module.exports = {
   getItemsFromModel: function(configItems, model, exceptions) {
     // Filter out any items that will be handled specifically in the template
     var filteredConfigItems = _.filter(configItems, function(item) {
-      // Only include if it is not an exception
-      return _.indexOf(exceptions, item.name) === -1;
-    }),
+        // Only include if it is not an exception
+        return _.indexOf(exceptions, item.name) === -1;
+      }),
       items = [];
 
     // Normalize the list

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -413,14 +413,14 @@ var self = (module.exports = {
         if (field.type === "common_form_element") {
           Object.assign(
             args.fields[i],
-            args.commonFormElements[args.fields[i].name]
+            args.commonFormElements[args.fields[i].name],
           );
         }
 
         var fieldData = _.extend(
           {},
           args.fields[i],
-          self.buildFieldContent(field, args.model.get(field.name))
+          self.buildFieldContent(field, args.model.get(field.name)),
         );
 
         if (args.isEditingToggled && fieldIsValidForEditor(fieldData)) {
@@ -429,7 +429,7 @@ var self = (module.exports = {
           fields.push(fieldData);
         }
       },
-      this
+      this,
     );
 
     return fields;
@@ -552,7 +552,7 @@ var self = (module.exports = {
         measure = measures[secondArg];
         if (!measure) {
           this.console.error(
-            'No metrics or dimensions matching "' + secondArg + '"'
+            'No metrics or dimensions matching "' + secondArg + '"',
           );
           return;
         }
@@ -677,7 +677,7 @@ var self = (module.exports = {
           var rotated = self.fixImageOrientation(canvas, orientation);
           callback(rotated);
         },
-        options
+        options,
       );
     };
 
@@ -769,7 +769,7 @@ var self = (module.exports = {
           JSON.stringify({
             expires: expDate,
             value: value,
-          })
+          }),
         );
       } catch (e) {
         // ignore exceptions

--- a/src/base/static/js/views/auth-nav-view.js
+++ b/src/base/static/js/views/auth-nav-view.js
@@ -9,10 +9,10 @@ module.exports = Backbone.View.extend({
 
   render: function() {
     var data = {
-      currentUser: Shareabouts.bootstrapped.currentUser,
-      apiRoot: this.options.apiRoot
-    },
-    template = Handlebars.templates["auth-nav"](data);
+        currentUser: Shareabouts.bootstrapped.currentUser,
+        apiRoot: this.options.apiRoot,
+      },
+      template = Handlebars.templates["auth-nav"](data);
 
     this.$el.html(template);
 

--- a/src/base/static/js/views/filter-menu-view.js
+++ b/src/base/static/js/views/filter-menu-view.js
@@ -3,30 +3,30 @@
 module.exports = Backbone.View.extend({
   events: {
     "change .filter-menu-item": "onFilterChange",
-    "click #filter-menu-select-reset": "onFilterChange"
+    "click #filter-menu-select-reset": "onFilterChange",
   },
 
-  initialize () {
+  initialize() {
     let locationTypes = {},
-        locationTypeModel = Backbone.Model.extend({
-          defaults: {
-            locationType: "",
-            iconUrl: "",
-            active: false,
-            label: ""
-          }
-        });
+      locationTypeModel = Backbone.Model.extend({
+        defaults: {
+          locationType: "",
+          iconUrl: "",
+          active: false,
+          label: "",
+        },
+      });
 
     this.numActiveFilters = 0;
     this.state = new Backbone.Model({
-      filters: new Backbone.Collection([])
+      filters: new Backbone.Collection([]),
     });
 
-    this.getFilters().forEach((item) => {
+    this.getFilters().forEach(item => {
       let model = new locationTypeModel({
         locationType: item.category,
         iconUrl: item.icon_url,
-        label: item.label
+        label: item.label,
       });
       model.on("change", this.onFilterStateChange, this);
       this.state.get("filters").add(model);
@@ -35,17 +35,17 @@ module.exports = Backbone.View.extend({
     this.render();
   },
 
-  getFilters () {
-    return (this.options.panelConfig.active_filters)
+  getFilters() {
+    return this.options.panelConfig.active_filters
       ? this.options.panelConfig.active_filters
-      : this.options.placeConfig.place_detail
+      : this.options.placeConfig.place_detail;
   },
 
-  onFilterChange (evt) {
+  onFilterChange(evt) {
     let locationType = evt.currentTarget.dataset.locationtype;
 
     if (locationType === "reset") {
-      this.state.get("filters").each((model) => {
+      this.state.get("filters").each(model => {
         model.set("active", false);
       });
 
@@ -53,27 +53,31 @@ module.exports = Backbone.View.extend({
     } else {
       let model = this.state
         .get("filters")
-        .findWhere({locationType: locationType});
+        .findWhere({ locationType: locationType });
 
       model.set({
-        active: !model.get("active")
+        active: !model.get("active"),
       });
     }
   },
 
-  onFilterStateChange (locationTypeModel) {
-    let mapWasUnfiltered = (this.numActiveFilters === 0) ? true : false;
-    this.numActiveFilters += (locationTypeModel.get("active")) ? 1 : -1;
-    let mapWillBeUnfiltered = (this.numActiveFilters === 0) ? true : false;
+  onFilterStateChange(locationTypeModel) {
+    let mapWasUnfiltered = this.numActiveFilters === 0 ? true : false;
+    this.numActiveFilters += locationTypeModel.get("active") ? 1 : -1;
+    let mapWillBeUnfiltered = this.numActiveFilters === 0 ? true : false;
 
-    this.options.mapView.filter(locationTypeModel, mapWasUnfiltered, mapWillBeUnfiltered);
+    this.options.mapView.filter(
+      locationTypeModel,
+      mapWasUnfiltered,
+      mapWillBeUnfiltered,
+    );
   },
 
-  render () {
+  render() {
     let data = {
-      activeFilters: this.state.get("filters").toJSON()
+      activeFilters: this.state.get("filters").toJSON(),
     };
 
     this.$el.html(Handlebars.templates["filter-menu"](data));
-  }
+  },
 });

--- a/src/base/static/js/views/geocode-address-view.js
+++ b/src/base/static/js/views/geocode-address-view.js
@@ -13,7 +13,9 @@ module.exports = Backbone.View.extend({
   onAddressChange: function(evt) {
     // .hide().addClass('is-hidden') is a bit redundant, but the .hide
     // is so that we can do a fade-in effect.
-    this.$(".error").hide().addClass("is-hidden");
+    this.$(".error")
+      .hide()
+      .addClass("is-hidden");
   },
   onGeocodeAddress: function(evt) {
     evt.preventDefault();

--- a/src/base/static/js/views/gis-legend-view.js
+++ b/src/base/static/js/views/gis-legend-view.js
@@ -8,45 +8,58 @@ module.exports = Backbone.View.extend({
     "change .map-legend-basemap-radio": "toggleBasemap",
     "change .map-legend-checkbox": "toggleVisibility",
     "change .map-legend-grouping-checkbox": "toggleHeaderVisibility",
-    "click .info-icon": "onClickInfoIcon"
+    "click .info-icon": "onClickInfoIcon",
   },
 
   initialize: function() {
-    this.options.mapView.map.on("layer:loading", this.onLayerLoading.bind(this));
+    this.options.mapView.map.on(
+      "layer:loading",
+      this.onLayerLoading.bind(this),
+    );
     this.options.mapView.map.on("layer:loaded", this.onLayerLoaded.bind(this));
     this.options.mapView.map.on("layer:error", this.onLayerError.bind(this));
 
     this.hasScrolled = false;
     this.initialScrollPoint;
-    this.options.sidebarView.$("#gis-layers-pane")
+    this.options.sidebarView
+      .$("#gis-layers-pane")
       .off("scroll")
       .on("scroll", this.onLayersPaneScroll.bind(this));
   },
 
   onLayerLoading: function(data) {
-    this
-      .$("#map-" + data.id + "~.status-icon")
+    this.$("#map-" + data.id + "~.status-icon")
       .empty()
       .removeClass("error loaded");
 
     new Spinner({
-      lines: 8, length: 0, width: 2, radius: 4, corners: 1, rotate: 0,
-      direction: 1, color: '#000', speed: 1, trail: 60, shadow: false,
-      hwaccel: false, className: 'spinner', zIndex: 2e9, top: '2px',
-      left: '-13px'
+      lines: 8,
+      length: 0,
+      width: 2,
+      radius: 4,
+      corners: 1,
+      rotate: 0,
+      direction: 1,
+      color: "#000",
+      speed: 1,
+      trail: 60,
+      shadow: false,
+      hwaccel: false,
+      className: "spinner",
+      zIndex: 2e9,
+      top: "2px",
+      left: "-13px",
     }).spin(this.$("#map-" + data.id + "~.status-icon")[0]);
   },
 
   onLayerLoaded: function(data) {
-    this
-      .$("#map-" + data.id + "~.status-icon")
+    this.$("#map-" + data.id + "~.status-icon")
       .empty()
       .addClass("loaded");
   },
 
   onLayerError: function(data) {
-    this
-      .$("#map-" + data.id + "~.status-icon")
+    this.$("#map-" + data.id + "~.status-icon")
       .empty()
       .addClass("error");
   },
@@ -55,7 +68,10 @@ module.exports = Backbone.View.extend({
     if (!this.hasScrolled) {
       this.hasScrolled = true;
       this.initialScrollPoint = evt.currentTarget.scrollTop;
-    } else if (Math.abs(this.initialScrollPoint - evt.currentTarget.scrollTop) > INFO_WINDOW_SCROLL_HIDE_THRESHOLD) {
+    } else if (
+      Math.abs(this.initialScrollPoint - evt.currentTarget.scrollTop) >
+      INFO_WINDOW_SCROLL_HIDE_THRESHOLD
+    ) {
       this.layerInfoWindowView && this.layerInfoWindowView.hide();
     }
   },
@@ -151,16 +167,22 @@ module.exports = Backbone.View.extend({
     if (!this.layerInfoWindowView) {
       this.layerInfoWindowView = new LayerInfoWindowView({
         el: "#layer-info-window-container",
-        sidebar: this.options.sidebar
+        sidebar: this.options.sidebar,
       });
     }
 
     this.layerInfoWindowView.setState({
       title: $currentTarget.data("info-title"),
       body: $currentTarget.data("info-content"),
-      left: $currentTarget.parent().offset().left + evt.currentTarget.offsetLeft + INFO_WINDOW_LEFT_OFFSET_ADJUST,
-      top: $currentTarget.parent().offset().top + evt.currentTarget.offsetTop + INFO_WINDOW_TOP_OFFSET_ADJUST,
-      lastActiveInfoWindowId: $currentTarget.data("layerid")
+      left:
+        $currentTarget.parent().offset().left +
+        evt.currentTarget.offsetLeft +
+        INFO_WINDOW_LEFT_OFFSET_ADJUST,
+      top:
+        $currentTarget.parent().offset().top +
+        evt.currentTarget.offsetTop +
+        INFO_WINDOW_TOP_OFFSET_ADJUST,
+      lastActiveInfoWindowId: $currentTarget.data("layerid"),
     });
-  }
+  },
 });

--- a/src/base/static/js/views/layer-info-window-view.js
+++ b/src/base/static/js/views/layer-info-window-view.js
@@ -12,7 +12,7 @@ module.exports = Backbone.View.extend({
       top: 0,
       left: 0,
       isVisible: false,
-      lastActiveInfoWindowId: null
+      lastActiveInfoWindowId: null,
     });
 
     this.options.sidebar.on("closing", this.hide, this);
@@ -23,8 +23,11 @@ module.exports = Backbone.View.extend({
   },
 
   setState: function(content = {}) {
-    if (!content.lastActiveInfoWindowId
-        || content.lastActiveInfoWindowId !== this.state.get("lastActiveInfoWindowId")) {
+    if (
+      !content.lastActiveInfoWindowId ||
+      content.lastActiveInfoWindowId !==
+        this.state.get("lastActiveInfoWindowId")
+    ) {
       this.state.set("isVisible", true);
     } else {
       this.state.set("isVisible", !this.state.get("isVisible"));
@@ -43,7 +46,7 @@ module.exports = Backbone.View.extend({
   },
 
   onVisibilityChange: function() {
-    (this.state.get("isVisible"))
+    this.state.get("isVisible")
       ? this.$el.removeClass("is-hidden-fadeout")
       : this.$el.addClass("is-hidden-fadeout");
   },
@@ -51,14 +54,12 @@ module.exports = Backbone.View.extend({
   render: function() {
     let data = {
       title: this.state.get("title"),
-      body: this.state.get("body")
+      body: this.state.get("body"),
     };
 
-    this.$el
-      .html(Handlebars.templates["layer-info-window"](data))
-      .css({
-        top: this.state.get("top") - (this.$el.height() / 2),
-        left: this.state.get("left")
-      });
-  }
+    this.$el.html(Handlebars.templates["layer-info-window"](data)).css({
+      top: this.state.get("top") - this.$el.height() / 2,
+      left: this.state.get("left"),
+    });
+  },
 });

--- a/src/base/static/js/views/layer-view.js
+++ b/src/base/static/js/views/layer-view.js
@@ -7,7 +7,7 @@ module.exports = Backbone.View.extend({
     this.isFocused = false;
     this.isEditing = false;
     this.layerIsAdminControlled = Util.getAdminStatus(
-      this.model.get("datasetId")
+      this.model.get("datasetId"),
     );
     this.throttledRender = _.throttle(this.render, 300);
     this.layerGroup = this.options.layerGroup;
@@ -23,7 +23,7 @@ module.exports = Backbone.View.extend({
         this.createLayer();
         this.render();
       },
-      this
+      this,
     );
     this.model.on("focus", this.focus, this);
     this.model.on("unfocus", this.unfocus, this);
@@ -54,7 +54,7 @@ module.exports = Backbone.View.extend({
                 _.each(prop, function(styleProp, stylePropKey) {
                   if (_.isString(styleProp) && styleProp.startsWith("this.")) {
                     prop[stylePropKey] = new Function(
-                      ["return ", styleProp, ";"].join("")
+                      ["return ", styleProp, ";"].join(""),
                     );
                   } else {
                     prop[stylePropKey] = styleProp;
@@ -66,12 +66,12 @@ module.exports = Backbone.View.extend({
                 fn.props[key] = prop;
               }
             },
-            this
+            this,
           );
 
           this.styleRules.push(fn);
         },
-        this
+        this,
       );
 
       if (this.placeType.hasOwnProperty("zoomType")) {
@@ -89,12 +89,12 @@ module.exports = Backbone.View.extend({
                   fn.props[key] = prop;
                 }
               },
-              this
+              this,
             );
 
             this.zoomRules.push(fn);
           },
-          this
+          this,
         );
       }
     }
@@ -118,7 +118,7 @@ module.exports = Backbone.View.extend({
         {},
         this.model.toJSON(),
         { map: { zoom: this.map.getZoom() } },
-        { layer: { focused: this.isFocused } }
+        { layer: { focused: this.isFocused } },
       );
 
     for (var i = 0; i < this.styleRules.length; i++) {
@@ -135,7 +135,7 @@ module.exports = Backbone.View.extend({
                 ? rule.apply(styleRuleContext)
                 : rule;
             },
-            this
+            this,
           );
         }
 
@@ -169,7 +169,7 @@ module.exports = Backbone.View.extend({
       console.warn(
         "Place type",
         this.model.get("location_type"),
-        "is not configured so it will not appear on the map."
+        "is not configured so it will not appear on the map.",
       );
       return;
     }
@@ -257,7 +257,7 @@ module.exports = Backbone.View.extend({
       "USER",
       "map",
       "place-marker-click",
-      this.model.getLoggingDetails()
+      this.model.getLoggingDetails(),
     );
     // support places with landmark-style urls
     if (this.model.get("url-title")) {
@@ -267,7 +267,7 @@ module.exports = Backbone.View.extend({
     } else {
       this.options.router.navigate(
         "/" + this.model.get("datasetSlug") + "/" + this.model.id,
-        { trigger: true }
+        { trigger: true },
       );
     }
   },

--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -18,7 +18,7 @@ module.exports = Backbone.View.extend({
           "map",
           "zoom",
           self.map.getBounds().toBBoxString(),
-          self.map.getZoom()
+          self.map.getZoom(),
         );
       },
       logUserPan = function(evt) {
@@ -27,7 +27,7 @@ module.exports = Backbone.View.extend({
           "map",
           "drag",
           self.map.getBounds().toBBoxString(),
-          self.map.getZoom()
+          self.map.getZoom(),
         );
       };
 
@@ -211,7 +211,7 @@ module.exports = Backbone.View.extend({
     this.$(".leaflet-top.leaflet-right").append(
       '<div class="leaflet-control leaflet-bar">' +
         '<a href="#" class="locate-me"></a>' +
-        "</div>"
+        "</div>",
     );
 
     // Bind event handling
@@ -230,7 +230,7 @@ module.exports = Backbone.View.extend({
       "map",
       "geolocate",
       this.map.getBounds().toBBoxString(),
-      this.map.getZoom()
+      this.map.getZoom(),
     );
     this.geolocate();
   },
@@ -276,18 +276,18 @@ module.exports = Backbone.View.extend({
       this.map.off(
         "zoomend",
         this.layerViews[collectionId][model.cid].updateLayer,
-        this.layerViews[collectionId][model.cid]
+        this.layerViews[collectionId][model.cid],
       );
       this.map.off(
         "move",
         this.layerViews[collectionId][model.cid].throttledRender,
-        this.layerViews[collectionId][model.cid]
+        this.layerViews[collectionId][model.cid],
       );
       this.map.off(
         "zoomend",
         this.layerViews[collectionId][model.cid].render,
-        this.layerViews[collectionId][model.cid]
-      )
+        this.layerViews[collectionId][model.cid],
+      );
 
       this.layerViews[collectionId][model.cid].remove();
       delete this.layerViews[collectionId][model.cid];
@@ -362,7 +362,7 @@ module.exports = Backbone.View.extend({
 
   getLayerGroups: function(collectionId) {
     if (this.isClusterable(collectionId)) {
-      return L.markerClusterGroup(this.options.cluster)
+      return L.markerClusterGroup(this.options.cluster);
     } else {
       return L.layerGroup();
     }
@@ -487,31 +487,32 @@ module.exports = Backbone.View.extend({
           Util.log("Cartodb layer creation error:", err);
         });
     } else if (config.type && config.type === "wmts") {
-      layer = L.tileLayer.wmts(config.url, {
-        service: "WMTS",
-        tilematrixSet: config.tilematrixSet,
-        layers: config.layers,
-        format: config.format,
-        transparent: config.transparent,
-        version: config.version,
-        crs: L.CRS.EPSG3857,
-        // default TileLayer options
-        attribution: config.attribution,
-        opacity: config.opacity,
-        fillColor: config.color,
-        weight: config.weight,
-        fillOpacity: config.fillOpacity,
-        style: config.style,
-      })
-      .on("loading", function() {
-        self.map.fire("layer:loading", {id: config.id});
-      })
-      .on("load", function() {
-        self.map.fire("layer:loaded", {id: config.id});
-      })
-      .on("tileerror", function() {
-        self.map.fire("layer:error", {id: config.id});
-      });
+      layer = L.tileLayer
+        .wmts(config.url, {
+          service: "WMTS",
+          tilematrixSet: config.tilematrixSet,
+          layers: config.layers,
+          format: config.format,
+          transparent: config.transparent,
+          version: config.version,
+          crs: L.CRS.EPSG3857,
+          // default TileLayer options
+          attribution: config.attribution,
+          opacity: config.opacity,
+          fillColor: config.color,
+          weight: config.weight,
+          fillOpacity: config.fillOpacity,
+          style: config.style,
+        })
+        .on("loading", function() {
+          self.map.fire("layer:loading", { id: config.id });
+        })
+        .on("load", function() {
+          self.map.fire("layer:loaded", { id: config.id });
+        })
+        .on("tileerror", function() {
+          self.map.fire("layer:error", { id: config.id });
+        });
       self.layers[config.id] = layer;
     } else if (config.layers) {
       // If "layers" is present, then we assume that the config

--- a/src/base/static/js/views/pages-nav-view.js
+++ b/src/base/static/js/views/pages-nav-view.js
@@ -13,11 +13,11 @@ module.exports = Backbone.View.extend({
       return obj["hide_from_top_bar"] !== true;
     });
     var data = {
-      pages: navPageConfig,
-      has_pages: navPageConfig.length > 0,
-      show_list_button_label: this.options.placeConfig.show_list_button_label,
-      show_map_button_label: this.options.placeConfig.show_map_button_label,
-    },
+        pages: navPageConfig,
+        has_pages: navPageConfig.length > 0,
+        show_list_button_label: this.options.placeConfig.show_list_button_label,
+        show_map_button_label: this.options.placeConfig.show_map_button_label,
+      },
       template = Handlebars.templates["pages-nav"](data);
     this.$el.html(template);
 

--- a/src/base/static/js/views/place-detail-view.js
+++ b/src/base/static/js/views/place-detail-view.js
@@ -29,7 +29,7 @@ module.exports = Backbone.View.extend({
     });
     this.isEditable = Util.getAdminStatus(
       this.options.datasetId,
-      this.categoryConfig.admin_groups
+      this.categoryConfig.admin_groups,
     );
     this.isEditingToggled = false;
     this.surveyType = this.options.surveyConfig.submission_type;
@@ -86,7 +86,7 @@ module.exports = Backbone.View.extend({
     this.model.attachmentCollection.on(
       "add",
       this.onAddAttachmentWrapper,
-      this
+      this,
     );
 
     this.$el.on("click", ".share-link a", function(evt) {
@@ -125,7 +125,7 @@ module.exports = Backbone.View.extend({
   onAddAttachmentWrapper: function(attachment) {
     this.onAddAttachmentCallback.call(
       this.onAddAttachmentCallbackContext,
-      attachment
+      attachment,
     );
   },
 
@@ -233,7 +233,7 @@ module.exports = Backbone.View.extend({
           fields: this.fields,
           suppressAttachments: this.categoryConfig.suppressAttachments,
         },
-        this.model.toJSON()
+        this.model.toJSON(),
       );
 
     this.options.router.on("route", this.tearDown, this);
@@ -266,7 +266,7 @@ module.exports = Backbone.View.extend({
     if (this.isEditingToggled) {
       $("#toggle-editor-btn").addClass("btn-depressed");
       $(
-        ".promotion, .place-submission-details, .survey-header, .reply-link, .response-header"
+        ".promotion, .place-submission-details, .survey-header, .reply-link, .response-header",
       ).addClass("faded");
 
       // detect changes made to non-Quill form elements
@@ -369,7 +369,7 @@ module.exports = Backbone.View.extend({
     var attrs = _.extend(
       Util.getAttrs($("#update-place-model-form")),
       Util.getAttrs($("#update-place-model-title-form")),
-      richTextAttrs
+      richTextAttrs,
     );
 
     // Special handling for binary toggle buttons: we need to remove
@@ -392,7 +392,7 @@ module.exports = Backbone.View.extend({
           self.model.unset(
             $(this)
               .find(":first-child")
-              .attr("name")
+              .attr("name"),
           );
         }
       });
@@ -457,7 +457,7 @@ module.exports = Backbone.View.extend({
     var self = this;
     if (
       confirm(
-        "Are you sure you want to remove this post? It will no longer be visible on the map."
+        "Are you sure you want to remove this post? It will no longer be visible on the map.",
       )
     ) {
       if (this.geometryEnabled) {
@@ -470,7 +470,7 @@ module.exports = Backbone.View.extend({
           success: function() {
             self.model.trigger("userHideModel", self.model);
           },
-        }
+        },
       );
     }
   },

--- a/src/base/static/js/views/place-list-view.js
+++ b/src/base/static/js/views/place-list-view.js
@@ -11,7 +11,7 @@ var PlaceCollection = require("../models/place-collection.js");
 
 // Handlebars support for Marionette
 Backbone.Marionette.TemplateCache.prototype.compileTemplate = function(
-  rawTemplate
+  rawTemplate,
 ) {
   return Handlebars.compile(rawTemplate);
 };
@@ -55,7 +55,7 @@ var PlaceListItemView = Backbone.Marionette.Layout.extend({
           fields: fields,
           suppressAttachments: categoryConfig.suppressAttachments,
         },
-        this.model.toJSON()
+        this.model.toJSON(),
       );
 
     // Prep embedded rich text images for render.
@@ -69,7 +69,7 @@ var PlaceListItemView = Backbone.Marionette.Layout.extend({
         if (field.type === constants.RICH_TEXTAREA_FIELD_TYPENAME) {
           field.content = insertEmbeddedImages(
             field.content,
-            serializedAttachments
+            serializedAttachments,
           );
         }
       });
@@ -223,7 +223,7 @@ module.exports = Backbone.Marionette.CompositeView.extend({
       this.applyFilters(
         this.collectionFilters,
         this.searchTerm,
-        this.numItemsShown
+        this.numItemsShown,
       );
     }
   },
@@ -326,7 +326,7 @@ module.exports = Backbone.Marionette.CompositeView.extend({
     this.applyFilters(
       this.collectionFilters,
       this.searchTerm,
-      this.numItemsShown
+      this.numItemsShown,
     );
   },
   filter: function(filters) {
@@ -334,7 +334,7 @@ module.exports = Backbone.Marionette.CompositeView.extend({
     this.applyFilters(
       this.collectionFilters,
       this.searchTerm,
-      this.numItemsShown
+      this.numItemsShown,
     );
   },
   search: function(term) {
@@ -342,7 +342,7 @@ module.exports = Backbone.Marionette.CompositeView.extend({
     this.applyFilters(
       this.collectionFilters,
       this.searchTerm,
-      this.numItemsShown
+      this.numItemsShown,
     );
   },
   applyFilters: function(filters, term, max) {
@@ -364,7 +364,7 @@ module.exports = Backbone.Marionette.CompositeView.extend({
       var submitter,
         locationType = model.get("location_type"),
         placeConfig = _.find(Shareabouts.Config.place.place_detail, function(
-          config
+          config,
         ) {
           return config.category === locationType;
         });

--- a/src/base/static/js/views/sidebar-view.js
+++ b/src/base/static/js/views/sidebar-view.js
@@ -49,7 +49,7 @@ module.exports = Backbone.View.extend({
           }).render();
         }
       },
-      this
+      this,
     );
 
     self.sidebar.addTo(this.options.mapView);

--- a/src/base/static/utils/embedded-images.js
+++ b/src/base/static/utils/embedded-images.js
@@ -6,7 +6,7 @@ const insertEmbeddedImages = (html, attachmentModels) => {
     .filter(
       attributes =>
         attributes.get(constants.ATTACHMENT_TYPE_PROPERTY_NAME) ===
-        constants.RICH_TEXT_IMAGE_CODE
+        constants.RICH_TEXT_IMAGE_CODE,
     )
     .reduce((images, attributes) => {
       images[
@@ -18,7 +18,7 @@ const insertEmbeddedImages = (html, attachmentModels) => {
     constants.RICH_TEXT_IMAGE_MARKUP_PREFIX +
       "(.*?)" +
       constants.RICH_TEXT_IMAGE_MARKUP_SUFFIX,
-    "g"
+    "g",
   );
 
   return (

--- a/src/base/static/utils/field-response-filter.js
+++ b/src/base/static/utils/field-response-filter.js
@@ -16,7 +16,7 @@ export default (fieldList, backboneModelAttributes) =>
           constants.TITLE_PROPERTY_NAME,
           "submitter_name",
           "name",
-        ].includes(fieldConfig.name)
+        ].includes(fieldConfig.name),
     )
     .filter(fieldConfig => fieldConfig.name.indexOf("private-") !== 0)
     .filter(fieldConfig => !!backboneModelAttributes.get(fieldConfig.name));

--- a/src/flavors/augusta/static/js/views/app-view.js
+++ b/src/flavors/augusta/static/js/views/app-view.js
@@ -44,7 +44,7 @@ module.exports = AppView.extend({
           return Object.assign(
             {},
             this.options.placeConfig.common_form_elements[field.name],
-            { name: field.name }
+            { name: field.name },
           );
         } else {
           return field;
@@ -99,7 +99,7 @@ module.exports = AppView.extend({
     if (this.options.activityConfig.show_in_right_panel === true) {
       $("body").addClass("right-sidebar-visible");
       $("#right-sidebar-container").html(
-        "<ul class='recent-points unstyled-list'></ul>"
+        "<ul class='recent-points unstyled-list'></ul>",
       );
     }
 
@@ -157,7 +157,7 @@ module.exports = AppView.extend({
           this.hideListView();
         }
       },
-      this
+      this,
     );
 
     // Only append the tools to add places (if supported)
@@ -165,7 +165,7 @@ module.exports = AppView.extend({
     // NOTE: append add place/story buttons after the #map-container
     // div (rather than inside of it) in order to support bottom-clinging buttons
     $("#map-container").after(
-      Handlebars.templates["add-places"](this.options.placeConfig)
+      Handlebars.templates["add-places"](this.options.placeConfig),
     );
 
     this.pagesNavView = new PagesNavView({
@@ -182,7 +182,7 @@ module.exports = AppView.extend({
     }).render();
 
     this.basemapConfigs = _.find(this.options.sidebarConfig.panels, function(
-      panel
+      panel,
     ) {
       return "basemaps" in panel;
     }).basemaps;
@@ -216,7 +216,7 @@ module.exports = AppView.extend({
       this.$(".leaflet-top.leaflet-right").append(
         '<div class="leaflet-control leaflet-bar">' +
           '<a href="#" class="show-layer-panel"></a>' +
-          "</div>"
+          "</div>",
       );
       // END FLAVOR-SPECIFIC CODE
 
@@ -224,7 +224,7 @@ module.exports = AppView.extend({
       this.$(".leaflet-top.leaflet-right").append(
         '<div class="leaflet-control leaflet-bar">' +
           '<a href="#" class="show-legend-panel"></a>' +
-          "</div>"
+          "</div>",
       );
       // END FLAVOR-SPECIFIC CODE
     }
@@ -301,11 +301,11 @@ module.exports = AppView.extend({
     // is enabled.
     $(Shareabouts).on("reversegeocode", function(evt, locationData) {
       var locationString = Handlebars.templates["location-string"](
-        locationData
+        locationData,
       );
       self.geocodeAddressView.setAddress($.trim(locationString));
       self.placeFormView.geocodeAddressPlaceView.setAddress(
-        $.trim(locationString)
+        $.trim(locationString),
       );
       self.placeFormView.setLatLng(locationData.latLng);
       // Don't pass location data into our geolocation's form field
@@ -437,7 +437,7 @@ module.exports = AppView.extend({
         placeConfig={this.options.placeConfig.place_detail}
         communityInput={this.places["augusta-input"]}
       />,
-      document.querySelector("#list-container")
+      document.querySelector("#list-container"),
     );
   },
   // END FLAVOR-SPECIFIC CODE

--- a/src/flavors/augusta/static/js/views/gis-legend-view.js
+++ b/src/flavors/augusta/static/js/views/gis-legend-view.js
@@ -1,7 +1,6 @@
 const GISLegendView = require("../../../../../base/static/js/views/gis-legend-view.js");
 
 module.exports = GISLegendView.extend({
-
   events: {
     "change .map-legend-basemap-radio": "toggleBasemap",
     "change .map-legend-checkbox": "toggleVisibility",
@@ -10,13 +9,17 @@ module.exports = GISLegendView.extend({
   },
 
   initialize: function() {
-    this.options.mapView.map.on("layer:loading", this.onLayerLoading.bind(this));
+    this.options.mapView.map.on(
+      "layer:loading",
+      this.onLayerLoading.bind(this),
+    );
     this.options.mapView.map.on("layer:loaded", this.onLayerLoaded.bind(this));
     this.options.mapView.map.on("layer:error", this.onLayerError.bind(this));
 
     this.hasScrolled = false;
     this.initialScrollPoint;
-    this.options.sidebarView.$("#gis-layers-pane")
+    this.options.sidebarView
+      .$("#gis-layers-pane")
       .off("scroll")
       .on("scroll", this.onLayersPaneScroll.bind(this));
 
@@ -50,5 +53,5 @@ module.exports = GISLegendView.extend({
 
   render: function() {
     return this;
-  }
+  },
 });

--- a/src/flavors/augusta/static/js/views/legend-view.js
+++ b/src/flavors/augusta/static/js/views/legend-view.js
@@ -1,7 +1,6 @@
 const LegendView = require("../../../../../base/static/js/views/legend-view.js");
 
 module.exports = LegendView.extend({
-
   render: function() {
     this.$el.html(Handlebars.templates["legend"]());
     return this;

--- a/src/flavors/augusta/static/js/views/sidebar-view.js
+++ b/src/flavors/augusta/static/js/views/sidebar-view.js
@@ -3,19 +3,20 @@ const GISLegendView = require("mapseed-gis-legend-view");
 const LegendView = require("mapseed-legend-view");
 
 module.exports = SidebarView.extend({
-
   // BEGIN FLAVOR-SPECIFIC CODE
   events: {
-    "click .sidebar-panel__close-panel": "onCloseLayerPanel"
+    "click .sidebar-panel__close-panel": "onCloseLayerPanel",
   },
 
   initialize: function() {
     this.$el.append("<div id='map-legend'></div>");
     this.$el.append("<div id='gis-legend'></div>");
 
-    this.$("#gis-legend").html(Handlebars.templates["sidebar"]({
-      sidebarConfig: this.options.sidebarConfig.panels[0],
-    }));
+    this.$("#gis-legend").html(
+      Handlebars.templates["sidebar"]({
+        sidebarConfig: this.options.sidebarConfig.panels[0],
+      }),
+    );
 
     this.$("#map-legend").html(Handlebars.templates["legend"]());
 
@@ -37,7 +38,7 @@ module.exports = SidebarView.extend({
 
   onCloseLayerPanel: function() {
     this.$el.removeClass("sidebar-container--visible");
-    this.$el.addClass("sidebar-container--hidden")
+    this.$el.addClass("sidebar-container--hidden");
     if ($("#main-btns-container").hasClass("pos-top-left")) {
       $("#main-btns-container").toggleClass("main-btns-container--offset-left");
     }

--- a/src/flavors/central-puget-sound/static/js/views/map-view.js
+++ b/src/flavors/central-puget-sound/static/js/views/map-view.js
@@ -2,7 +2,7 @@ let MapView = require("../../../../../base/static/js/views/map-view.js");
 const MAX_LOCATION_TYPES = 8;
 const Y_JITTER_RANGE = [[-20, -80], [20, 80]];
 const X_JITTER_RANGE = [[-20, -80], [20, 80]];
-const TWO_PI = 2*Math.PI;
+const TWO_PI = 2 * Math.PI;
 
 module.exports = MapView.extend({
   getLayerGroups: function() {
@@ -26,13 +26,16 @@ module.exports = MapView.extend({
       // }
 
       Object.assign(this.options.cluster, {
-        maxClusterRadius: (zoom) => {
-          return (zoom >= 16) ? 40 : 110;
+        maxClusterRadius: zoom => {
+          return zoom >= 16 ? 40 : 110;
         },
-        iconCreateFunction: (cluster) => {
+        iconCreateFunction: cluster => {
           return L.divIcon({
             className: "",
-            html: "<div class='cluster-child-counter cluster-group'>" + cluster.getChildCount() + "</div>"
+            html:
+              "<div class='cluster-child-counter cluster-group'>" +
+              cluster.getChildCount() +
+              "</div>",
           });
 
           // NOTE: the clustering strategy is as follows:
@@ -70,14 +73,14 @@ module.exports = MapView.extend({
           //     html += [
           //       "<div class='cluster-subgroup-container' style='left: ",
           //       Math.sin(i*(TWO_PI/(numClusterSubGroups))) * (jitters[i][0]),
-          //       "px; top: ", 
+          //       "px; top: ",
           //       Math.cos(i*(TWO_PI/(numClusterSubGroups))) * (jitters[i][1]),
           //       "px'><img class='custom-cluster-icon' src='",
           //       clusterSubGroups[x].iconUrl,
           //       "' /><div class='cluster-child-counter top-right",
           //       ((clusterSubGroups[x].count === 1) ? " is-hidden" : "" ),
-          //       "'>", 
-          //       clusterSubGroups[x].count, 
+          //       "'>",
+          //       clusterSubGroups[x].count,
           //       "</div></div>"
           //     ].join("");
 
@@ -94,10 +97,10 @@ module.exports = MapView.extend({
           //     html: "<div class='cluster-child-counter cluster-group'>" + cluster.getChildCount() + "</div>"
           //   });
           // }
-        }
+        },
       });
     }
 
     return L.markerClusterGroup(this.options.cluster);
-  }
+  },
 });

--- a/src/flavors/central-puget-sound/static/js/views/pages-nav-view.js
+++ b/src/flavors/central-puget-sound/static/js/views/pages-nav-view.js
@@ -1,38 +1,34 @@
 var PagesNavView = require("../../../../../base/static/js/views/pages-nav-view.js");
 
 module.exports = PagesNavView.extend({
-
   render: function() {
     var navPageConfig = this.options.pagesConfig || [],
-
-        // Begin flavor-specific code
-        rightNavPageConfig = navPageConfig.filter(function(obj, i) {
-          return obj["pull_right"] === true;
-        });
-        // End flavor-specific code
+      // Begin flavor-specific code
+      rightNavPageConfig = navPageConfig.filter(function(obj, i) {
+        return obj["pull_right"] === true;
+      });
+    // End flavor-specific code
 
     navPageConfig = navPageConfig.filter(function(obj) {
-
       // Begin flavor-specific code
       return obj["hide_from_top_bar"] !== true && obj["pull_right"] !== true;
       // End flavor-specific code
     });
 
     var data = {
-      pages: navPageConfig,
-      has_pages: navPageConfig.length > 0,
-      show_list_button_label: this.options.placeConfig.show_list_button_label,
-      show_map_button_label: this.options.placeConfig.show_map_button_label,
+        pages: navPageConfig,
+        has_pages: navPageConfig.length > 0,
+        show_list_button_label: this.options.placeConfig.show_list_button_label,
+        show_map_button_label: this.options.placeConfig.show_map_button_label,
 
-      // Begin flavor-specific code
-      add_button_label: this.options.placeConfig.add_button_label,
-      pagesRight: rightNavPageConfig
-      // End flavor-specific code
-    },
+        // Begin flavor-specific code
+        add_button_label: this.options.placeConfig.add_button_label,
+        pagesRight: rightNavPageConfig,
+        // End flavor-specific code
+      },
       template = Handlebars.templates["pages-nav"](data);
     this.$el.html(template);
 
     return this;
-  }
-
+  },
 });

--- a/src/flavors/greensboropb/static/js/views/layer-view.js
+++ b/src/flavors/greensboropb/static/js/views/layer-view.js
@@ -1,19 +1,17 @@
 var LayerView = require("../../../../../base/static/js/views/layer-view.js");
 var originalOnMarkerClick = LayerView.prototype.onMarkerClick;
 
-module.exports = LayerView.extend(
-  {
-    // onMarkerClick: function(evt) {
-    //   var self = this;
-    //   originalOnMarkerClick.apply(this, arguments);
-    //   if (this.map.getZoom() < this.map.getMaxZoom()-3) {
-    //     _.delay(function() {
-    //       self.map.setView(evt.latlng, self.map.getMaxZoom()-3, {
-    //         animate: true
-    //       });
-    //       self.map.invalidateSize({ animate:false, pan:false });
-    //     }, 200);
-    //   }
-    // }
-  },
-);
+module.exports = LayerView.extend({
+  // onMarkerClick: function(evt) {
+  //   var self = this;
+  //   originalOnMarkerClick.apply(this, arguments);
+  //   if (this.map.getZoom() < this.map.getMaxZoom()-3) {
+  //     _.delay(function() {
+  //       self.map.setView(evt.latlng, self.map.getMaxZoom()-3, {
+  //         animate: true
+  //       });
+  //       self.map.invalidateSize({ animate:false, pan:false });
+  //     }, 200);
+  //   }
+  // }
+});

--- a/src/flavors/greensboropb/static/js/views/sidebar-view.js
+++ b/src/flavors/greensboropb/static/js/views/sidebar-view.js
@@ -44,7 +44,7 @@ module.exports = SidebarView.extend({
           config: panelConfig,
           sidebar: self.sidebar,
           placeConfig: self.options.placeConfig,
-          sidebarView: self
+          sidebarView: self,
         }).render();
       }
     });

--- a/src/flavors/hull/static/js/views/app-view.js
+++ b/src/flavors/hull/static/js/views/app-view.js
@@ -45,7 +45,7 @@ module.exports = AppView.extend({
           return Object.assign(
             {},
             this.options.placeConfig.common_form_elements[field.name],
-            { name: field.name }
+            { name: field.name },
           );
         } else {
           return field;
@@ -57,7 +57,7 @@ module.exports = AppView.extend({
 
     // store promises returned from collection fetches
     Shareabouts.deferredCollections = [];
-    
+
     languageModule.changeLanguage(this.options.languageCode);
 
     var self = this,
@@ -100,7 +100,7 @@ module.exports = AppView.extend({
     if (this.options.activityConfig.show_in_right_panel === true) {
       $("body").addClass("right-sidebar-visible");
       $("#right-sidebar-container").html(
-        "<ul class='recent-points unstyled-list'></ul>"
+        "<ul class='recent-points unstyled-list'></ul>",
       );
     }
 
@@ -158,7 +158,7 @@ module.exports = AppView.extend({
           this.hideListView();
         }
       },
-      this
+      this,
     );
 
     // Only append the tools to add places (if supported)
@@ -166,7 +166,7 @@ module.exports = AppView.extend({
     // NOTE: append add place/story buttons after the #map-container
     // div (rather than inside of it) in order to support bottom-clinging buttons
     $("#map-container").after(
-      Handlebars.templates["add-places"](this.options.placeConfig)
+      Handlebars.templates["add-places"](this.options.placeConfig),
     );
 
     this.pagesNavView = new PagesNavView({
@@ -183,7 +183,7 @@ module.exports = AppView.extend({
     }).render();
 
     this.basemapConfigs = _.find(this.options.sidebarConfig.panels, function(
-      panel
+      panel,
     ) {
       return "basemaps" in panel;
     }).basemaps;
@@ -217,7 +217,7 @@ module.exports = AppView.extend({
       this.$(".leaflet-top.leaflet-right").append(
         '<div class="leaflet-control leaflet-bar">' +
           '<a href="#" class="show-layer-panel"></a>' +
-          "</div>"
+          "</div>",
       );
       // END FLAVOR-SPECIFIC CODE
 
@@ -225,7 +225,7 @@ module.exports = AppView.extend({
       this.$(".leaflet-top.leaflet-right").append(
         '<div class="leaflet-control leaflet-bar">' +
           '<a href="#" class="show-legend-panel"></a>' +
-          "</div>"
+          "</div>",
       );
       // END FLAVOR-SPECIFIC CODE
     }
@@ -302,11 +302,11 @@ module.exports = AppView.extend({
     // is enabled.
     $(Shareabouts).on("reversegeocode", function(evt, locationData) {
       var locationString = Handlebars.templates["location-string"](
-        locationData
+        locationData,
       );
       self.geocodeAddressView.setAddress($.trim(locationString));
       self.placeFormView.geocodeAddressPlaceView.setAddress(
-        $.trim(locationString)
+        $.trim(locationString),
       );
       self.placeFormView.setLatLng(locationData.latLng);
       // Don't pass location data into our geolocation's form field
@@ -438,7 +438,7 @@ module.exports = AppView.extend({
         placeConfig={this.options.placeConfig.place_detail}
         communityInput={this.places["hull-input"]}
       />,
-      document.querySelector("#list-container")
+      document.querySelector("#list-container"),
     );
   },
   // END FLAVOR-SPECIFIC CODE

--- a/src/flavors/hull/static/js/views/gis-legend-view.js
+++ b/src/flavors/hull/static/js/views/gis-legend-view.js
@@ -1,7 +1,6 @@
 const GISLegendView = require("../../../../../base/static/js/views/gis-legend-view.js");
 
 module.exports = GISLegendView.extend({
-
   events: {
     "change .map-legend-basemap-radio": "toggleBasemap",
     "change .map-legend-checkbox": "toggleVisibility",
@@ -10,13 +9,17 @@ module.exports = GISLegendView.extend({
   },
 
   initialize: function() {
-    this.options.mapView.map.on("layer:loading", this.onLayerLoading.bind(this));
+    this.options.mapView.map.on(
+      "layer:loading",
+      this.onLayerLoading.bind(this),
+    );
     this.options.mapView.map.on("layer:loaded", this.onLayerLoaded.bind(this));
     this.options.mapView.map.on("layer:error", this.onLayerError.bind(this));
 
     this.hasScrolled = false;
     this.initialScrollPoint;
-    this.options.sidebarView.$("#gis-layers-pane")
+    this.options.sidebarView
+      .$("#gis-layers-pane")
       .off("scroll")
       .on("scroll", this.onLayersPaneScroll.bind(this));
 
@@ -50,5 +53,5 @@ module.exports = GISLegendView.extend({
 
   render: function() {
     return this;
-  }
+  },
 });

--- a/src/flavors/hull/static/js/views/legend-view.js
+++ b/src/flavors/hull/static/js/views/legend-view.js
@@ -1,7 +1,6 @@
 const LegendView = require("../../../../../base/static/js/views/legend-view.js");
 
 module.exports = LegendView.extend({
-
   render: function() {
     this.$el.html(Handlebars.templates["legend"]());
     return this;

--- a/src/flavors/hull/static/js/views/sidebar-view.js
+++ b/src/flavors/hull/static/js/views/sidebar-view.js
@@ -3,19 +3,20 @@ const GISLegendView = require("mapseed-gis-legend-view");
 const LegendView = require("mapseed-legend-view");
 
 module.exports = SidebarView.extend({
-
   // BEGIN FLAVOR-SPECIFIC CODE
   events: {
-    "click .sidebar-panel__close-panel": "onCloseLayerPanel"
+    "click .sidebar-panel__close-panel": "onCloseLayerPanel",
   },
 
   initialize: function() {
     this.$el.append("<div id='map-legend'></div>");
     this.$el.append("<div id='gis-legend'></div>");
 
-    this.$("#gis-legend").html(Handlebars.templates["sidebar"]({
-      sidebarConfig: this.options.sidebarConfig.panels[0],
-    }));
+    this.$("#gis-legend").html(
+      Handlebars.templates["sidebar"]({
+        sidebarConfig: this.options.sidebarConfig.panels[0],
+      }),
+    );
 
     this.$("#map-legend").html(Handlebars.templates["legend"]());
 
@@ -37,7 +38,7 @@ module.exports = SidebarView.extend({
 
   onCloseLayerPanel: function() {
     this.$el.removeClass("sidebar-container--visible");
-    this.$el.addClass("sidebar-container--hidden")
+    this.$el.addClass("sidebar-container--hidden");
     if ($("#main-btns-container").hasClass("pos-top-left")) {
       $("#main-btns-container").toggleClass("main-btns-container--offset-left");
     }

--- a/src/flavors/manzanares/static/js/views/app-view.js
+++ b/src/flavors/manzanares/static/js/views/app-view.js
@@ -44,7 +44,7 @@ module.exports = AppView.extend({
           return Object.assign(
             {},
             this.options.placeConfig.common_form_elements[field.name],
-            { name: field.name }
+            { name: field.name },
           );
         } else {
           return field;
@@ -99,7 +99,7 @@ module.exports = AppView.extend({
     if (this.options.activityConfig.show_in_right_panel === true) {
       $("body").addClass("right-sidebar-visible");
       $("#right-sidebar-container").html(
-        "<ul class='recent-points unstyled-list'></ul>"
+        "<ul class='recent-points unstyled-list'></ul>",
       );
     }
 
@@ -157,7 +157,7 @@ module.exports = AppView.extend({
           this.hideListView();
         }
       },
-      this
+      this,
     );
 
     // Only append the tools to add places (if supported)
@@ -165,7 +165,7 @@ module.exports = AppView.extend({
     // NOTE: append add place/story buttons after the #map-container
     // div (rather than inside of it) in order to support bottom-clinging buttons
     $("#map-container").after(
-      Handlebars.templates["add-places"](this.options.placeConfig)
+      Handlebars.templates["add-places"](this.options.placeConfig),
     );
 
     this.pagesNavView = new PagesNavView({
@@ -182,7 +182,7 @@ module.exports = AppView.extend({
     }).render();
 
     this.basemapConfigs = _.find(this.options.sidebarConfig.panels, function(
-      panel
+      panel,
     ) {
       return "basemaps" in panel;
     }).basemaps;
@@ -216,7 +216,7 @@ module.exports = AppView.extend({
       this.$(".leaflet-top.leaflet-right").append(
         '<div class="leaflet-control leaflet-bar">' +
           '<a href="#" class="show-layer-panel"></a>' +
-          "</div>"
+          "</div>",
       );
       // END FLAVOR-SPECIFIC CODE
 
@@ -224,7 +224,7 @@ module.exports = AppView.extend({
       this.$(".leaflet-top.leaflet-right").append(
         '<div class="leaflet-control leaflet-bar">' +
           '<a href="#" class="show-legend-panel"></a>' +
-          "</div>"
+          "</div>",
       );
       // END FLAVOR-SPECIFIC CODE
     }
@@ -301,11 +301,11 @@ module.exports = AppView.extend({
     // is enabled.
     $(Shareabouts).on("reversegeocode", function(evt, locationData) {
       var locationString = Handlebars.templates["location-string"](
-        locationData
+        locationData,
       );
       self.geocodeAddressView.setAddress($.trim(locationString));
       self.placeFormView.geocodeAddressPlaceView.setAddress(
-        $.trim(locationString)
+        $.trim(locationString),
       );
       self.placeFormView.setLatLng(locationData.latLng);
       // Don't pass location data into our geolocation's form field
@@ -437,7 +437,7 @@ module.exports = AppView.extend({
         placeConfig={this.options.placeConfig.place_detail}
         communityInput={this.places["manzanares-input"]}
       />,
-      document.querySelector("#list-container")
+      document.querySelector("#list-container"),
     );
   },
   // END FLAVOR-SPECIFIC CODE

--- a/src/flavors/manzanares/static/js/views/gis-legend-view.js
+++ b/src/flavors/manzanares/static/js/views/gis-legend-view.js
@@ -1,7 +1,6 @@
 const GISLegendView = require("../../../../../base/static/js/views/gis-legend-view.js");
 
 module.exports = GISLegendView.extend({
-
   events: {
     "change .map-legend-basemap-radio": "toggleBasemap",
     "change .map-legend-checkbox": "toggleVisibility",
@@ -10,13 +9,17 @@ module.exports = GISLegendView.extend({
   },
 
   initialize: function() {
-    this.options.mapView.map.on("layer:loading", this.onLayerLoading.bind(this));
+    this.options.mapView.map.on(
+      "layer:loading",
+      this.onLayerLoading.bind(this),
+    );
     this.options.mapView.map.on("layer:loaded", this.onLayerLoaded.bind(this));
     this.options.mapView.map.on("layer:error", this.onLayerError.bind(this));
 
     this.hasScrolled = false;
     this.initialScrollPoint;
-    this.options.sidebarView.$("#gis-layers-pane")
+    this.options.sidebarView
+      .$("#gis-layers-pane")
       .off("scroll")
       .on("scroll", this.onLayersPaneScroll.bind(this));
 
@@ -50,5 +53,5 @@ module.exports = GISLegendView.extend({
 
   render: function() {
     return this;
-  }
+  },
 });

--- a/src/flavors/manzanares/static/js/views/legend-view.js
+++ b/src/flavors/manzanares/static/js/views/legend-view.js
@@ -1,7 +1,6 @@
 const LegendView = require("../../../../../base/static/js/views/legend-view.js");
 
 module.exports = LegendView.extend({
-
   render: function() {
     this.$el.html(Handlebars.templates["legend"]());
     return this;

--- a/src/flavors/manzanares/static/js/views/sidebar-view.js
+++ b/src/flavors/manzanares/static/js/views/sidebar-view.js
@@ -3,19 +3,20 @@ const GISLegendView = require("mapseed-gis-legend-view");
 const LegendView = require("mapseed-legend-view");
 
 module.exports = SidebarView.extend({
-
   // BEGIN FLAVOR-SPECIFIC CODE
   events: {
-    "click .sidebar-panel__close-panel": "onCloseLayerPanel"
+    "click .sidebar-panel__close-panel": "onCloseLayerPanel",
   },
 
   initialize: function() {
     this.$el.append("<div id='map-legend'></div>");
     this.$el.append("<div id='gis-legend'></div>");
 
-    this.$("#gis-legend").html(Handlebars.templates["sidebar"]({
-      sidebarConfig: this.options.sidebarConfig.panels[0],
-    }));
+    this.$("#gis-legend").html(
+      Handlebars.templates["sidebar"]({
+        sidebarConfig: this.options.sidebarConfig.panels[0],
+      }),
+    );
 
     this.$("#map-legend").html(Handlebars.templates["legend"]());
 
@@ -37,7 +38,7 @@ module.exports = SidebarView.extend({
 
   onCloseLayerPanel: function() {
     this.$el.removeClass("sidebar-container--visible");
-    this.$el.addClass("sidebar-container--hidden")
+    this.$el.addClass("sidebar-container--hidden");
     if ($("#main-btns-container").hasClass("pos-top-left")) {
       $("#main-btns-container").toggleClass("main-btns-container--offset-left");
     }

--- a/src/flavors/pboakland/static/js/views/sidebar-view.js
+++ b/src/flavors/pboakland/static/js/views/sidebar-view.js
@@ -44,7 +44,7 @@ module.exports = SidebarView.extend({
           config: panelConfig,
           sidebar: self.sidebar,
           placeConfig: self.options.placeConfig,
-          sidebarView: self
+          sidebarView: self,
         }).render();
       }
     });

--- a/src/flavors/pugetsound/static/js/views/landmark-detail-view.js
+++ b/src/flavors/pugetsound/static/js/views/landmark-detail-view.js
@@ -14,14 +14,18 @@ module.exports = LandmarkDetailView.extend({
     this.$el.html(Handlebars.templates["place-detail-story-bar"](data));
     this.$el.append(
       "<div class='landmark-detail-content'>" +
-      // BEGIN FLAVOR-SPECIFIC CODE
-      // Overwriting here to handle the custom "original-title" field, since the
-      // landmark serverless endpoint converts the "title" field to url-friendly
-      // format
-      "<h1 class='soundkeeper-landmark-title'>" + this.model.get("properties")["original-title"] + "</h1>" +
-      // END FLAVOR-SPECIFIC CODE
-      (this.model.attributes.story ? this.description : this.originalDescription) +
-      "</div>"
+        // BEGIN FLAVOR-SPECIFIC CODE
+        // Overwriting here to handle the custom "original-title" field, since the
+        // landmark serverless endpoint converts the "title" field to url-friendly
+        // format
+        "<h1 class='soundkeeper-landmark-title'>" +
+        this.model.get("properties")["original-title"] +
+        "</h1>" +
+        // END FLAVOR-SPECIFIC CODE
+        (this.model.attributes.story
+          ? this.description
+          : this.originalDescription) +
+        "</div>",
     );
     // Render the view as-is (collection may have content already)
     this.$(".survey").html(this.landmarkSurveyView.render().$el);
@@ -31,5 +35,5 @@ module.exports = LandmarkDetailView.extend({
     $("#content article").animate({ scrollTop: 0 }, "fast");
 
     return this;
-  }
+  },
 });

--- a/src/flavors/williams/static/components/messages.js
+++ b/src/flavors/williams/static/components/messages.js
@@ -4,5 +4,5 @@ export default {
     "What concerns do you have about this garden or its future development?",
   subcategorySummaryLabel: "All",
   recommendationsLabel: "Recommendations",
-  concernsLabel: "Concerns"
+  concernsLabel: "Concerns",
 };

--- a/src/flavors/williams/static/js/views/gis-legend-view.js
+++ b/src/flavors/williams/static/js/views/gis-legend-view.js
@@ -1,7 +1,6 @@
 const GISLegendView = require("../../../../../base/static/js/views/gis-legend-view.js");
 
 module.exports = GISLegendView.extend({
-
   events: {
     "change .map-legend-basemap-radio": "toggleBasemap",
     "change .map-legend-checkbox": "toggleVisibility",
@@ -10,13 +9,17 @@ module.exports = GISLegendView.extend({
   },
 
   initialize: function() {
-    this.options.mapView.map.on("layer:loading", this.onLayerLoading.bind(this));
+    this.options.mapView.map.on(
+      "layer:loading",
+      this.onLayerLoading.bind(this),
+    );
     this.options.mapView.map.on("layer:loaded", this.onLayerLoaded.bind(this));
     this.options.mapView.map.on("layer:error", this.onLayerError.bind(this));
 
     this.hasScrolled = false;
     this.initialScrollPoint;
-    this.options.sidebarView.$("#gis-layers-pane")
+    this.options.sidebarView
+      .$("#gis-layers-pane")
       .off("scroll")
       .on("scroll", this.onLayersPaneScroll.bind(this));
 
@@ -50,5 +53,5 @@ module.exports = GISLegendView.extend({
 
   render: function() {
     return this;
-  }
+  },
 });

--- a/src/flavors/williams/static/js/views/legend-view.js
+++ b/src/flavors/williams/static/js/views/legend-view.js
@@ -1,7 +1,6 @@
 const LegendView = require("../../../../../base/static/js/views/legend-view.js");
 
 module.exports = LegendView.extend({
-
   render: function() {
     this.$el.html(Handlebars.templates["legend"]());
     return this;

--- a/src/flavors/williams/static/js/views/sidebar-view.js
+++ b/src/flavors/williams/static/js/views/sidebar-view.js
@@ -3,19 +3,20 @@ const GISLegendView = require("mapseed-gis-legend-view");
 const LegendView = require("mapseed-legend-view");
 
 module.exports = SidebarView.extend({
-
   // BEGIN FLAVOR-SPECIFIC CODE
   events: {
-    "click .sidebar-panel__close-panel": "onCloseLayerPanel"
+    "click .sidebar-panel__close-panel": "onCloseLayerPanel",
   },
 
   initialize: function() {
     this.$el.append("<div id='map-legend'></div>");
     this.$el.append("<div id='gis-legend'></div>");
 
-    this.$("#gis-legend").html(Handlebars.templates["sidebar"]({
-      sidebarConfig: this.options.sidebarConfig.panels[0],
-    }));
+    this.$("#gis-legend").html(
+      Handlebars.templates["sidebar"]({
+        sidebarConfig: this.options.sidebarConfig.panels[0],
+      }),
+    );
 
     this.$("#map-legend").html(Handlebars.templates["legend"]());
 
@@ -37,7 +38,7 @@ module.exports = SidebarView.extend({
 
   onCloseLayerPanel: function() {
     this.$el.removeClass("sidebar-container--visible");
-    this.$el.addClass("sidebar-container--hidden")
+    this.$el.addClass("sidebar-container--hidden");
     if ($("#main-btns-container").hasClass("pos-top-left")) {
       $("#main-btns-container").toggleClass("main-btns-container--offset-left");
     }


### PR DESCRIPTION
This PR:
 - runs Prettier via `npm run prettier`
 - runs the Jest test runner `jest-runner-prettier` to enforce Prettier formatting conventions across all relevant files
 - excludes the `/src/base/static/libs` dir from our Prettier formatting and test suite.