### PR TITLE
refactor: make story abstraction robust to misconfigurations

### DIFF
--- a/src/base/static/components/molecules/story-chapter.scss
+++ b/src/base/static/components/molecules/story-chapter.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  width: 100%;
   margin-left: 8px;
   padding: 10px;
   border-left: 2px solid transparent;

--- a/src/base/static/components/story-sidebar/index.js
+++ b/src/base/static/components/story-sidebar/index.js
@@ -43,7 +43,6 @@ class StorySidebar extends Component {
         );
       })
       .catch(e => {
-        console.log("ERROR", e);
         this.setState({
           isWithError: true,
         });

--- a/src/base/static/utils/collection-utils.js
+++ b/src/base/static/utils/collection-utils.js
@@ -9,12 +9,13 @@ const getModelFromUrl = (collections, route) => {
   // If the url has a slash in it with text on either side, we assume we have
   // a place model url and can look up the model directly.
   if (splitRoute.length === 2) {
-    return (
-      collections[
-        mapConfig.layers.find(layerConfig => layerConfig.slug === splitRoute[0])
-          .id
-      ].get(splitRoute[1]) || {}
+    const layerConfig = mapConfig.layers.find(
+      config => config.slug === splitRoute[0],
     );
+
+    if (layerConfig) {
+      return collections[layerConfig.id].get(splitRoute[1]);
+    }
   } else {
     // Otherwise, we have a "landmark-style" url, and have to search all place
     // collections.
@@ -29,7 +30,7 @@ const getModelFromUrl = (collections, route) => {
       }
     });
 
-    return foundModel || {};
+    return foundModel;
   }
 };
 

--- a/src/base/static/utils/story-utils.js
+++ b/src/base/static/utils/story-utils.js
@@ -16,12 +16,18 @@ const hydrateStoriesFromConfig = (placeCollectionPromises, places) => {
                 .set(
                   "chapters",
                   storyEntry[1].chapters.reduce((chapters, chapter) => {
-                    return chapters.set(
-                      chapter.url,
-                      fromJS(
-                        getModelFromUrl(places, chapter.url).attributes,
-                      ).set("sidebarIconUrl", chapter.sidebarIconUrl),
-                    );
+                    const model = getModelFromUrl(places, chapter.url);
+                    if (model) {
+                      return chapters.set(
+                        chapter.url,
+                        fromJS(model.attributes).set(
+                          "sidebarIconUrl",
+                          chapter.sidebarIconUrl,
+                        ),
+                      );
+                    } else {
+                      return chapters;
+                    }
                   }, OrderedMap()),
                 )
                 .set("header", storyConfig[storyName].header)


### PR DESCRIPTION
The story sidebar will refuse to load if any chapter contains an incorrect url or a url that doesn't exist in any collection. This PR makes the sidebar robust to these misconfigurations.

Also fix an issue with story chapter content overflowing its container.