### PR TITLE
Support submitter editing on detail views

### DIFF
--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -92,6 +92,8 @@ class PlaceDetail extends Component {
       isEditable: Util.getAdminStatus(
         this.props.model.get(constants.DATASET_ID_PROPERTY_NAME),
         this.categoryConfig.admin_groups,
+        !!this.categoryConfig.submitter_editing_supported,
+        this.props.model.get(constants.SUBMITTER_FIELD_NAME),
       ),
       isEditFormSubmitting: false,
       isSurveyEditFormSubmitting: false,

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -333,6 +333,7 @@ place:
   #### begin dynamic form config ####
   place_detail:
     - category: demo
+      submitter_editing_supported: true
       includeOnForm: true
       name: location_type
       dataset: demo


### PR DESCRIPTION
This PR is a companion to https://github.com/mapseed/api/pull/118 and should be merged at the same time.

Add the ability for logged-in users to edit places they previously submitted under the same user credentials. Submitter editors are presented with the same editor tools as administrators.

Submitter editing can be controlled at the `location_type` level. Submitter editing is disabled by default. To enable it, add the following flag under the `place_detail` section for a given `location_type` in the config:

```
submitter_editing_supported: true
```