### PR TITLE
Luke/input form test refactor

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -2,4 +2,13 @@ import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import "raf/polyfill";
 
+// https://github.com/i18next/react-i18next/issues/417
+jest.mock("react-i18next", () => ({
+  // this mock makes sure any components using the translate HoC receive the t function as a prop
+  translate: () => Component => {
+    Component.defaultProps = { ...Component.defaultProps, t: () => "" };
+    return Component;
+  },
+}));
+
 Enzyme.configure({ adapter: new Adapter() });

--- a/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
+++ b/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
@@ -4,11 +4,7 @@ exports[`InputForm renders input form 1`] = `
 <div
   className="input-form"
 >
-  <WarningMessagesContainer
-    errors={Array []}
-    headerMsg="validationHeader"
-    t={[Function]}
-  />
+  0
   <form
     className="input-form__form"
     id="mapseed-input-form"

--- a/src/base/static/components/input-form/__tests__/input-form.test.js
+++ b/src/base/static/components/input-form/__tests__/input-form.test.js
@@ -3,13 +3,13 @@ import { shallow } from "enzyme";
 import InputForm from "../index.js";
 import FormField from "../../form-fields/form-field";
 import constants from "../../../constants";
+import WarningMessagesContainer from "../../ui-elements/warning-messages-container";
 import { OrderedMap, Map } from "immutable";
 
 describe("InputForm", () => {
   // TODO: consider generalizing this stub into a mock:
   const eventStub = { preventDefault: () => {} };
   const defaultProps = {
-    t: key => key,
     container: {},
     hideCenterPoint: () => {},
     hideSpotlightMask: () => {},
@@ -29,6 +29,15 @@ describe("InputForm", () => {
   test("renders input form", () => {
     const wrapper = shallow(<InputForm {...defaultProps} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  test("renders form validation errors", () => {
+    const wrapper = shallow(<InputForm {...defaultProps} />);
+    wrapper.setState({
+      formValidationErrors: new Set(["asdf", "asdf2"]),
+    });
+
+    expect(wrapper.find(WarningMessagesContainer)).toHaveLength(1);
   });
 
   test("renders form fields", () => {

--- a/src/base/static/components/input-form/__tests__/input-form.test.js
+++ b/src/base/static/components/input-form/__tests__/input-form.test.js
@@ -5,15 +5,6 @@ import FormField from "../../form-fields/form-field";
 import constants from "../../../constants";
 import { OrderedMap, Map } from "immutable";
 
-// https://github.com/i18next/react-i18next/issues/417
-jest.mock("react-i18next", () => ({
-  // this mock makes sure any components using the translate HoC receive the t function as a prop
-  translate: () => Component => {
-    Component.defaultProps = { ...Component.defaultProps, t: () => "" };
-    return Component;
-  },
-}));
-
 describe("InputForm", () => {
   // TODO: consider generalizing this stub into a mock:
   const eventStub = { preventDefault: () => {} };

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -273,10 +273,12 @@ class InputForm extends Component {
 
     return (
       <div className="input-form">
-        <WarningMessagesContainer
-          errors={[...this.state.formValidationErrors]}
-          headerMsg={this.props.t("validationHeader")}
-        />
+        {this.state.formValidationErrors.size && (
+          <WarningMessagesContainer
+            errors={[...this.state.formValidationErrors]}
+            headerMsg={this.props.t("validationHeader")}
+          />
+        )}
         <form
           id="mapseed-input-form"
           className={cn.form}


### PR DESCRIPTION
This PR:
 - moves our Jest `react-i18next` mock into the global setup file for Jest.
 - refactor some logic around WarningMessagesContainer, and update the snapshot accordingly.