### PR TITLE
Importable config singleton

### DIFF
--- a/__mocks__/config-mock.js
+++ b/__mocks__/config-mock.js
@@ -1,0 +1,26 @@
+module.exports = {
+  app: {},
+  place_types: {},
+  place: {
+    place_detail: [
+      {
+        category: "someCategory",
+        fields: [
+          {
+            name: "test1",
+          },
+          {
+            name: "test2",
+          },
+        ],
+      },
+    ],
+  },
+  survey: {},
+  support: {},
+  pages: {},
+  story: {},
+  sidebar: {},
+  activity: {},
+  cluster: {},
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,9 +2,6 @@ module.exports = {
   projects: [
     {
       displayName: "jest-prettier",
-      moduleNameMapper: {
-        config: "<rootDir>/src/__mocks__/config-mock.js",
-      },
       runner: "jest-runner-prettier",
       moduleFileExtensions: ["js"],
       testMatch: ["<rootDir>/src/**/*.js", "<rootDir>/scripts/**/*.js"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
           "<rootDir>/__mocks__/file-mock.js",
         "\\.(css|less|scss)$": "<rootDir>/__mocks__/style-mock.js",
+        "^config$": "<rootDir>/__mocks__/config-mock.js",
       },
       setupFiles: ["<rootDir>/jest-setup.js"],
       snapshotSerializers: ["enzyme-to-json/serializer"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,9 @@ module.exports = {
   projects: [
     {
       displayName: "jest-prettier",
+      moduleNameMapper: {
+        config: "<rootDir>/src/__mocks__/config-mock.js",
+      },
       runner: "jest-runner-prettier",
       moduleFileExtensions: ["js"],
       testMatch: ["<rootDir>/src/**/*.js", "<rootDir>/scripts/**/*.js"],
@@ -16,6 +19,7 @@ module.exports = {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
           "<rootDir>/__mocks__/file-mock.js",
         "\\.(css|less|scss)$": "<rootDir>/__mocks__/style-mock.js",
+        "^config$": "<rootDir>/__mocks__/config-mock.js",
       },
       setupFiles: ["<rootDir>/jest-setup.js"],
       snapshotSerializers: ["enzyme-to-json/serializer"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,6 @@ module.exports = {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
           "<rootDir>/__mocks__/file-mock.js",
         "\\.(css|less|scss)$": "<rootDir>/__mocks__/style-mock.js",
-        "^config$": "<rootDir>/__mocks__/config-mock.js",
       },
       setupFiles: ["<rootDir>/jest-setup.js"],
       snapshotSerializers: ["enzyme-to-json/serializer"],

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -3,6 +3,8 @@ const Handlebars = require("handlebars");
 const fs = require("fs-extra");
 const path = require("path");
 
+const transformCommonFormElements = require("../src/base/static/utils/common-form-elements");
+
 // This loader is used to listen to changes in the config file during development.
 // Any config changes will be detected and the config (but not the rest of the
 // static site) will be rebuilt. This loader only rebuilds the English version
@@ -58,19 +60,10 @@ module.exports = function(source) {
   });
 
   // Resolve fields of type common_form_element.
-  config.place.place_detail.forEach(category => {
-    category.fields = category.fields.map(field => {
-      if (field.type === "common_form_element") {
-        return Object.assign(
-          {},
-          config.place.common_form_elements[field.name],
-          { name: field.name },
-        );
-      } else {
-        return field;
-      }
-    });
-  });
+  config.place.place_detail = transformCommonFormElements(
+    config.place.place_detail,
+    config.place.common_form_elements,
+  );
 
   const templateSource = fs.readFileSync(
     path.resolve(__dirname, "../build-utils/config-template.hbs"),

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -57,7 +57,7 @@ module.exports = function(source) {
     }
   });
 
-  // Resolve fields of type common_form_element
+  // Resolve fields of type common_form_element.
   config.place.place_detail.forEach(category => {
     category.fields = category.fields.map(field => {
       if (field.type === "common_form_element") {

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -57,6 +57,21 @@ module.exports = function(source) {
     }
   });
 
+  // Resolve fields of type common_form_element
+  config.place.place_detail.forEach(category => {
+    category.fields = category.fields.map(field => {
+      if (field.type === "common_form_element") {
+        return Object.assign(
+          {},
+          config.place.common_form_elements[field.name],
+          { name: field.name },
+        );
+      } else {
+        return field;
+      }
+    });
+  });
+
   const templateSource = fs.readFileSync(
     path.resolve(__dirname, "../build-utils/config-template.hbs"),
     "utf8",

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -9,8 +9,6 @@ const path = require("path");
 // of the config; to test other languages in development it will be necessary
 // to produce a full production build:
 //   npm run build
-// Or, to build in production mode and also start the dev server:
-//   NODE_ENV=production npm start
 
 const configGettextRegex = /^_\(/;
 
@@ -22,8 +20,8 @@ Handlebars.registerHelper("serialize", function(json) {
 module.exports = function(source) {
   source = source.substring(17);
 
-  let datasetSiteUrls = {};
-  config = JSON.parse(source);
+  const datasetSiteUrls = {};
+  const config = JSON.parse(source);
 
   Object.keys(process.env).forEach(function(key) {
     if (key.endsWith("SITE_URL")) {
@@ -64,17 +62,17 @@ module.exports = function(source) {
     "utf8",
   );
   const template = Handlebars.compile(templateSource);
-  outputFile = template({
+  const outputFile = template({
     config: config,
     languageCode: "en_US",
   });
 
-  outputPath = path.resolve(__dirname, "../www/dist/config-en_US.js");
+  const outputPath = path.resolve(__dirname, "../www/dist/config-en_US.js");
   try {
     fs.writeFileSync(outputPath, outputFile);
   } catch (e) {
     // ignore exceptions
   }
 
-  return source;
+  return config;
 };

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -233,6 +233,22 @@ activeLanguages.forEach(language => {
     thisConfig.app.api_root = process.env.API_ROOT;
   }
 
+  // Resolve fields of type common_form_element.
+  // This supports the importable config module.
+  thisConfig.place.place_detail.forEach(category => {
+    category.fields = category.fields.map(field => {
+      if (field.type === "common_form_element") {
+        return Object.assign(
+          {},
+          thisConfig.place.common_form_elements[field.name],
+          { name: field.name },
+        );
+      } else {
+        return field;
+      }
+    });
+  });
+
   // (5a) Copy all jstemplates and flavor pages to a working directory from
   //      which the templates can be localized and precompiled. Also resolve
   //      flavor jstemplates overrides at this step

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -13,6 +13,8 @@ const shell = require("shelljs");
 const glob = require("glob");
 const colors = require("colors");
 
+const transformCommonFormElements = require("../src/base/static/utils/common-form-elements");
+
 // =============================================================================
 // BEGIN STATIC SITE BUILD
 //
@@ -234,20 +236,10 @@ activeLanguages.forEach(language => {
   }
 
   // Resolve fields of type common_form_element.
-  // This supports the importable config module.
-  thisConfig.place.place_detail.forEach(category => {
-    category.fields = category.fields.map(field => {
-      if (field.type === "common_form_element") {
-        return Object.assign(
-          {},
-          thisConfig.place.common_form_elements[field.name],
-          { name: field.name },
-        );
-      } else {
-        return field;
-      }
-    });
-  });
+  thisConfig.place.place_detail = transformCommonFormElements(
+    thisConfig.place.place_detail,
+    thisConfig.place.common_form_elements,
+  );
 
   // (5a) Copy all jstemplates and flavor pages to a working directory from
   //      which the templates can be localized and precompiled. Also resolve

--- a/src/base/static/components/form-fields/field-definitions.js
+++ b/src/base/static/components/form-fields/field-definitions.js
@@ -220,10 +220,7 @@ export default {
   [constants.GEOCODING_FIELD_TYPENAME]: {
     getValidator: getPermissiveValidator,
     getComponent: (fieldConfig, context) => (
-      <GeocodingField
-        {...getSharedFieldProps(fieldConfig, context)}
-        mapConfig={context.props.mapConfig}
-      />
+      <GeocodingField {...getSharedFieldProps(fieldConfig, context)} />
     ),
     getInitialValue: ({ value }) => value,
     getResponseComponent: () => null,

--- a/src/base/static/components/form-fields/form-field.js
+++ b/src/base/static/components/form-fields/form-field.js
@@ -111,12 +111,10 @@ class FormField extends Component {
 
 FormField.propTypes = {
   attachmentModels: PropTypes.instanceOf(List),
-  categoryConfig: PropTypes.object,
   disabled: PropTypes.bool,
   fieldConfig: PropTypes.object.isRequired,
   fieldState: PropTypes.object,
   map: PropTypes.object,
-  mapConfig: PropTypes.object,
   modelId: PropTypes.number,
   onFieldChange: PropTypes.func.isRequired,
   onGeometryStyleChange: PropTypes.func,

--- a/src/base/static/components/form-fields/types/geocoding-field.js
+++ b/src/base/static/components/form-fields/types/geocoding-field.js
@@ -6,6 +6,8 @@ import emitter from "../../../utils/emitter";
 import { translate } from "react-i18next";
 import "./geocoding-field.scss";
 
+import { map as mapConfig } from "config";
+
 // TODO: Consolidate Util methods used here.
 const Util = require("../../../js/utils.js");
 
@@ -16,10 +18,8 @@ class GeocodingField extends Component {
       isGeocoding: false,
       isWithGeocodingError: false,
     };
-    this.geocodingEngine = this.props.mapConfig.geocoding_engine || "MapQuest";
-    this.hint =
-      this.props.mapConfig.geocode_bounding_box ||
-      this.props.mapConfig.geocode_hint;
+    this.geocodingEngine = mapConfig.geocoding_engine || "MapQuest";
+    this.hint = mapConfig.geocode_bounding_box || mapConfig.geocode_hint;
   }
 
   componentDidMount() {
@@ -103,7 +103,6 @@ class GeocodingField extends Component {
 }
 
 GeocodingField.propTypes = {
-  mapConfig: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,

--- a/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
+++ b/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
@@ -11,19 +11,6 @@ exports[`InputForm renders input form 1`] = `
   >
     <FormField
       attachmentModels={Immutable.List []}
-      categoryConfig={
-        Object {
-          "category": "someCategory",
-          "fields": Array [
-            Object {
-              "name": "test1",
-            },
-            Object {
-              "name": "test2",
-            },
-          ],
-        }
-      }
       disabled={false}
       fieldConfig={
         Object {
@@ -44,7 +31,6 @@ exports[`InputForm renders input form 1`] = `
           "on": [Function],
         }
       }
-      mapConfig={Object {}}
       onAddAttachment={[Function]}
       onFieldChange={[Function]}
       onGeometryStyleChange={[Function]}
@@ -56,19 +42,6 @@ exports[`InputForm renders input form 1`] = `
     />
     <FormField
       attachmentModels={Immutable.List []}
-      categoryConfig={
-        Object {
-          "category": "someCategory",
-          "fields": Array [
-            Object {
-              "name": "test1",
-            },
-            Object {
-              "name": "test2",
-            },
-          ],
-        }
-      }
       disabled={false}
       fieldConfig={
         Object {
@@ -89,7 +62,6 @@ exports[`InputForm renders input form 1`] = `
           "on": [Function],
         }
       }
-      mapConfig={Object {}}
       onAddAttachment={[Function]}
       onFieldChange={[Function]}
       onGeometryStyleChange={[Function]}

--- a/src/base/static/components/input-form/__tests__/input-form.test.js
+++ b/src/base/static/components/input-form/__tests__/input-form.test.js
@@ -14,16 +14,12 @@ describe("InputForm", () => {
     container: {},
     hideCenterPoint: () => {},
     hideSpotlightMask: () => {},
-    selectedCategoryConfig: {
-      category: categoryName,
-      fields: [{ name: "test1" }, { name: "test2" }],
-    },
+    selectedCategory: "someCategory",
     map: {
       on: () => {},
       off: () => {},
       getCenter: () => {},
     },
-    mapConfig: {},
     places: {},
     router: {},
     showNewPin: () => {},

--- a/src/base/static/components/input-form/form-category-menu-wrapper.js
+++ b/src/base/static/components/input-form/form-category-menu-wrapper.js
@@ -3,12 +3,14 @@ import PropTypes from "prop-types";
 
 import InputFormCategorySelector from "./input-form-category-selector";
 
+import { place as placeConfig } from "config";
+
 const Util = require("../../js/utils.js");
 
 class FormCategoryMenuWrapper extends Component {
   constructor(props) {
     super(props);
-    this.visibleCategoryConfigs = this.props.placeConfig.place_detail
+    this.visibleCategoryConfigs = placeConfig.place_detail
       .filter(config => config.includeOnForm)
       .filter(config => {
         return !(
@@ -17,18 +19,16 @@ class FormCategoryMenuWrapper extends Component {
         );
       });
     this.state = {
-      selectedCategoryConfig:
+      selectedCategory:
         this.visibleCategoryConfigs.length === 1
-          ? this.visibleCategoryConfigs[0]
+          ? this.visibleCategoryConfigs[0].category
           : false,
     };
   }
 
   onCategoryChange(selectedCategory) {
     this.setState({
-      selectedCategoryConfig: this.visibleCategoryConfigs.find(
-        config => config.category === selectedCategory,
-      ),
+      selectedCategory: selectedCategory,
     });
   }
 
@@ -37,10 +37,10 @@ class FormCategoryMenuWrapper extends Component {
       <div className="input-form-category-menu-container">
         <InputFormCategorySelector
           onCategoryChange={this.onCategoryChange.bind(this)}
-          selectedCategoryConfig={this.state.selectedCategoryConfig}
+          selectedCategory={this.state.selectedCategory}
           visibleCategoryConfigs={this.visibleCategoryConfigs}
         />
-        {this.state.selectedCategoryConfig
+        {this.state.selectedCategory
           ? this.props.render(this.state, this.props)
           : null}
       </div>
@@ -49,30 +49,6 @@ class FormCategoryMenuWrapper extends Component {
 }
 
 FormCategoryMenuWrapper.propTypes = {
-  mapConfig: PropTypes.shape({
-    geolocation_enabled: PropTypes.bool,
-    geolocation_onload: PropTypes.bool,
-    cartodb_enabled: PropTypes.bool,
-    geocode_field_label: PropTypes.string,
-    geocode_bounding_box: PropTypes.arrayOf(PropTypes.number),
-    options: PropTypes.shape({
-      center: PropTypes.shape({
-        lat: PropTypes.number.isRequired,
-        lng: PropTypes.number.isRequired,
-      }),
-      zoom: PropTypes.number,
-      minZoom: PropTypes.number,
-      maxZoom: PropTypes.number,
-    }),
-    layer: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        url: PropTypes.string.isRequired,
-        attribution: PropTypes.string,
-        type: PropTypes.string,
-      }),
-    ),
-  }),
   hideSpotlightMask: PropTypes.func.isRequired,
   hideCenterPoint: PropTypes.func.isRequired,
   showNewPin: PropTypes.func.isRequired,
@@ -88,40 +64,6 @@ FormCategoryMenuWrapper.propTypes = {
   container: PropTypes.instanceOf(HTMLElement),
   render: PropTypes.func.isRequired,
   customComponents: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
-  placeConfig: PropTypes.shape({
-    adding_supported: PropTypes.bool.isRequired,
-    add_button_label: PropTypes.string.isRequired,
-    show_list_button_label: PropTypes.string.isRequired,
-    show_map_button_label: PropTypes.string.isRequired,
-    action_text: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-    anonymous_name: PropTypes.string.isRequired,
-    submit_button_label: PropTypes.string.isRequired,
-    location_item_name: PropTypes.string.isRequired,
-    default_basemap: PropTypes.string,
-    place_detail: PropTypes.arrayOf(
-      PropTypes.shape({
-        category: PropTypes.string.isRequired,
-        includeOnForm: PropTypes.bool,
-        name: PropTypes.string.isRequired,
-        dataset: PropTypes.string.isRequired,
-        icon_url: PropTypes.string.isRequired,
-        value: PropTypes.string.isRequired,
-        label: PropTypes.string.isRequired,
-        fields: PropTypes.arrayOf(
-          PropTypes.shape({
-            name: PropTypes.string.isRequired,
-            type: PropTypes.string.isRequired,
-            autocomplete: PropTypes.bool,
-            prompt: PropTypes.string,
-            display_prompt: PropTypes.string,
-            placeholder: PropTypes.string,
-            optional: PropTypes.bool,
-          }),
-        ),
-      }),
-    ),
-  }).isRequired,
 };
 
 export default FormCategoryMenuWrapper;

--- a/src/base/static/components/input-form/input-form-category-button.js
+++ b/src/base/static/components/input-form/input-form-category-button.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
+import { getCategoryConfig } from "../../utils/config-utils";
 import "./input-form-category-button.scss";
 
 const InputFormCategoryButton = props => {
@@ -23,29 +24,30 @@ const InputFormCategoryButton = props => {
       },
     ),
   };
+  const categoryConfig = getCategoryConfig(props.categoryName);
 
   return (
     <div className={cn.base}>
       <input
         className="input-form-category-button__input"
         checked={props.isSelected}
-        id={props.categoryConfig.category}
+        id={props.categoryName}
         type="radio"
         name="input-form-category-buttons"
-        value={props.categoryConfig.category}
+        value={props.categoryName}
         onChange={props.onCategoryChange}
       />
       <label
         className={"input-form-category-button__label"}
-        htmlFor={props.categoryConfig.category}
+        htmlFor={props.categoryName}
       >
         <span className={cn.imageContainer}>
           <img
             className="input-form-category-button__image"
-            src={props.categoryConfig.icon_url}
+            src={categoryConfig.icon_url}
           />
         </span>
-        <span className={cn.labelContainer}>{props.categoryConfig.label}</span>
+        <span className={cn.labelContainer}>{categoryConfig.label}</span>
       </label>
       <button
         className={cn.expandCategoriesButton}
@@ -57,7 +59,7 @@ const InputFormCategoryButton = props => {
 };
 
 InputFormCategoryButton.propTypes = {
-  categoryConfig: PropTypes.object.isRequired,
+  categoryName: PropTypes.string.isRequired,
   isCategoryMenuCollapsed: PropTypes.bool.isRequired,
   isSelected: PropTypes.bool.isRequired,
   isSingleCategory: PropTypes.bool.isRequired,

--- a/src/base/static/components/input-form/input-form-category-selector.js
+++ b/src/base/static/components/input-form/input-form-category-selector.js
@@ -22,9 +22,7 @@ class InputFormCategorySelector extends Component {
     return (
       <div className="input-form__category-selector">
         {this.props.visibleCategoryConfigs.map(config => {
-          const isSelected =
-            this.props.selectedCategoryConfig &&
-            this.props.selectedCategoryConfig.category === config.category;
+          const isSelected = this.props.selectedCategory === config.category;
 
           return (
             <InputFormCategoryButton
@@ -32,7 +30,7 @@ class InputFormCategorySelector extends Component {
               isCategoryMenuCollapsed={this.state.isCollapsed && !isSelected}
               isSingleCategory={this.props.visibleCategoryConfigs.length === 1}
               key={config.category}
-              categoryConfig={config}
+              categoryName={config.category}
               onCategoryChange={evt => {
                 this.setCategory(evt.target.value, false);
               }}
@@ -47,10 +45,8 @@ class InputFormCategorySelector extends Component {
 
 InputFormCategorySelector.propTypes = {
   onCategoryChange: PropTypes.func.isRequired,
-  selectedCategoryConfig: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.bool,
-  ]),
+  selectedCategory: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
+    .isRequired,
   visibleCategoryConfigs: PropTypes.array.isRequired,
 };
 

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -17,10 +17,7 @@ import fieldResponseFilter from "../../utils/field-response-filter";
 import constants from "../../constants";
 import { scrollTo } from "../../utils/scroll-helpers";
 
-import {
-  survey as surveyConfig,
-  support as supportConfig,
-} from "config";
+import { survey as surveyConfig, support as supportConfig } from "config";
 import { getCategoryConfig } from "../../utils/config-utils";
 const Util = require("../../js/utils.js");
 

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -17,6 +17,11 @@ import fieldResponseFilter from "../../utils/field-response-filter";
 import constants from "../../constants";
 import { scrollTo } from "../../utils/scroll-helpers";
 
+import {
+  survey as surveyConfig,
+  support as supportConfig,
+} from "config";
+import { getCategoryConfig } from "../../utils/config-utils";
 const Util = require("../../js/utils.js");
 
 import { translate } from "react-i18next";
@@ -35,8 +40,8 @@ class PlaceDetail extends Component {
   constructor(props) {
     super(props);
 
-    this.surveyType = this.props.surveyConfig.submission_type;
-    this.supportType = this.props.supportConfig.submission_type;
+    this.surveyType = surveyConfig.submission_type;
+    this.supportType = supportConfig.submission_type;
     if (!this.props.model.submissionSets[this.surveyType]) {
       this.props.model.submissionSets[
         this.surveyType
@@ -54,10 +59,8 @@ class PlaceDetail extends Component {
       });
     }
 
-    this.categoryConfig = this.props.placeConfig.place_detail.find(
-      config =>
-        config.category ===
-        this.props.model.get(constants.LOCATION_TYPE_PROPERTY_NAME),
+    this.categoryConfig = getCategoryConfig(
+      this.props.model.get(constants.LOCATION_TYPE_PROPERTY_NAME),
     );
 
     // Maintain reset listeners for submission collections in case the detail
@@ -217,7 +220,7 @@ class PlaceDetail extends Component {
 
     return (
       <div className="place-detail-view">
-        {this.state.isEditable ? (
+        {this.state.isEditable && (
           <EditorBar
             isEditModeToggled={this.state.isEditModeToggled}
             isGeocodingBarEnabled={this.props.isGeocodingBarEnabled}
@@ -228,7 +231,7 @@ class PlaceDetail extends Component {
               });
             }}
           />
-        ) : null}
+        )}
         <h1
           className={classNames("place-detail-view__header", {
             "place-detail-view__header--centered": isStoryChapter,
@@ -255,24 +258,19 @@ class PlaceDetail extends Component {
           onSocialShare={service =>
             Util.onSocialShare(this.props.model, service)
           }
-          supportConfig={this.props.supportConfig}
           supportModelCreate={this.props.model.submissionSets[
             this.supportType
           ].create.bind(this.props.model.submissionSets[this.supportType])}
           userSupportModel={userSupportModel}
           userToken={this.props.userToken}
         />
-        {!isStoryChapter ? (
+        {!isStoryChapter && (
           <MetadataBar
             submitter={submitter}
             placeModel={this.state.placeModel}
             surveyModels={this.state.surveyModels}
-            anonymousName={this.props.placeConfig.anonymous_name}
-            actionText={this.props.placeConfig.action_text}
-            placeTypes={this.props.placeTypes}
-            surveyConfig={this.props.surveyConfig}
           />
-        ) : null}
+        )}
         <div className="place-detail-view__clearfix" />
         {this.state.attachmentModels
           .filter(
@@ -291,10 +289,8 @@ class PlaceDetail extends Component {
             placeModel={this.state.placeModel}
             container={this.props.container}
             attachmentModels={this.state.attachmentModels}
-            categoryConfig={this.categoryConfig}
             layerView={this.props.layerView}
             map={this.props.map}
-            mapConfig={this.props.mapConfig}
             onAddAttachment={this.onAddAttachment.bind(this)}
             onModelIO={this.onChildModelIO.bind(this)}
             onPlaceModelSave={this.props.model.save.bind(this.props.model)}
@@ -316,7 +312,6 @@ class PlaceDetail extends Component {
           ))
         )}
         <Survey
-          apiRoot={this.props.apiRoot}
           currentUser={this.props.currentUser}
           getLoggingDetails={this.props.model.getLoggingDetails.bind(
             this.props.model,
@@ -331,10 +326,8 @@ class PlaceDetail extends Component {
           ].create.bind(this.props.model.submissionSets[this.surveyType])}
           onSurveyModelSave={this.onSurveyModelSave.bind(this)}
           onSurveyModelRemove={this.onSurveyModelRemove.bind(this)}
-          anonymousName={this.props.placeConfig.anonymous_name}
           scrollToResponseId={this.props.scrollToResponseId}
           submitter={submitter}
-          surveyConfig={this.props.surveyConfig}
         />
       </div>
     );
@@ -342,7 +335,6 @@ class PlaceDetail extends Component {
 }
 
 PlaceDetail.propTypes = {
-  apiRoot: PropTypes.string.isRequired,
   container: PropTypes.instanceOf(HTMLElement),
   currentUser: PropTypes.shape({
     avatar_url: PropTypes.string,
@@ -361,77 +353,10 @@ PlaceDetail.propTypes = {
   isGeocodingBarEnabled: PropTypes.bool,
   layerView: PropTypes.instanceOf(Backbone.View),
   map: PropTypes.instanceOf(L.Map),
-  mapConfig: PropTypes.object.isRequired,
   model: PropTypes.instanceOf(Backbone.Model),
-  placeConfig: PropTypes.shape({
-    adding_supported: PropTypes.bool.isRequired,
-    add_button_label: PropTypes.string.isRequired,
-    anonymous_name: PropTypes.string.isRequired,
-    show_list_button_label: PropTypes.string.isRequired,
-    show_map_button_label: PropTypes.string.isRequired,
-    action_text: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-    submit_button_label: PropTypes.string.isRequired,
-    location_item_name: PropTypes.string.isRequired,
-    default_basemap: PropTypes.string,
-    place_detail: PropTypes.arrayOf(
-      PropTypes.shape({
-        category: PropTypes.string.isRequired,
-        includeOnForm: PropTypes.bool,
-        name: PropTypes.string.isRequired,
-        dataset: PropTypes.string.isRequired,
-        icon_url: PropTypes.string.isRequired,
-        value: PropTypes.string.isRequired,
-        label: PropTypes.string.isRequired,
-        fields: PropTypes.arrayOf(
-          PropTypes.shape({
-            name: PropTypes.string.isRequired,
-            type: PropTypes.string.isRequired,
-            autocomplete: PropTypes.bool,
-            prompt: PropTypes.string,
-            display_prompt: PropTypes.string,
-            placeholder: PropTypes.string,
-            optional: PropTypes.bool,
-          }),
-        ),
-      }),
-    ),
-  }).isRequired,
   places: PropTypes.objectOf(PropTypes.instanceOf(Backbone.Collection)),
-  placeTypes: PropTypes.objectOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      rules: PropTypes.arrayOf(
-        PropTypes.shape({
-          condition: PropTypes.string.isRequired,
-          icon: PropTypes.object,
-          style: PropTypes.object,
-        }),
-      ),
-    }),
-  ).isRequired,
   router: PropTypes.instanceOf(Backbone.Router),
   scrollToResponseId: PropTypes.string,
-  supportConfig: PropTypes.shape({
-    submission_type: PropTypes.string.isRequired,
-    submit_btn_text: PropTypes.string.isRequired,
-    response_name: PropTypes.string.isRequired,
-    response_plural_name: PropTypes.string.isRequired,
-    action_text: PropTypes.string.isRequired,
-    anonymous_name: PropTypes.string.isRequired,
-  }),
-  surveyConfig: PropTypes.shape({
-    submission_type: PropTypes.string.isRequired,
-    show_responses: PropTypes.bool.isRequired,
-    response_name: PropTypes.string.isRequired,
-    response_plural_name: PropTypes.string.isRequired,
-    action_text: PropTypes.string.isRequired,
-    anonymous_name: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-    form_link_text: PropTypes.string.isRequired,
-    submit_btn_text: PropTypes.string.isRequired,
-    items: PropTypes.arrayOf(PropTypes.object).isRequired,
-  }).isRequired,
   t: PropTypes.func.isRequired,
   userToken: PropTypes.string.isRequired,
 };

--- a/src/base/static/components/place-detail/metadata-bar.js
+++ b/src/base/static/components/place-detail/metadata-bar.js
@@ -8,15 +8,19 @@ import SubmitterName from "../ui-elements/submitter-name";
 import { translate, Trans } from "react-i18next";
 
 import constants from "../../constants";
+import {
+  place_types as placeTypes,
+  place as placeConfig,
+  survey as surveyConfig,
+} from "config";
 
 import "./metadata-bar.scss";
 
 const MetadataBar = props => {
   const placeTypeLabel =
-    props.placeTypes[
-      props.placeModel.get(constants.LOCATION_TYPE_PROPERTY_NAME)
-    ].label;
-  const actionText = props.actionText;
+    placeTypes[props.placeModel.get(constants.LOCATION_TYPE_PROPERTY_NAME)]
+      .label;
+  const actionText = placeConfig.action_text;
 
   return (
     <div className="place-detail-metadata-bar">
@@ -32,7 +36,6 @@ const MetadataBar = props => {
                 props.submitter.get(constants.NAME_PROPERTY_NAME) ||
                 props.placeModel.get(constants.SUBMITTER_FIELDNAME)
               }
-              anonymousName={props.anonymousName}
             />{" "}
             {{ actionText }} this {{ placeTypeLabel }}
           </Trans>
@@ -55,8 +58,8 @@ const MetadataBar = props => {
         <p className="place-detail-metadata-bar__survey-count">
           {props.surveyModels.size}{" "}
           {props.surveyModels.size === 1
-            ? props.surveyConfig.response_name
-            : props.surveyConfig.response_plural_name}
+            ? surveyConfig.response_name
+            : surveyConfig.response_plural_name}
         </p>
       </div>
     </div>
@@ -64,14 +67,10 @@ const MetadataBar = props => {
 };
 
 MetadataBar.propTypes = {
-  actionText: PropTypes.string.isRequired,
   avatarSrc: PropTypes.string,
   placeModel: PropTypes.object.isRequired,
   surveyModels: PropTypes.object.isRequired,
-  anonymousName: PropTypes.string.isRequired,
-  placeTypes: PropTypes.object.isRequired,
   submitter: PropTypes.object.isRequired,
-  surveyConfig: PropTypes.object.isRequired,
 };
 
 export default translate("MetadataBar")(MetadataBar);

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -15,14 +15,20 @@ const Util = require("../../js/utils.js");
 import { translate } from "react-i18next";
 import constants from "../../constants";
 
+import { getCategoryConfig } from "../../utils/config-utils";
+
 import "./place-detail-editor.scss";
 
 class PlaceDetailEditor extends Component {
   constructor(props) {
     super(props);
 
+    this.categoryConfig = getCategoryConfig(
+      this.props.placeModel.get(constants.LOCATION_TYPE_PROPERTY_NAME),
+    );
+
     let fields = OrderedMap();
-    this.props.categoryConfig.fields
+    this.categoryConfig.fields
       // NOTE: In the editor, we have to strip out the submit field here,
       // otherwise, since we don't render it at all, it will always be invalid.
       .filter(field => field.type !== constants.SUBMIT_FIELD_TYPENAME)
@@ -71,7 +77,7 @@ class PlaceDetailEditor extends Component {
         // image's name.
         // TODO: This logic is better suited for the FormField component,
         // perhaps in an onSave hook.
-        this.props.categoryConfig.fields
+        this.categoryConfig.fields
           .filter(
             field => field.type === constants.RICH_TEXTAREA_FIELD_TYPENAME,
           )
@@ -160,12 +166,12 @@ class PlaceDetailEditor extends Component {
           {this.state.fields
             .filter(
               (fieldState, fieldName) =>
-                this.props.categoryConfig.fields.find(
+                this.categoryConfig.fields.find(
                   field => field.name === fieldName,
                 ).type !== constants.SUBMIT_FIELD_TYPENAME,
             )
             .map((fieldState, fieldName) => {
-              const fieldConfig = this.props.categoryConfig.fields.find(
+              const fieldConfig = this.categoryConfig.fields.find(
                 field => field.name === fieldName,
               );
 
@@ -188,7 +194,6 @@ class PlaceDetailEditor extends Component {
                   isInitializing={this.state.isInitializing}
                   key={fieldName}
                   map={this.props.map}
-                  mapConfig={this.props.mapConfig}
                   modelId={this.props.placeModel.get(
                     constants.MODEL_ID_PROPERTY_NAME,
                   )}
@@ -210,12 +215,10 @@ class PlaceDetailEditor extends Component {
 
 PlaceDetailEditor.propTypes = {
   attachmentModels: PropTypes.object,
-  categoryConfig: PropTypes.object.isRequired,
   container: PropTypes.object.isRequired,
   isSubmitting: PropTypes.bool.isRequired,
   layerView: PropTypes.object,
   map: PropTypes.object,
-  mapConfig: PropTypes.object,
   onAddAttachment: PropTypes.func,
   onModelIO: PropTypes.func.isRequired,
   onPlaceModelSave: PropTypes.func.isRequired,

--- a/src/base/static/components/place-detail/promotion-bar.js
+++ b/src/base/static/components/place-detail/promotion-bar.js
@@ -90,7 +90,6 @@ class PromotionBar extends Component {
         <SupportButton
           className="place-detail-promotion-bar__support-button"
           isSupported={this.props.isSupported}
-          label={this.props.supportConfig.submit_btn_text}
           numSupports={this.props.numSupports}
           onClickSupport={this.onClickSupport.bind(this)}
         />
@@ -121,7 +120,6 @@ PromotionBar.propTypes = {
   numSupports: PropTypes.number,
   onModelIO: PropTypes.func.isRequired,
   onSocialShare: PropTypes.func.isRequired,
-  supportConfig: PropTypes.object.isRequired,
   supportModelCreate: PropTypes.func.isRequired,
   userSupportModel: PropTypes.instanceOf(Backbone.Model),
   userToken: PropTypes.string,

--- a/src/base/static/components/place-detail/survey-response-editor.js
+++ b/src/base/static/components/place-detail/survey-response-editor.js
@@ -9,6 +9,7 @@ import ActionTime from "../ui-elements/action-time";
 import SubmitterName from "../ui-elements/submitter-name";
 import EditorButton from "../ui-elements/editor-button";
 
+import { survey as surveyConfig, place as placeConfig } from "config";
 import { translate } from "react-i18next";
 import constants from "../../constants";
 
@@ -18,7 +19,7 @@ class SurveyResponseEditor extends Component {
   constructor(props) {
     super(props);
 
-    const fields = this.props.surveyItems
+    const fields = surveyConfig.items
       // NOTE: In the editor, we have to strip out the submit field here,
       // otherwise, since we don't render it at all, it will always be invalid.
       .filter(field => field.type !== constants.SUBMIT_FIELD_TYPENAME)
@@ -99,7 +100,7 @@ class SurveyResponseEditor extends Component {
               ? this.props.t("notSaved")
               : this.props.t("saved")}
           </em>
-          {this.props.surveyItems
+          {surveyConfig.items
             .filter(field => field.type !== constants.SUBMIT_FIELD_TYPENAME)
             .map(fieldConfig => (
               <FormField
@@ -127,7 +128,7 @@ class SurveyResponseEditor extends Component {
             <SubmitterName
               className="place-detail-survey-response__submitter-name"
               submitter={this.props.submitter}
-              anonymousName={this.props.anonymousName}
+              anonymousName={placeConfig.anonymous_name}
             />
             <ActionTime time={this.props.attributes.get("updated_datetime")} />
           </div>
@@ -139,7 +140,6 @@ class SurveyResponseEditor extends Component {
 
 SurveyResponseEditor.propTypes = {
   attributes: PropTypes.object,
-  anonymousName: PropTypes.string.isRequired,
   isSubmitting: PropTypes.bool.isRequired,
   modelId: PropTypes.number.isRequired,
   onSurveyModelRemove: PropTypes.func.isRequired,
@@ -147,14 +147,7 @@ SurveyResponseEditor.propTypes = {
   submitter: PropTypes.shape({
     avatar_url: PropTypes.string,
   }),
-  surveyItems: PropTypes.arrayOf(
-    PropTypes.shape({
-      prompt: PropTypes.string,
-      label: PropTypes.string,
-      type: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 export default translate("SurveyResponseEditor")(SurveyResponseEditor);

--- a/src/base/static/components/place-detail/survey-response.js
+++ b/src/base/static/components/place-detail/survey-response.js
@@ -6,6 +6,7 @@ import ActionTime from "../ui-elements/action-time";
 import SubmitterName from "../ui-elements/submitter-name";
 import constants from "../../constants";
 
+import { survey as surveyConfig, place as placeConfig } from "config";
 import "./survey-response.scss";
 
 class SurveyResponse extends Component {
@@ -22,7 +23,7 @@ class SurveyResponse extends Component {
         ref={response => (this.responseRef = response)}
       >
         <div className="place-detail-survey-response__body">
-          {this.props.surveyConfig.items
+          {surveyConfig.items
             .filter(
               field =>
                 field.type !== constants.SUBMIT_FIELD_TYPENAME &&
@@ -49,7 +50,7 @@ class SurveyResponse extends Component {
                 this.props.submitter.get(constants.NAME_PROPERTY_NAME) ||
                 this.props.attributes.get(constants.SUBMITTER_FIELDNAME)
               }
-              anonymousName={this.props.anonymousName}
+              anonymousName={placeConfig.anonymous_name}
             />
             <ActionTime time={this.props.attributes.get("updated_datetime")} />
           </div>
@@ -65,8 +66,6 @@ SurveyResponse.propTypes = {
   onMountTargetResponse: PropTypes.func.isRequired,
   scrollToResponseId: PropTypes.string,
   submitter: PropTypes.object.isRequired,
-  anonymousName: PropTypes.string.isRequired,
-  surveyConfig: PropTypes.object.isRequired,
 };
 
 export default SurveyResponse;

--- a/src/base/static/components/place-detail/survey.js
+++ b/src/base/static/components/place-detail/survey.js
@@ -10,6 +10,7 @@ import WarningMessagesContainer from "../ui-elements/warning-messages-container"
 import Avatar from "../ui-elements/avatar";
 import SurveyResponseEditor from "./survey-response-editor";
 
+import { survey as surveyConfig, app as appConfig } from "config";
 import constants from "../../constants";
 import { translate } from "react-i18next";
 
@@ -44,7 +45,7 @@ class Survey extends Component {
   }
 
   initializeFields() {
-    return this.props.surveyConfig.items.reduce((fields, field) => {
+    return surveyConfig.items.reduce((fields, field) => {
       fields = fields.set(
         field.name,
         Map()
@@ -125,11 +126,11 @@ class Survey extends Component {
           <h4 className="place-detail-survey__num-comments-header">
             {numSubmissions}{" "}
             {numSubmissions === 1
-              ? this.props.surveyConfig.response_name
-              : this.props.surveyConfig.response_plural_name}
+              ? surveyConfig.response_name
+              : surveyConfig.response_plural_name}
           </h4>
           <SecondaryButton className="place-detail-survey__leave-comment-button">
-            {this.props.surveyConfig.form_link_text}
+            {surveyConfig.form_link_text}
           </SecondaryButton>
           <hr className="place-detail-survey__horizontal-rule" />
         </div>
@@ -143,19 +144,15 @@ class Survey extends Component {
                   modelId={attributes.get(constants.MODEL_ID_PROPERTY_NAME)}
                   onSurveyModelRemove={this.props.onSurveyModelRemove}
                   onSurveyModelSave={this.props.onSurveyModelSave}
-                  surveyItems={this.props.surveyConfig.items}
                   attributes={attributes}
-                  anonymousName={this.props.anonymousName}
                   submitter={this.props.submitter}
                 />
               ) : (
                 <SurveyResponse
-                  anonymousName={this.props.anonymousName}
                   key={attributes.get(constants.MODEL_ID_PROPERTY_NAME)}
                   modelId={attributes.get(constants.MODEL_ID_PROPERTY_NAME)}
                   onMountTargetResponse={this.props.onMountTargetResponse}
                   scrollToResponseId={this.props.scrollToResponseId}
-                  surveyConfig={this.props.surveyConfig}
                   attributes={attributes}
                   submitter={this.props.submitter}
                 />
@@ -176,7 +173,7 @@ class Survey extends Component {
               <FormField
                 key={fieldState.get(constants.FIELD_RENDER_KEY)}
                 isInitializing={this.state.isInitializing}
-                fieldConfig={this.props.surveyConfig.items.find(
+                fieldConfig={surveyConfig.items.find(
                   field => field.name === fieldName,
                 )}
                 updatingField={this.state.updatingField}
@@ -196,7 +193,7 @@ class Survey extends Component {
             </span>
             <a
               className="place-detail-survey__logout-button"
-              href={this.props.apiRoot + "users/logout/"}
+              href={appConfig.apiRoot + "users/logout/"}
             >
               {t("logOut")}
             </a>
@@ -208,8 +205,6 @@ class Survey extends Component {
 }
 
 Survey.propTypes = {
-  anonymousName: PropTypes.string.isRequired,
-  apiRoot: PropTypes.string.isRequired,
   getLoggingDetails: PropTypes.func.isRequired,
   isEditModeToggled: PropTypes.bool.isRequired,
   isSubmitting: PropTypes.bool.isRequired,
@@ -222,7 +217,6 @@ Survey.propTypes = {
   onSurveyModelRemove: PropTypes.func.isRequired,
   onSurveyModelSave: PropTypes.func.isRequired,
   submitter: PropTypes.object.isRequired,
-  surveyConfig: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
 };
 

--- a/src/base/static/components/ui-elements/submitter-name.js
+++ b/src/base/static/components/ui-elements/submitter-name.js
@@ -2,17 +2,18 @@ import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
+import { place as placeConfig } from "config";
+
 const SubmitterName = props => {
   return (
     <strong className={classNames("submitter-name", props.className)}>
-      {props.submitterName || props.anonymousName}
+      {props.submitterName || placeConfig.anonymous_name}
     </strong>
   );
 };
 
 SubmitterName.propTypes = {
   className: PropTypes.string,
-  anonymousName: PropTypes.string.isRequired,
   submitterName: PropTypes.string,
 };
 

--- a/src/base/static/components/ui-elements/support-button.js
+++ b/src/base/static/components/ui-elements/support-button.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import SecondaryButton from "./secondary-button";
+import { support as supportConfig } from "config";
 
 import "./support-button.scss";
 
@@ -14,7 +15,7 @@ const SupportButton = props => {
       })}
       onClick={props.onClickSupport}
     >
-      {props.numSupports || ""} {props.label}
+      {props.numSupports || ""} {supportConfig.submit_btn_text}
     </SecondaryButton>
   );
 };
@@ -22,7 +23,6 @@ const SupportButton = props => {
 SupportButton.propTypes = {
   className: PropTypes.string,
   isSupported: PropTypes.bool.isRequired,
-  label: PropTypes.string.isRequired,
   numSupports: PropTypes.number,
   onClickSupport: PropTypes.func.isRequired,
 };

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -9,6 +9,8 @@ import VVInputForm from "../../components/vv-input-form";
 import PlaceDetail from "../../components/place-detail";
 import FormCategoryMenuWrapper from "../../components/input-form/form-category-menu-wrapper";
 import GeocodeAddressBar from "../../components/geocode-address-bar";
+
+import transformCommonFormElements from "../../utils/common-form-elements";
 // END REACT PORT SECTION //////////////////////////////////////////////////////
 
 var Util = require("../utils.js");
@@ -86,23 +88,10 @@ module.exports = Backbone.View.extend({
       };
 
     // REACT PORT SECTION //////////////////////////////////////////////////////
-    // NOTE: we resolve all common_form_elements here, before the React entry
-    // point. This simplifies the work we have to do within React components.
-    // TODO: This should be bumped as high as possible in the hierarchy, and
-    // possibly should happen in the build process.
-    this.options.placeConfig.place_detail.forEach(category => {
-      category.fields = category.fields.map(field => {
-        if (field.type === "common_form_element") {
-          return Object.assign(
-            {},
-            this.options.placeConfig.common_form_elements[field.name],
-            { name: field.name },
-          );
-        } else {
-          return field;
-        }
-      });
-    });
+    this.options.placeConfig.place_detail = transformCommonFormElements(
+      this.options.placeConfig.place_detail,
+      this.options.placeConfig.common_form_elements,
+    );
     // END REACT PORT SECTION //////////////////////////////////////////////////
 
     // Use the page size as dictated by the server by default, unless

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -605,7 +605,6 @@ module.exports = Backbone.View.extend({
     // when the AppView is ported.
     ReactDOM.render(
       <FormCategoryMenuWrapper
-        mapConfig={this.options.mapConfig}
         hideSpotlightMask={this.hideSpotlightMask.bind(this)}
         hideCenterPoint={this.hideCenterPoint.bind(this)}
         showNewPin={this.showNewPin.bind(this)}
@@ -624,20 +623,19 @@ module.exports = Backbone.View.extend({
             return (
               <VVInputForm
                 {...props}
-                selectedCategoryConfig={state.selectedCategoryConfig}
+                selectedCategory={state.selectedCategory}
               />
             );
           } else {
             return (
               <InputForm
                 {...props}
-                selectedCategoryConfig={state.selectedCategoryConfig}
+                selectedCategory={state.selectedCategory}
               />
             );
           }
         }}
         customComponents={this.options.customComponents}
-        placeConfig={this.options.placeConfig}
       />,
       document.querySelector("#content article"),
     );
@@ -789,17 +787,10 @@ module.exports = Backbone.View.extend({
             map={this.mapView.map}
             model={model}
             appView={this}
-            apiRoot={this.options.appConfig.api_root}
             layerView={this.mapView.layerViews[datasetId][model.cid]}
-            surveyConfig={this.options.surveyConfig}
-            supportConfig={this.options.supportConfig}
-            placeConfig={this.options.placeConfig}
             places={this.places}
-            placeTypes={this.options.placeTypes}
             scrollToResponseId={args.responseId}
             router={this.options.router}
-            storyConfig={this.options.storyConfig}
-            mapConfig={this.options.mapConfig}
             userToken={this.options.userToken}
           />,
           document.querySelector("#content article"),

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -628,10 +628,7 @@ module.exports = Backbone.View.extend({
             );
           } else {
             return (
-              <InputForm
-                {...props}
-                selectedCategory={state.selectedCategory}
-              />
+              <InputForm {...props} selectedCategory={state.selectedCategory} />
             );
           }
         }}

--- a/src/base/static/utils/common-form-elements.js
+++ b/src/base/static/utils/common-form-elements.js
@@ -1,0 +1,15 @@
+module.exports = (placeDetail, commonFormElements) => {
+  placeDetail.forEach(category => {
+    category.fields = category.fields.map(field => {
+      if (field.type === "common_form_element") {
+        return Object.assign({}, commonFormElements[field.name], {
+          name: field.name,
+        });
+      } else {
+        return field;
+      }
+    });
+  });
+
+  return placeDetail;
+};

--- a/src/base/static/utils/config-utils.js
+++ b/src/base/static/utils/config-utils.js
@@ -1,0 +1,9 @@
+import { place as placeConfig } from "config";
+
+const getCategoryConfig = categoryName => {
+  return placeConfig.place_detail.find(
+    categoryConfig => categoryConfig.category === categoryName,
+  );
+};
+
+export { getCategoryConfig };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,13 +59,14 @@ for (var i = 0; i < baseViewPaths.length; i++) {
   }
 }
 
+alias.config = path.resolve(__dirname, "src/flavors", process.env.FLAVOR, "config.yml");
+
 var outputBasePath = path.resolve(__dirname, "www");
 const extractSCSS = new ExtractTextPlugin(
   process.env.NODE_ENV === "production"
     ? "[contenthash].bundle.css"
     : "bundle.css",
 );
-const extractYML = new ExtractTextPlugin("config-en_US.js");
 const theme = process.env.THEME ? process.env.THEME : "default-theme";
 
 module.exports = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,12 @@ for (var i = 0; i < baseViewPaths.length; i++) {
   }
 }
 
-alias.config = path.resolve(__dirname, "src/flavors", process.env.FLAVOR, "config.yml");
+alias.config = path.resolve(
+  __dirname,
+  "src/flavors",
+  process.env.FLAVOR,
+  "config.yml",
+);
 
 var outputBasePath = path.resolve(__dirname, "www");
 const extractSCSS = new ExtractTextPlugin(
@@ -141,7 +146,6 @@ module.exports = {
     new CompressionPlugin({
       asset: "[path].gz[query]",
     }),
-    extractYML,
   ],
   devtool:
     process.env.NODE_ENV === "production" ? false : "cheap-eval-souce-map",


### PR DESCRIPTION
Just your everyday importable config singleton. Nothing fancy.

Convert the `config.yml` object to an importable module. This eliminates the need to pass the config object through layers of component props.

Note that the config is still injected into the Backbone entry point and passed around as usual. For the time being we'll have two copies of the config object: one for use by Backbone, and one for use by React.

**TODO**

 - [x] Update tests