### PR TITLE
Move Config into Redux store

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,10 @@
     ],
     "react"
   ],
-  "plugins": ["transform-runtime", "transform-es2015-destructuring", "transform-object-rest-spread" ]
+  "plugins": [
+    "transform-runtime",
+    "transform-object-rest-spread",
+    "transform-async-to-generator",
+    "transform-async-generator-functions"
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,9 +10,12 @@
     }
   },
   "globals": {
-    "__LOGGER__": false,
-    "SERVER_SIDE": false,
-    "Backbone": true
+    "Backbone": false,
+    "module": false,
+    "_": false,
+    "$": false,
+    "Handlebars": false,
+    "Shareabouts": false
   },
   "env": {
     "browser": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -682,7 +682,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -821,7 +820,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -834,7 +832,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -875,7 +872,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -933,7 +929,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -979,8 +974,12 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
@@ -1012,11 +1011,20 @@
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
     },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -1472,7 +1480,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -1485,7 +1492,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
@@ -1502,7 +1508,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
@@ -1513,8 +1518,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2777,7 +2781,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -5913,8 +5917,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "6.1.0",
@@ -6773,7 +6776,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -9106,6 +9108,11 @@
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lodash-es": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -14312,7 +14319,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "opn": {
@@ -15796,6 +15803,19 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "2.5.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.10",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.1"
+      }
+    },
     "react-spinner": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/react-spinner/-/react-spinner-0.2.7.tgz",
