### PR TITLE
Improve datepicker field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,7 @@
     },
     "accessible-autocomplete": {
       "version": "github:mapseed/accessible-autocomplete#7e56b805ee7ce77bebae67f6454a5c3f5e4987a8",
+      "from": "accessible-autocomplete@github:mapseed/accessible-autocomplete#7e56b805ee7ce77bebae67f6454a5c3f5e4987a8",
       "requires": {
         "preact": "8.2.7"
       }
@@ -15713,6 +15714,24 @@
         "prop-types": "15.6.1",
         "react-onclickoutside": "6.7.1",
         "react-popper": "0.8.2"
+      }
+    },
+    "react-datetime": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-2.14.0.tgz",
+      "integrity": "sha512-BUWIzMLRGzWQSYyJf0mivLyDgw4KCTFYn8zW50UTl2qB3xd/BH/TgPzfgDvAScNbiXwWpXei/GCoc6nI2J3GgA==",
+      "requires": {
+        "create-react-class": "^15.5.2",
+        "object-assign": "^3.0.0",
+        "prop-types": "^15.5.7",
+        "react-onclickoutside": "^6.5.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rc-color-picker": "^1.2.3",
     "react": "^16.1.0",
     "react-addons-update": "^15.6.2",
-    "react-datepicker": "^1.0.4",
+    "react-datetime": "^2.14.0",
     "react-dom": "^16.2.0",
     "react-i18next": "^7.5.1",
     "react-modal": "^3.4.4",

--- a/src/base/static/components/form-fields/field-definitions.js
+++ b/src/base/static/components/form-fields/field-definitions.js
@@ -211,8 +211,10 @@ export default {
     getComponent: (fieldConfig, context) => (
       <DatetimeField
         {...getSharedFieldProps(fieldConfig, context)}
-        date={context.props.fieldState.get(constants.FIELD_VALUE_KEY)}
         showTimeSelect={fieldConfig.show_time_select}
+        timeFormat={fieldConfig.time_format}
+        dateFormat={fieldConfig.date_format}
+        displayFormat={fieldConfig.display_format}
       />
     ),
     getInitialValue: ({ value }) => value,

--- a/src/base/static/components/form-fields/response-field.js
+++ b/src/base/static/components/form-fields/response-field.js
@@ -47,6 +47,7 @@ const ResponseField = props => {
           value={props.fieldValue}
           attachmentModels={props.attachmentModels}
           labels={getCheckboxLabels(props.fieldValue, props.fieldConfig)}
+          fieldConfig={props.fieldConfig}
         />
       )}
     </div>

--- a/src/base/static/components/form-fields/types/datetime-field-response.js
+++ b/src/base/static/components/form-fields/types/datetime-field-response.js
@@ -1,11 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
+import moment from "moment";
+
+import constants from "../../../constants";
 
 const DatetimeFieldResponse = props => {
-  return <p>{props.value}</p>;
+  return (
+    <p>
+      {moment(props.value).format(
+        props.fieldConfig.display_format ||
+          constants.DEFAULT_DATE_DISPLAY_FORMAT,
+      )}
+    </p>
+  );
 };
 
 DatetimeFieldResponse.propTypes = {
+  fieldConfig: PropTypes.object.isRequired,
   value: PropTypes.string.isRequired,
 };
 

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -1,35 +1,70 @@
 import React from "react";
 import PropTypes from "prop-types";
-import DatePicker from "react-datepicker";
+import Datetime from "react-datetime";
 import moment from "moment";
+
+import "react-datetime/css/react-datetime.css";
+
+import constants from "../../../constants";
 
 import "./datetime-field.scss";
 
-const DatetimeField = props => {
-  const datetimeFormat = "MMMM Do YYYY, h:mm:ss a";
-
+/* eslint-disable react/prop-types */
+const renderInput = ({ datetimeProps, props, openCalendar }) => {
   return (
-    <DatePicker
+    <button
+      type="button"
+      className="datetime-field__open-button"
+      onClick={openCalendar}
+    >
+      {datetimeProps.value
+        ? moment(datetimeProps.value).format(props.displayFormat)
+        : props.placeholder ? props.placeholder : "Select a date"}
+    </button>
+  );
+};
+/* eslint-enable react/prop-types */
+
+const DatetimeField = props => {
+  return (
+    <Datetime
       className="datetime-field"
-      dateFormat={props.showTimeSelect ? "LLL" : "LL"}
-      showTimeSelect={props.showTimeSelect}
-      selected={props.date ? moment(props.date, datetimeFormat) : ""}
-      onChange={dateObj =>
-        props.onChange(props.name, dateObj.format(datetimeFormat))
-      }
+      dateFormat={props.dateFormat}
+      timeFormat={props.timeFormat}
+      renderInput={(datetimeProps, openCalendar) => {
+        return renderInput({
+          datetimeProps: datetimeProps,
+          openCalendar: openCalendar,
+          props: props,
+        });
+      }}
+      onChange={date => {
+        props.onChange(
+          props.name,
+          date.format(
+            `${props.dateFormat}${
+              props.timeFormat ? " " + props.timeFormat : ""
+            }`,
+          ),
+        );
+      }}
     />
   );
 };
 
 DatetimeField.propTypes = {
-  date: PropTypes.string,
+  dateFormat: PropTypes.string.isRequired,
+  displayFormat: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-  showTimeSelect: PropTypes.bool.isRequired,
+  timeFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
+    .isRequired,
 };
 
 DatetimeField.defaultProps = {
-  showTimeSelect: false,
+  dateFormat: constants.DEFAULT_DATE_FORMAT,
+  displayFormat: constants.DEFAULT_DATE_DISPLAY_FORMAT,
+  timeFormat: false,
 };
 
 export default DatetimeField;

--- a/src/base/static/components/form-fields/types/datetime-field.scss
+++ b/src/base/static/components/form-fields/types/datetime-field.scss
@@ -16,4 +16,10 @@
   text-transform: uppercase;
   background-image: linear-gradient(#a3c7d9, #699ab3);
   box-shadow: -2px 2px 3px #ccc;
+
+  &:before {
+    font-family: FontAwesome;
+    content: "\F073";
+    margin-right: 10px;
+  }
 }

--- a/src/base/static/components/form-fields/types/datetime-field.scss
+++ b/src/base/static/components/form-fields/types/datetime-field.scss
@@ -1,18 +1,19 @@
-@import "react-datepicker.min";
 @import "variables";
 
 .datetime-field {
   width: $datetime-field-width;
-  border: $datetime-field-border;
+  border: none;
   padding: $datetime-field-padding;
   box-sizing: border-box;
 }
 
-.react-datepicker-wrapper,
-.react-datepicker__input-container {
-  width: 100%;
-}
-
-.react-datepicker__time-list {
-  padding: 0 !important;
+.datetime-field__open-button {
+  font-size: 0.9em;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 10px 5px 10px;
+  text-transform: uppercase;
+  background-image: linear-gradient(#a3c7d9, #699ab3);
+  box-shadow: -2px 2px 3px #ccc;
 }

--- a/src/base/static/components/place-detail/snohomish-field-summary.js
+++ b/src/base/static/components/place-detail/snohomish-field-summary.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import ResponseField from "../form-fields/response-field";
 import fieldResponseFilter from "../../utils/field-response-filter";
 import { Header1, Header4, Paragraph } from "../atoms/typography";
 

--- a/src/base/static/constants.js
+++ b/src/base/static/constants.js
@@ -68,4 +68,7 @@ export default {
   PLACE_MODEL_IO_END_ERROR_ACTION: "place:io-end-error",
   SURVEY_MODEL_IO_END_SUCCESS_ACTION: "survey:io-end",
   SUPPORT_MODEL_IO_END_SUCCESS_ACTION: "support:io-end-success",
+
+  DEFAULT_DATE_FORMAT: "YYYY-MM-DD",
+  DEFAULT_DATE_DISPLAY_FORMAT: "MMMM Do YYYY",
 };

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -644,6 +644,14 @@ place:
           display_prompt: _(Title:)
           placeholder: _(Enter title...)
           optional: false
+        - name: datetime_field
+          type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
+          placeholder: _(Please select a date)
+          prompt: _(Datetime field prompt:)
+          display_prompt: _(Rendered datetime:)
+          optional: false
         - name: description
           type: textarea
           prompt: "_(What's your question?)"

--- a/src/flavors/snohomish/config.yml
+++ b/src/flavors/snohomish/config.yml
@@ -302,35 +302,35 @@ place:
         # Farm
         - start_field_index: 3
           end_field_index: 21
-          icon_url: /static/css/images/form-stage-header-graphic-b.png
+          icon_url: /static/css/images/form-stage-header-graphic.png
           header: _(Farm Conservation)
           description: _(Tell us what you’ve done on your farm to protect natural resources)
 
         # Forest
         - start_field_index: 22
           end_field_index: 42
-          icon_url: /static/css/images/form-stage-header-graphic-b.png
+          icon_url: /static/css/images/form-stage-header-graphic.png
           header: _(Forest Conservation)
           description: _(Tell us what you’ve done to improve forest conservation)
 
         # Shoreline
         - start_field_index: 43
           end_field_index: 63
-          icon_url: /static/css/images/form-stage-header-graphic-b.png
+          icon_url: /static/css/images/form-stage-header-graphic.png
           header: _(Shoreline Conservation)
           description: _(Tell us what you’ve done to improve shoreline conservation)
         
         # Urban
         - start_field_index: 64
           end_field_index: 88
-          icon_url: /static/css/images/form-stage-header-graphic-b.png
+          icon_url: /static/css/images/form-stage-header-graphic.png
           header: _(Urban / Suburban Conservation)
           description: _(Tell us what you’ve done to improve urban / surburban conservation)
 
         # Final
         - start_field_index: 89
           end_field_index: 95
-          icon_url: /static/css/images/form-stage-header-graphic-b.png
+          icon_url: /static/css/images/form-stage-header-graphic.png
           header: _(Almost Done!)
           description: _( )
       label: _(Conservation Actions)
@@ -374,6 +374,8 @@ place:
               value: no
         - name: farm_rotation-grazing-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -396,6 +398,8 @@ place:
               value: no
         - name: farm_fencing-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -418,6 +422,8 @@ place:
               value: no
         - name: farm_off-stream-watering-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -445,6 +451,8 @@ place:
             ]          
         - name: farm_livestock-heavy-use-areas-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -467,6 +475,8 @@ place:
               value: no
         - name: farm_gutters-diversion-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -489,6 +499,8 @@ place:
               value: no
         - name: farm_soil-testing-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -511,6 +523,8 @@ place:
               value: no
         - name: farm_manure-storage-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -542,6 +556,8 @@ place:
           hidden_default: true
         - name: farm_other-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -584,6 +600,8 @@ place:
               value: no
         - name: forest_protected-buffers-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -606,6 +624,8 @@ place:
               value: no
         - name: forest_restored-buffers-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -628,6 +648,8 @@ place:
               value: no
         - name: forest_left-trees-snags-etc-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -649,6 +671,8 @@ place:
               value: no
         - name: forest_maintain-roads-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -671,6 +695,8 @@ place:
               value: no
         - name: forest_reduce-harvest-compaction-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -693,6 +719,8 @@ place:
               value: no
         - name: forest_fish-passage-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -715,6 +743,8 @@ place:
               value: no
         - name: forest_logging-slash-etc-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -737,6 +767,8 @@ place:
               value: no
         - name: forest_stewardship-plan-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -766,6 +798,8 @@ place:
           hidden_default: true
         - name: forest_other-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -807,6 +841,8 @@ place:
               value: no
         - name: shoreline_left-slope-vegetation-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -829,6 +865,8 @@ place:
               value: no
         - name: shoreline_slope-native-buffer-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -851,6 +889,8 @@ place:
               value: no
         - name: shoreline_remove-noxious-weeds-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -873,6 +913,8 @@ place:
               value: no
         - name: shoreline_left-dead-trees-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -895,6 +937,8 @@ place:
               value: no
         - name: shoreline_impervious-surfaces-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -917,6 +961,8 @@ place:
               value: no
         - name: shoreline_relocated-slope-structures-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -939,6 +985,8 @@ place:
               value: no
         - name: shoreline_grass-clippings-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -961,6 +1009,8 @@ place:
               value: no
         - name: shoreline_removed-armoring-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -989,6 +1039,8 @@ place:
           hidden_default: true
         - name: shoreline_other-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1030,6 +1082,8 @@ place:
               value: no
         - name: urban_rain-gardens-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1052,6 +1106,8 @@ place:
               value: no
         - name: urban_rain-barrels-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1074,6 +1130,8 @@ place:
               value: no
         - name: urban_rain-beds-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1096,6 +1154,8 @@ place:
               value: no
         - name: urban_natural-yard-care-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1118,6 +1178,8 @@ place:
               value: no
         - name: general_wildlife-backyard-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1140,6 +1202,8 @@ place:
               value: no
         - name: urban_pollinator-habitat-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1162,6 +1226,8 @@ place:
               value: no
         - name: urban_water-conservation-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1184,6 +1250,8 @@ place:
               value: no
         - name: urban_compost-mulch-soil-amendments-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1206,6 +1274,8 @@ place:
               value: no
         - name: urban_food-garden-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1228,6 +1298,8 @@ place:
               value: no
         - name: urban_drainage-concerns-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )
@@ -1256,6 +1328,8 @@ place:
           hidden_default: true
         - name: urban_other-datetime
           type: datetime
+          date_format: "YYYY-MM"
+          display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
           placeholder: _(Approximate date and time)
           display_prompt: _( )

--- a/src/flavors/snohomish/static/css/custom.css
+++ b/src/flavors/snohomish/static/css/custom.css
@@ -283,6 +283,15 @@
   margin-bottom: 40px;
 }
 
+.datetime-field__open-button {
+  background-image: linear-gradient(#769300, #5e7306);
+}
+
+/* Datepicker plugin overrides */
+.rdtActive {
+  background-color: #02440b !important;
+}
+
 /* =Info modal
 -------------------------------------------------------------- */
 .mapseed-info-modal__header-bar,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,10 +110,6 @@ module.exports = {
               loader: "sass-loader",
               options: {
                 includePaths: [
-                  path.resolve(
-                    __dirname,
-                    "./node_modules/react-datepicker/dist",
-                  ),
                   path.resolve(__dirname, "./node_modules/compass-mixins/lib"),
                   path.resolve(__dirname, "./src/base/static/stylesheets/util"),
                   path.resolve(


### PR DESCRIPTION
Updates to the datepicker field.

* convert the datepicker input from a text field to a button. This removes the need for complex validation logic by preventing the user from entering dates in arbitrary formats.
* add a placeholder text option. Set it with the `placeholder` property in the config.
* replace `react-datepicker` with [`react-datetime`](https://www.npmjs.com/package/react-datetime). `react-datetime` is more flexible.
* add optional timepicker. The timepicker defaults to being off; use the `time_format` config property to set a time format (using moment's format strings), e.g.: `time_format: "HH:mm:ss"`
* set the date format with the `date_format` property, e.g.: `date_format: "YYYY-MM"`. Leave out any configuration for days to create a month and year picker.
* set the display format for dates using the `display_format` key. This format will be used on the datepicker button in the form and in detail views.