### PR TITLE
chore(webpack): update extract-text-webpack-plugin to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2777,7 +2777,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -4552,9 +4552,9 @@
       }
     },
     "extract-text-webpack-plugin": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
-      "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+      "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -14307,7 +14307,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "opn": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "enzyme-to-json": "^3.3.3",
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.7.0",
-    "extract-text-webpack-plugin": "^2.1.2",
+    "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^0.11.2",
     "fs-extra": "^4.0.1",
     "gettext-parser": "^1.2.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,8 +30,6 @@ var entryPoints = [
   "./src/base/static/js/routes.js",
   "./src/base/static/js/handlebars-helpers.js",
   "./src/base/static/scss/default.scss",
-  "./src/base/static/css/quill.snow.css",
-  "./src/base/static/css/jquery.datetimepicker.css",
   "./src/base/static/css/leaflet.draw.css",
   "./src/base/static/css/leaflet-sidebar.css",
   "./src/base/static/css/spectrum.css",


### PR DESCRIPTION
We were having some issues with CSS rules bundling in the wrong order (custom css was getting bundled before base project css). This might have started happening when we updated webpack or it might have been an issue all along and we just got around it with `!important` flags in the custom css.

In any case, based on [this](https://github.com/webpack/webpack/issues/215) thread, it sounds like updating the `extract-text-webpack-plugin` fixes issues with css bundle order.

Also remove a couple of unused css files from the bundle.