@@ -15918,6 +15938,15 @@
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
+      }
+    },
+    "redux": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+      "requires": {
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.2.0"
       }
     },
     "regenerate": {
@@ -17249,6 +17278,11 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -17480,8 +17514,7 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "dependencies": {
     "accessible-autocomplete": "github:mapseed/accessible-autocomplete#7e56b805ee7ce77bebae67f6454a5c3f5e4987a8",
+    "babel-plugin-transform-async-generator-functions": "^6.24.1",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "classnames": "^2.2.5",
@@ -57,7 +59,9 @@
     "react-i18next": "^7.5.1",
     "react-modal": "^3.4.4",
     "react-quill": "^1.1.0",
+    "react-redux": "^5.0.7",
     "react-spinner": "^0.2.7",
+    "redux": "^4.0.0",
     "s3-website": "^3.2.2",
     "shelljs": "^0.5.3",
     "static-eval": "^1.1.1",

--- a/src/base/static/client/mapseed-api-client.js
+++ b/src/base/static/client/mapseed-api-client.js
@@ -1,0 +1,79 @@
+const getPlaceCollections = async ({
+  placeParams,
+  placeCollections,
+  mapView,
+  mapConfig,
+}) => {
+  const $progressContainer = $("#map-progress");
+  const $currentProgress = $("#map-progress .current-progress");
+  let totalPages;
+  let pagesComplete = 0;
+  let pageSize;
+
+  // TODO(luke): Once backbone models are ported into the redux store,
+  // mapseedApiClient will handle the logic for handling the responses
+  // from the api directly.
+
+  // loop over all place collections
+  const placeCollectionPromises = [];
+  _.each(placeCollections, function(collection, key) {
+    mapView.map.fire("layer:loading", { id: key });
+    const placeCollectionPromise = collection.fetchAllPages({
+      remove: false,
+      // Check for a valid location type before adding it to the collection
+      validate: true,
+      data: placeParams,
+      // get the dataset slug and id from the array of map layers
+      attributesToAdd: {
+        datasetSlug: _.find(mapConfig.layers, function(layer) {
+          return layer.id == key;
+        }).slug,
+        datasetId: _.find(mapConfig.layers, function(layer) {
+          return layer.id == key;
+        }).id,
+      },
+      attribute: "properties",
+
+      // Only do this for the first page...
+      pageSuccess: _.once(function(collection, data) {
+        pageSize = data.features.length;
+        totalPages = Math.ceil(data.metadata.length / pageSize);
+
+        if (data.metadata.next) {
+          $progressContainer.show();
+        }
+      }),
+
+      // Do this for every page...
+      pageComplete: function() {
+        var percent;
+
+        pagesComplete++;
+        percent = pagesComplete / totalPages * 100;
+        $currentProgress.width(percent + "%");
+
+        if (pagesComplete === totalPages) {
+          _.delay(function() {
+            $progressContainer.hide();
+          }, 2000);
+        }
+      },
+
+      success: function() {
+        mapView.map.fire("layer:loaded", { id: key });
+      },
+
+      error: function() {
+        mapView.map.fire("layer:error", { id: key });
+      },
+    });
+    placeCollectionPromises.push(placeCollectionPromise);
+  });
+  return await Promise.all(placeCollectionPromises);
+};
+
+export default {
+  place: {
+    get: getPlaceCollections,
+  },
+};

--- a/src/base/static/state/ducks/config.js
+++ b/src/base/static/state/ducks/config.js
@@ -1,0 +1,34 @@
+// Selectors:
+export const storyConfigSelector = state => {
+  return state.config.story;
+};
+export const placeConfigSelector = state => {
+  return state.config.place;
+};
+export const mapConfigSelector = state => {
+  return state.config.map;
+};
+
+// Actions:
+const SET_CONFIG = "SET_CONFIG";
+
+// Action creators:
+export function setConfig(config) {
+  return { type: SET_CONFIG, payload: config };
+}
+
+// Reducers:
+// TODO(luke): refactor our current implementation in AppView to use
+const INITIAL_STATE = null;
+
+export default function reducer(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case SET_CONFIG:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/base/static/state/ducks/ui.js
+++ b/src/base/static/state/ducks/ui.js
@@ -1,0 +1,47 @@
+// This is skeleton code only!
+// TODO(luke): refactor our current implementation in AppView to use
+// this reducer
+
+// Selectors:
+export const sidebarExpandedSelector = state => {
+  return state.ui.isSidebarExpanded;
+};
+export const contentPanelOpenSelector = state => {
+  return state.ui.isConentPanelOpen;
+};
+
+// Actions:
+const SET_UI_SIDEBAR = "ui/SET_UI_SIDEBAR";
+const SET_UI_CONTENT_PANEL = "ui/SET_UI_CONTENT_PANEL";
+
+// Action creators:
+export function setContentPanel(isOpen) {
+  return { type: SET_UI_CONTENT_PANEL, payload: isOpen };
+}
+
+export function setSidebar(isExpanded) {
+  return { type: SET_UI_SIDEBAR, payload: isExpanded };
+}
+
+// Reducers:
+const INITIAL_STATE = {
+  isContentPanelOpen: undefined,
+  isSidebarExpanded: undefined,
+};
+
+export default function reducer(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case SET_UI_CONTENT_PANEL:
+      return {
+        ...state,
+        isContentPanelOpen: action.payload,
+      };
+    case SET_UI_SIDEBAR:
+      return {
+        ...state,
+        isSidebarExpanded: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/base/static/state/reducers.js
+++ b/src/base/static/state/reducers.js
@@ -1,0 +1,10 @@
+import { combineReducers } from "redux";
+import uiReducer from "./ducks/ui";
+import configReducer from "./ducks/config";
+
+const reducers = combineReducers({
+  ui: uiReducer,
+  config: configReducer,
+});
+
+export default reducers;

--- a/src/base/static/utils/collection-utils.js
+++ b/src/base/static/utils/collection-utils.js
@@ -1,9 +1,9 @@
 import constants from "../constants";
-import { map as mapConfig } from "config";
 
 // Given a route and a POJO of Backbone collections, return the model that
 // matches the route if it exists.
-const getModelFromUrl = (collections, route) => {
+const getModelFromUrl = ({ collections, route, mapConfig }) => {
+  // ie: "myStory/123"
   const splitRoute = route.split("/");
 
   // If the url has a slash in it with text on either side, we assume we have

--- a/src/flavors/augusta/static/js/views/app-view.js
+++ b/src/flavors/augusta/static/js/views/app-view.js
@@ -6,6 +6,16 @@ import GeocodeAddressBar from "../../../../../base/static/components/geocode-add
 import InfoModal from "../../../../../base/static/components/organisms/info-modal";
 import languageModule from "../../../../../base/static/language-module";
 
+import { Provider } from "react-redux";
+import { createStore } from "redux";
+import reducer from "../../../../../base/static/state/reducers";
+import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
+// TODO(luke): This should be the only instance of our config singleton.
+// Eventually, it will be removed once we start fetching the config
+// from the api:
+import config from "config";
+import { setConfig } from "../../../../../base/static/state/ducks/config";
+
 import transformCommonFormElements from "../../../../../base/static/utils/common-form-elements";
 
 const AppView = require("../../../../../base/static/js/views/app-view.js");
@@ -19,6 +29,9 @@ const ActivityView = require("../../../../../base/static/js/views/activity-view"
 //const PlaceListView = require('../../../../../base/static/js/views/place-list-view');
 // END FLAVOR-SPECIFIC CODE
 const RightSidebarView = require("../../../../../base/static/js/views/right-sidebar-view");
+
+// TODO(luke): move this into index.js (currently routes.js)
+const store = createStore(reducer);
 
 module.exports = AppView.extend({
   events: {
@@ -36,6 +49,9 @@ module.exports = AppView.extend({
   initialize: function() {
     // store promises returned from collection fetches
     Shareabouts.deferredCollections = [];
+    // TODO(luke): move this into "componentDidMount" when App becomes a
+    // component:
+    store.dispatch(setConfig(config));
 
     languageModule.changeLanguage(this.options.languageCode);
 
@@ -237,7 +253,9 @@ module.exports = AppView.extend({
     // REACT PORT SECTION /////////////////////////////////////////////////////
     if (this.options.mapConfig.geocoding_bar_enabled) {
       ReactDOM.render(
-        <GeocodeAddressBar mapConfig={this.options.mapConfig} />,
+        <Provider store={store}>
+          <GeocodeAddressBar mapConfig={this.options.mapConfig} />
+        </Provider>,
         document.getElementById("geocode-address-bar"),
       );
     }
@@ -268,11 +286,13 @@ module.exports = AppView.extend({
       );
 
       ReactDOM.render(
-        <InfoModal
-          parentId="info-modal-container"
-          isModalOpen={true}
-          {...modalContent}
-        />,
+        <Provider store={store}>
+          <InfoModal
+            parentId="info-modal-container"
+            isModalOpen={true}
+            {...modalContent}
+          />
+        </Provider>,
         document.getElementById("info-modal-container"),
       );
     });
@@ -353,8 +373,14 @@ module.exports = AppView.extend({
     this.setBodyClass();
     this.showCenterPoint();
 
-    // Load places from the API
-    this.loadPlaces(placeParams);
+    // TODO(luke): move this into componentDidMount when App is ported
+    // to a component:
+    mapseedApiClient.place.get({
+      placeParams,
+      placeCollections: self.places,
+      mapView: self.mapView,
+      mapConfig: self.options.mapConfig,
+    });
 
     // Load activities from the API
     _.each(this.activities, function(collection, key) {
@@ -410,11 +436,13 @@ module.exports = AppView.extend({
 
     // NOTE: we hard-code the augusta-input collection here
     ReactDOM.render(
-      <InputExplorer
-        appConfig={this.options.appConfig}
-        placeConfig={this.options.placeConfig.place_detail}
-        communityInput={this.places["augusta-input"]}
-      />,
+      <Provider store={store}>
+        <InputExplorer
+          appConfig={this.options.appConfig}
+          placeConfig={this.options.placeConfig.place_detail}
+          communityInput={this.places["augusta-input"]}
+        />
+      </Provider>,
       document.querySelector("#list-container"),
     );
   },

--- a/src/flavors/hull/static/js/views/app-view.js
+++ b/src/flavors/hull/static/js/views/app-view.js
@@ -5,7 +5,16 @@ import InputExplorer from "../../../../../base/static/components/input-explorer"
 import GeocodeAddressBar from "../../../../../base/static/components/geocode-address-bar";
 import InfoModal from "../../../../../base/static/components/organisms/info-modal";
 import languageModule from "../../../../../base/static/language-module";
-import i18next from "i18next";
+
+import { Provider } from "react-redux";
+import { createStore } from "redux";
+import reducer from "../../../../../base/static/state/reducers";
+import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
+// TODO(luke): This should be the only instance of our config singleton.
+// Eventually, it will be removed once we start fetching the config
+// from the api:
+import config from "config";
+import { setConfig } from "../../../../../base/static/state/ducks/config";
 
 import transformCommonFormElements from "../../../../../base/static/utils/common-form-elements";
 
@@ -20,6 +29,9 @@ const ActivityView = require("../../../../../base/static/js/views/activity-view"
 //const PlaceListView = require('../../../../../base/static/js/views/place-list-view');
 // END FLAVOR-SPECIFIC CODE
 const RightSidebarView = require("../../../../../base/static/js/views/right-sidebar-view");
+
+// TODO(luke): move this into index.js (currently routes.js)
+const store = createStore(reducer);
 
 module.exports = AppView.extend({
   events: {
@@ -37,6 +49,9 @@ module.exports = AppView.extend({
   initialize: function() {
     // store promises returned from collection fetches
     Shareabouts.deferredCollections = [];
+    // TODO(luke): move this into "componentDidMount" when App becomes a
+    // component:
+    store.dispatch(setConfig(config));
 
     languageModule.changeLanguage(this.options.languageCode);
 
@@ -238,7 +253,9 @@ module.exports = AppView.extend({
     // REACT PORT SECTION /////////////////////////////////////////////////////
     if (this.options.mapConfig.geocoding_bar_enabled) {
       ReactDOM.render(
-        <GeocodeAddressBar mapConfig={this.options.mapConfig} />,
+        <Provider store={store}>
+          <GeocodeAddressBar mapConfig={this.options.mapConfig} />
+        </Provider>,
         document.getElementById("geocode-address-bar"),
       );
     }
@@ -269,11 +286,13 @@ module.exports = AppView.extend({
       );
 
       ReactDOM.render(
-        <InfoModal
-          parentId="info-modal-container"
-          isModalOpen={true}
-          {...modalContent}
-        />,
+        <Provider store={store}>
+          <InfoModal
+            parentId="info-modal-container"
+            isModalOpen={true}
+            {...modalContent}
+          />
+        </Provider>,
         document.getElementById("info-modal-container"),
       );
     });
@@ -354,8 +373,14 @@ module.exports = AppView.extend({
     this.setBodyClass();
     this.showCenterPoint();
 
-    // Load places from the API
-    this.loadPlaces(placeParams);
+    // TODO(luke): move this into componentDidMount when App is ported
+    // to a component:
+    mapseedApiClient.place.get({
+      placeParams,
+      placeCollections: self.places,
+      mapView: self.mapView,
+      mapConfig: self.options.mapConfig,
+    });
 
     // Load activities from the API
     _.each(this.activities, function(collection, key) {
@@ -411,11 +436,13 @@ module.exports = AppView.extend({
 
     // NOTE: we hard-code the hull-input collection here
     ReactDOM.render(
-      <InputExplorer
-        appConfig={this.options.appConfig}
-        placeConfig={this.options.placeConfig.place_detail}
-        communityInput={this.places["hull-input"]}
-      />,
+      <Provider store={store}>
+        <InputExplorer
+          appConfig={this.options.appConfig}
+          placeConfig={this.options.placeConfig.place_detail}
+          communityInput={this.places["hull-input"]}
+        />
+      </Provider>,
       document.querySelector("#list-container"),
     );
   },

--- a/src/flavors/manzanares/static/js/views/app-view.js
+++ b/src/flavors/manzanares/static/js/views/app-view.js
@@ -6,6 +6,16 @@ import GeocodeAddressBar from "../../../../../base/static/components/geocode-add
 import InfoModal from "../../../../../base/static/components/organisms/info-modal";
 import languageModule from "../../../../../base/static/language-module";
 
+import { Provider } from "react-redux";
+import { createStore } from "redux";
+import reducer from "../../../../../base/static/state/reducers";
+import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
+// TODO(luke): This should be the only instance of our config singleton.
+// Eventually, it will be removed once we start fetching the config
+// from the api:
+import config from "config";
+import { setConfig } from "../../../../../base/static/state/ducks/config";
+
 import transformCommonFormElements from "../../../../../base/static/utils/common-form-elements";
 
 const AppView = require("../../../../../base/static/js/views/app-view.js");
@@ -19,6 +29,9 @@ const ActivityView = require("../../../../../base/static/js/views/activity-view"
 //const PlaceListView = require("../../../../../base/static/js/views/place-list-view");
 // END FLAVOR-SPECIFIC CODE
 const RightSidebarView = require("../../../../../base/static/js/views/right-sidebar-view");
+
+// TODO(luke): move this into index.js (currently routes.js)
+const store = createStore(reducer);
 
 module.exports = AppView.extend({
   events: {
@@ -36,6 +49,9 @@ module.exports = AppView.extend({
   initialize: function() {
     // store promises returned from collection fetches
     Shareabouts.deferredCollections = [];
+    // TODO(luke): move this into "componentDidMount" when App becomes a
+    // component:
+    store.dispatch(setConfig(config));
 
     languageModule.changeLanguage(this.options.languageCode);
 
@@ -237,7 +253,9 @@ module.exports = AppView.extend({
     // REACT PORT SECTION /////////////////////////////////////////////////////
     if (this.options.mapConfig.geocoding_bar_enabled) {
       ReactDOM.render(
-        <GeocodeAddressBar mapConfig={this.options.mapConfig} />,
+        <Provider store={store}>
+          <GeocodeAddressBar mapConfig={this.options.mapConfig} />
+        </Provider>,
         document.getElementById("geocode-address-bar"),
       );
     }
@@ -268,11 +286,13 @@ module.exports = AppView.extend({
       );
 
       ReactDOM.render(
-        <InfoModal
-          parentId="info-modal-container"
-          isModalOpen={true}
-          {...modalContent}
-        />,
+        <Provider store={store}>
+          <InfoModal
+            parentId="info-modal-container"
+            isModalOpen={true}
+            {...modalContent}
+          />
+        </Provider>,
         document.getElementById("info-modal-container"),
       );
     });
@@ -354,7 +374,14 @@ module.exports = AppView.extend({
     this.showCenterPoint();
 
     // Load places from the API
-    this.loadPlaces(placeParams);
+    // TODO(luke): move this into componentDidMount when App is ported
+    // to a component:
+    mapseedApiClient.place.get({
+      placeParams,
+      placeCollections: self.places,
+      mapView: self.mapView,
+      mapConfig: self.options.mapConfig,
+    });
 
     // Load activities from the API
     _.each(this.activities, function(collection, key) {
@@ -410,11 +437,13 @@ module.exports = AppView.extend({
 
     // NOTE: we hard-code the manzanares-input collection here
     ReactDOM.render(
-      <InputExplorer
-        appConfig={this.options.appConfig}
-        placeConfig={this.options.placeConfig.place_detail}
-        communityInput={this.places["manzanares-input"]}
-      />,
+      <Provider store={store}>
+        <InputExplorer
+          appConfig={this.options.appConfig}
+          placeConfig={this.options.placeConfig.place_detail}
+          communityInput={this.places["manzanares-input"]}
+        />
+      </Provider>,
       document.querySelector("#list-container"),
     );
   },

--- a/src/flavors/williams/static/js/views/app-view.js
+++ b/src/flavors/williams/static/js/views/app-view.js
@@ -6,6 +6,16 @@ import GeocodeAddressBar from "../../../../../base/static/components/geocode-add
 import InfoModal from "../../../../../base/static/components/organisms/info-modal";
 import languageModule from "../../../../../base/static/language-module";
 
+import { Provider } from "react-redux";
+import { createStore } from "redux";
+import reducer from "../../../../../base/static/state/reducers";
+import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
+// TODO(luke): This should be the only instance of our config singleton.
+// Eventually, it will be removed once we start fetching the config
+// from the api:
+import config from "config";
+import { setConfig } from "../../../../../base/static/state/ducks/config";
+
 import transformCommonFormElements from "../../../../../base/static/utils/common-form-elements";
 
 const AppView = require("../../../../../base/static/js/views/app-view.js");
@@ -19,6 +29,9 @@ const ActivityView = require("../../../../../base/static/js/views/activity-view"
 //const PlaceListView = require('../../../../../base/static/js/views/place-list-view');
 // END FLAVOR-SPECIFIC CODE
 const RightSidebarView = require("../../../../../base/static/js/views/right-sidebar-view");
+
+// TODO(luke): move this into index.js (currently routes.js)
+const store = createStore(reducer);
 
 module.exports = AppView.extend({
   events: {
@@ -36,6 +49,9 @@ module.exports = AppView.extend({
   initialize: function() {
     // store promises returned from collection fetches
     Shareabouts.deferredCollections = [];
+    // TODO(luke): move this into "componentDidMount" when App becomes a
+    // component:
+    store.dispatch(setConfig(config));
 
     languageModule.changeLanguage(this.options.languageCode);
 
@@ -237,7 +253,9 @@ module.exports = AppView.extend({
     // REACT PORT SECTION /////////////////////////////////////////////////////
     if (this.options.mapConfig.geocoding_bar_enabled) {
       ReactDOM.render(
-        <GeocodeAddressBar mapConfig={this.options.mapConfig} />,
+        <Provider store={store}>
+          <GeocodeAddressBar mapConfig={this.options.mapConfig} />
+        </Provider>,
         document.getElementById("geocode-address-bar"),
       );
     }
@@ -268,11 +286,13 @@ module.exports = AppView.extend({
       );
 
       ReactDOM.render(
-        <InfoModal
-          parentId="info-modal-container"
-          isModalOpen={true}
-          {...modalContent}
-        />,
+        <Provider store={store}>
+          <InfoModal
+            parentId="info-modal-container"
+            isModalOpen={true}
+            {...modalContent}
+          />
+        </Provider>,
         document.getElementById("info-modal-container"),
       );
     });
@@ -354,7 +374,14 @@ module.exports = AppView.extend({
     this.showCenterPoint();
 
     // Load places from the API
-    this.loadPlaces(placeParams);
+    // TODO(luke): move this into componentDidMount when App is ported
+    // to a component:
+    mapseedApiClient.place.get({
+      placeParams,
+      placeCollections: self.places,
+      mapView: self.mapView,
+      mapConfig: self.options.mapConfig,
+    });
 
     // Load activities from the API
     _.each(this.activities, function(collection, key) {
@@ -410,11 +437,13 @@ module.exports = AppView.extend({
 
     // NOTE: we hard-code the williams-input collection here
     ReactDOM.render(
-      <InputExplorer
-        appConfig={this.options.appConfig}
-        placeConfig={this.options.placeConfig.place_detail}
-        communityInput={this.places["williams-input"]}
-      />,
+      <Provider store={store}>
+        <InputExplorer
+          appConfig={this.options.appConfig}
+          placeConfig={this.options.placeConfig.place_detail}
+          communityInput={this.places["williams-input"]}
+        />
+      </Provider>,
       document.querySelector("#list-container"),
     );
   },


### PR DESCRIPTION
This PR:
 - Adds Redux as a dep, and stores our Config data in the store. Uses the "ducks" pattern as described here: https://github.com/erikras/ducks-modular-redux
 - Updates StorySidebar to read config data from the Redux store instead of from the Config singleton. 
 - Implements a MapseedApiClient to clean up the logic in AppView
 - Adds async/await support via Babel



TODO:
 - [x] Update custom code flavors AppView to by in sync with the new AppView changes **DONE, but getting this error: https://github.com/mapseed/platform/pull/949/files#r188185629**