### PR TITLE
Fix form field init bug

### DIFF
--- a/src/base/static/components/form-fields/form-field.js
+++ b/src/base/static/components/form-fields/form-field.js
@@ -26,6 +26,10 @@ class FormField extends Component {
       : null;
     this.props.fieldConfig.hasAutofill = !!autofillValue;
 
+    // TODO: This field initialization mechanism is a little convoluted.
+    // We have to coordinate between the FormField component and its parent--
+    // which manages the state--in order to initialize properly. We should
+    // search for a better pattern to support field state management.
     const initialFieldValue = this.fieldDefinition.getInitialValue({
       value:
         this.props.fieldState.get(constants.FIELD_VALUE_KEY) ||
@@ -36,6 +40,10 @@ class FormField extends Component {
       attachmentModels: this.props.attachmentModels,
     });
 
+    this.state = {
+      isInitialized: false,
+    };
+
     this.onChange(this.props.fieldConfig.name, initialFieldValue, true);
   }
 
@@ -45,6 +53,12 @@ class FormField extends Component {
       nextProps.showValidityStatus ||
       nextProps.updatingField === this.props.fieldConfig.name
     );
+  }
+
+  componentDidMount() {
+    this.setState({
+      isInitialized: true,
+    });
   }
 
   onChange(fieldName, fieldValue, isInitializing = false) {
@@ -88,7 +102,8 @@ class FormField extends Component {
           {this.props.fieldConfig.prompt}
           <span className={cn.optionalMsg}>{t("optionalMsg")}</span>
         </p>
-        {this.fieldDefinition.getComponent(this.props.fieldConfig, this)}
+        {this.state.isInitialized &&
+          this.fieldDefinition.getComponent(this.props.fieldConfig, this)}
       </div>
     );
   }


### PR DESCRIPTION
Fixes: #910 

Fix a subtle bug that causes rich textarea fields to initialize incorrectly in the place detail editor. The bug was caused by the fact that field type components were mounting with the initial value set by their state-managing grandparents; the "initialization" logic in `FormField` actually caused the *second* render of the field type component. 

In most cases this behavior didn't cause a problem. But in the cause of rich textarea fields, the initial field value might need to be transformed in order to swap rich text markup with `<img>` tags of the image content itself. Thus it was possible for rich textarea fields to render with the markup in place.

To fix this, we prevent mounting of field type components until after `FormField` has had a chance to trigger its field initialization logic. I don't think this is a particularly great solution, though, and it points to the need to re-think the way we manage form fields.