### PR TITLE
Prevent the enter button from submitting forms

### DIFF
--- a/src/base/static/components/form-fields/field-definitions.js
+++ b/src/base/static/components/form-fields/field-definitions.js
@@ -260,9 +260,10 @@ export default {
   },
   [constants.SUBMIT_FIELD_TYPENAME]: {
     getValidator: getPermissiveValidator,
-    getComponent: fieldConfig => (
+    getComponent: (fieldConfig, context) => (
       <InputFormSubmitButton
-        name={fieldConfig.name}
+        {...getSharedFieldProps(fieldConfig, context)}
+        onClickSubmit={context.props.onClickSubmit.bind(context)}
         label={fieldConfig.label}
       />
     ),

--- a/src/base/static/components/form-fields/types/input-form-submit-button.js
+++ b/src/base/static/components/form-fields/types/input-form-submit-button.js
@@ -1,22 +1,27 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 
 import "./input-form-submit-button.scss";
 
-class InputFormSubmitButton extends Component {
-  render() {
-    return (
-      <button className="input-form-submit-button" type="submit">
-        {this.props.label}
-      </button>
-    );
-  }
-}
+const InputFormSubmitButton = props => {
+  return (
+    <button
+      name={props.name}
+      disabled={props.disabled}
+      className="input-form-submit-button"
+      type="button"
+      onClick={props.onClickSubmit}
+    >
+      {props.label}
+    </button>
+  );
+};
 
 InputFormSubmitButton.propTypes = {
   disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  onClickSubmit: PropTypes.func.isRequired,
 };
 
 export default InputFormSubmitButton;

--- a/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
+++ b/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
@@ -36,6 +36,7 @@ exports[`InputForm renders input form 1`] = `
         }
       }
       onAddAttachment={[Function]}
+      onClickSubmit={[Function]}
       onFieldChange={[Function]}
       onGeometryStyleChange={[Function]}
       places={Object {}}
@@ -71,6 +72,7 @@ exports[`InputForm renders input form 1`] = `
         }
       }
       onAddAttachment={[Function]}
+      onClickSubmit={[Function]}
       onFieldChange={[Function]}
       onGeometryStyleChange={[Function]}
       places={Object {}}
@@ -106,6 +108,7 @@ exports[`InputForm renders input form 1`] = `
         }
       }
       onAddAttachment={[Function]}
+      onClickSubmit={[Function]}
       onFieldChange={[Function]}
       onGeometryStyleChange={[Function]}
       places={Object {}}

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -173,8 +173,7 @@ class InputForm extends Component {
     }
   }
 
-  onSubmit(evt) {
-    evt.preventDefault();
+  onSubmit() {
     Util.log("USER", "new-place", "submit-place-btn-click");
 
     this.validateForm(this.saveModel.bind(this));
@@ -354,7 +353,7 @@ class InputForm extends Component {
         <form
           id="mapseed-input-form"
           className={cn.form}
-          onSubmit={this.onSubmit.bind(this)}
+          onSubmit={evt => evt.preventDefault()}
         >
           {this.getFields()
             .map((fieldState, fieldName) => {
@@ -375,6 +374,7 @@ class InputForm extends Component {
                   router={this.props.router}
                   showValidityStatus={this.state.showValidityStatus}
                   updatingField={this.state.updatingField}
+                  onClickSubmit={this.onSubmit.bind(this)}
                 />
               );
             })

--- a/src/base/static/components/place-detail/survey.js
+++ b/src/base/static/components/place-detail/survey.js
@@ -68,9 +68,7 @@ class Survey extends Component {
     }));
   }
 
-  onSubmit(evt) {
-    evt.preventDefault();
-
+  onSubmit() {
     const newValidationErrors = this.state.fields
       .filter(value => !value.get(constants.FIELD_VALIDITY_KEY))
       .reduce((newValidationErrors, invalidField) => {
@@ -166,7 +164,7 @@ class Survey extends Component {
         />
         <form
           className="place-detail-survey__form"
-          onSubmit={this.onSubmit.bind(this)}
+          onSubmit={evt => evt.preventDefault()}
         >
           {this.state.fields
             .map((fieldState, fieldName) => (
@@ -181,6 +179,7 @@ class Survey extends Component {
                 disabled={this.state.isFormSubmitting}
                 onFieldChange={this.onFieldChange.bind(this)}
                 fieldState={fieldState}
+                onClickSubmit={this.onSubmit.bind(this)}
               />
             ))
             .toArray()}


### PR DESCRIPTION
It was previously possible to submit forms in Mapseed by pressing the enter key on certain fields (like text fields).

This is undesirable, since we want submissions to occur only via the Submit button.

This PR disables enter submissions on the input form and the place detail survey form.