### PR TITLE
feat: add an information-only field type

### DIFF
--- a/src/base/static/components/form-fields/field-definitions.js
+++ b/src/base/static/components/form-fields/field-definitions.js
@@ -31,6 +31,7 @@ import {
   BigToggleFieldResponse,
   DropdownFieldResponse,
   AutocompleteComboboxFieldResponse,
+  InformationalHTMLField,
 } from "./types";
 import { isWithAnyValue, isNotEmpty, isWithUniqueUrl } from "./validators";
 import { insertEmbeddedImages } from "../../utils/embedded-images";
@@ -281,5 +282,16 @@ export default {
     ),
     getInitialValue: ({ value }) => value,
     getResponseComponent: () => RangeFieldResponse,
+  },
+  [constants.INFORMATIONAL_HTML_FIELD_TYPENAME]: {
+    getValidator: getPermissiveValidator,
+    getComponent: (fieldConfig, context) => (
+      <InformationalHTMLField
+        {...getSharedFieldProps(fieldConfig, context)}
+        content={fieldConfig.content}
+      />
+    ),
+    getInitialValue: () => null,
+    getResponseComponent: () => null,
   },
 };

--- a/src/base/static/components/form-fields/types/index.js
+++ b/src/base/static/components/form-fields/types/index.js
@@ -37,3 +37,4 @@ export { default as MapDrawingToolbar } from "./map-drawing-toolbar";
 export { default as PublishControlToolbar } from "./publish-control-toolbar";
 export { default as RangeSliderWithLabel } from "./range-slider-with-label";
 export { default as RichTextareaField } from "./rich-textarea-field";
+export { default as InformationalHTMLField } from "./informational-html-field";

--- a/src/base/static/components/form-fields/types/informational-html-field.js
+++ b/src/base/static/components/form-fields/types/informational-html-field.js
@@ -1,0 +1,12 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const InformationalHTMLField = props => {
+  return <div dangerouslySetInnerHTML={{ __html: props.content }} />;
+};
+
+InformationalHTMLField.propTypes = {
+  content: PropTypes.string.isRequired,
+};
+
+export default InformationalHTMLField;

--- a/src/base/static/constants.js
+++ b/src/base/static/constants.js
@@ -16,6 +16,7 @@ export default {
   COMMON_FORM_ELEMENT_TYPENAME: "common_form_element",
   SUBMIT_FIELD_TYPENAME: "submit",
   RANGE_FIELD_TYPENAME: "range",
+  INFORMATIONAL_HTML_FIELD_TYPENAME: "informational_html",
 
   SUBMITTER_FIELDNAME: "submitter_name",
 

--- a/src/base/static/utils/field-response-filter.js
+++ b/src/base/static/utils/field-response-filter.js
@@ -10,6 +10,7 @@ export default (fieldList, backboneModelAttributes) =>
           constants.CUSTOM_URL_TOOLBAR_TYPENAME,
           constants.MAP_DRAWING_TOOLBAR_TYPENAME,
           constants.PUBLISH_CONTROL_TOOLBAR_TYPENAME,
+          constants.INFORMATIONAL_HTML_FIELD_TYPENAME,
         ].includes(fieldConfig.type) &&
         ![
           constants.LOCATION_TYPE_PROPERTY_NAME,

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -358,7 +358,7 @@ place:
           icon_url: ""
           header: _(Stage 3)
         - start_field_index: 11
-          end_field_index: 16
+          end_field_index: 18
           icon_url: ""
           header: _(Stage 4)
 
@@ -371,6 +371,10 @@ place:
           display_prompt: _(Ttile:)
           placeholder: _(Enter title...)
           optional: false
+        - name: informational
+          type: informational_html
+          prompt: _(Info)
+          content: <h1>This is some information for you.</h1><p>Hooray.</p>
         - name: text_field
           type: text
           autocomplete: true


### PR DESCRIPTION
Add a form "field" intended to display arbitrary HTML content. Use as follows:

```
- name: info
  type: informational_html
  prompt: _(Some information:)
  content: <div>Any HTML string</div>
```

Contents of this field will not be submitted to the database and will not appear on detail views.