### PR TITLE
optimize production bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17656,23 +17656,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
-    "uglifyjs-webpack-plugin": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.1.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
     "umd": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
@@ -18313,6 +18296,16 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+          "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-js": "2.8.29",
+            "webpack-sources": "1.1.0"
           }
         },
         "which-module": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build-js": "webpack -d",
     "build-js-production": "NODE_ENV=production webpack -p",
     "watch-js": "webpack -d --watch",
-    "build": "NODE_ENV=production npm run build-js-production && NODE_ENV=production node scripts/static-build.js",
+    "build": "npm run build-js-production && NODE_ENV=production node scripts/static-build.js",
     "prettier": "prettier --write \"{src,scripts}/**/*.{js,jsx}\""
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ shell.rm("-rf", distPath);
 shell.mkdir("-p", distPath);
 
 var flavorJsFiles = glob.sync(
-  "./src/flavors/" + process.env.FLAVOR + "/static/js/*.js"
+  "./src/flavors/" + process.env.FLAVOR + "/static/js/*.js",
 );
 var entryPoints = [
   "babel-polyfill",
@@ -32,13 +32,12 @@ var entryPoints = [
   "./src/base/static/scss/default.scss",
   "./src/base/static/css/leaflet.draw.css",
   "./src/base/static/css/leaflet-sidebar.css",
-  "./src/base/static/css/spectrum.css",
   "./src/flavors/" + process.env.FLAVOR + "/static/css/custom.css",
   "./src/flavors/" + process.env.FLAVOR + "/config.yml",
 ].concat(flavorJsFiles);
 
 var baseViewPaths = glob.sync(
-  path.resolve(__dirname, "src/base/static/js/views/*.js")
+  path.resolve(__dirname, "src/base/static/js/views/*.js"),
 );
 var alias = {};
 
@@ -51,7 +50,7 @@ for (var i = 0; i < baseViewPaths.length; i++) {
     "src/flavors",
     process.env.FLAVOR,
     "static/js/views/",
-    viewName + ".js"
+    viewName + ".js",
   );
   if (fs.existsSync(flavorViewPath)) {
     alias[aliasName] = flavorViewPath;
@@ -64,7 +63,7 @@ var outputBasePath = path.resolve(__dirname, "www");
 const extractSCSS = new ExtractTextPlugin(
   process.env.NODE_ENV === "production"
     ? "[contenthash].bundle.css"
-    : "bundle.css"
+    : "bundle.css",
 );
 const extractYML = new ExtractTextPlugin("config-en_US.js");
 const theme = process.env.THEME ? process.env.THEME : "default-theme";
@@ -91,7 +90,7 @@ module.exports = {
         loader: "i18next-resource-store-loader",
         query: {
           include: /\.json$/,
-        }
+        },
       },
       {
         test: /\.s?css$/,
@@ -107,14 +106,14 @@ module.exports = {
                 includePaths: [
                   path.resolve(
                     __dirname,
-                    "./node_modules/react-datepicker/dist"
+                    "./node_modules/react-datepicker/dist",
                   ),
                   path.resolve(__dirname, "./node_modules/compass-mixins/lib"),
                   path.resolve(__dirname, "./src/base/static/stylesheets/util"),
                   path.resolve(
                     __dirname,
                     "./src/base/static/stylesheets/themes",
-                    theme
+                    theme,
                   ),
                 ],
               },
@@ -130,14 +129,20 @@ module.exports = {
     ],
   },
   plugins: [
+    new webpack.DefinePlugin({
+      "process.env.NODE_ENV":
+        process.env.NODE_ENV === "production"
+          ? JSON.stringify("production")
+          : JSON.stringify("dev"),
+    }),
     extractSCSS,
     new CompressionPlugin({
       asset: "[path].gz[query]",
     }),
     extractYML,
-    new webpack.optimize.UglifyJsPlugin({ minimize: true }),
   ],
-  devtool: "cheap-eval-souce-map",
+  devtool:
+    process.env.NODE_ENV === "production" ? false : "cheap-eval-souce-map",
   devServer: {
     contentBase: outputBasePath,
     historyApiFallback: {


### PR DESCRIPTION
A few optimizations to our production build:

* remove the redundant Uglify plugin (the `-p` flag to webpack accomplishes the same thing)
* use `DefinePlugin` to make sure the `NODE_ENV` variable is correctly received by packages (see [here](https://webpack.js.org/guides/production/))
* switch off `devtool` on production builds. Somehow the `devtool` setting affects production, which is weird

These optimizations cut the bundle size almost in half.