### PR TITLE
remove moment global

### DIFF
--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -1,10 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DatePicker from "react-datepicker";
+import moment from "moment";
 
 import "./datetime-field.scss";
-
-// TODO: replace moment global.
 
 const DatetimeField = props => {
   const datetimeFormat = "MMMM Do YYYY, h:mm:ss a";

--- a/src/base/static/components/input-explorer/input-explorer-input-item.js
+++ b/src/base/static/components/input-explorer/input-explorer-input-item.js
@@ -1,11 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 const cn = require("classnames");
+import moment from "moment";
 
 import constants from "./constants";
 import "./input-explorer-input-item.scss";
-
-// TODO: Remove moment global.
 
 class InputExplorerInputItem extends Component {
   constructor(props) {

--- a/src/base/static/components/place-detail/metadata-bar.js
+++ b/src/base/static/components/place-detail/metadata-bar.js
@@ -1,7 +1,6 @@
-// TODO: replace moment global.
-
 import React from "react";
 import PropTypes from "prop-types";
+import moment from "moment";
 
 import Avatar from "../ui-elements/avatar";
 import ActionTime from "../ui-elements/action-time";

--- a/src/base/static/components/ui-elements/action-time.js
+++ b/src/base/static/components/ui-elements/action-time.js
@@ -1,9 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
+import moment from "moment";
 
 import "./action-time.scss";
-
-// TODO: replace moment global.
 
 const ActionTime = props => {
   return <time className="action-time">{moment(props.time).fromNow()}</time>;

--- a/src/base/static/js/handlebars-helpers.js
+++ b/src/base/static/js/handlebars-helpers.js
@@ -1,3 +1,5 @@
+import moment from "moment";
+
 var Util = require("./utils.js");
 
 Handlebars.registerHelper("STATIC_URL", function() {

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -189,39 +189,31 @@
 
   {{#if production}}
     <script src="//cdnjs.cloudflare.com/ajax/libs/json2/20121008/json2.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.5.2/underscore-min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.0.0/backbone-min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/backbone.marionette/1.6.1/backbone.marionette.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.10/handlebars.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/esri-leaflet/1.0.3/esri-leaflet.js"></script>
     <script src="//cdn.jsdelivr.net/leaflet.esri.renderers/1.0.0/esri-leaflet-renderers.js"></script>
-    <script src="//cdn.quilljs.com/1.1.4/quill.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-datetimepicker/2.5.3/build/jquery.datetimepicker.full.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/1.4.12/jquery.scrollTo.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/blueimp-load-image/1.2.3/load-image.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/javascript-canvas-to-blob/2.0.6/js/canvas-to-blob.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/spin.js/1.3.2/spin.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.9/leaflet.draw-src.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.0/spectrum.js"></script>
   {{else}}
     <!-- Non-minified, where available -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/json2/20121008/json2.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.5.2/underscore.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.0.0/backbone.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/backbone.marionette/1.6.1/backbone.marionette.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.10/handlebars.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/esri-leaflet/1.0.3/esri-leaflet.js"></script>
     <script src="//cdn.jsdelivr.net/leaflet.esri.renderers/1.0.0/esri-leaflet-renderers.js"></script>
-    <script src="//cdn.quilljs.com/1.1.4/quill.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-datetimepicker/2.5.3/build/jquery.datetimepicker.full.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/1.4.12/jquery.scrollTo.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/blueimp-load-image/1.2.3/load-image.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/javascript-canvas-to-blob/2.0.6/js/canvas-to-blob.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/spin.js/1.3.2/spin.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.9/leaflet.draw-src.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.0/spectrum.js"></script>
   {{/if}}
   
   <!-- These are obscure or customized, self-hosted. -->

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,6 +135,7 @@ module.exports = {
           ? JSON.stringify("production")
           : JSON.stringify("dev"),
     }),
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     extractSCSS,
     new CompressionPlugin({
       asset: "[path].gz[query]",


### PR DESCRIPTION
- remove the `moment` script tag and references to the `moment` global
- use webpack's `IgnorePlugin` to ignore moment's locales
- remove some other extraneous script tags

This cuts production bundle size by about 15%.