### PR TITLE
Map and form enhancements

### DIFF
--- a/src/base/static/components/form-fields/field-definitions.js
+++ b/src/base/static/components/form-fields/field-definitions.js
@@ -58,6 +58,9 @@ const getSharedFieldProps = (fieldConfig, context) => {
     onChange: context.onChange.bind(context),
     placeholder: fieldConfig.placeholder,
     value: context.props.fieldState.get(constants.FIELD_VALUE_KEY),
+    isAutoFocusing: !!context.props.fieldState.get(
+      constants.FIELD_AUTO_FOCUS_KEY,
+    ),
   };
 };
 

--- a/src/base/static/components/form-fields/form-field.js
+++ b/src/base/static/components/form-fields/form-field.js
@@ -91,6 +91,10 @@ class FormField extends Component {
         .set(
           constants.FIELD_VISIBILITY_KEY,
           this.props.fieldState.get(constants.FIELD_VISIBILITY_KEY),
+        )
+        .set(
+          constants.FIELD_AUTO_FOCUS_KEY,
+          this.props.fieldState.get(constants.FIELD_AUTO_FOCUS_KEY),
         ),
       isInitializing: isInitializing,
     });

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Datetime from "react-datetime";
 import moment from "moment";
@@ -9,55 +9,59 @@ import constants from "../../../constants";
 
 import "./datetime-field.scss";
 
-/* eslint-disable react/prop-types */
-const renderInput = ({ props, openCalendar }) => {
-  return (
-    <button
-      type="button"
-      className="datetime-field__open-button"
-      onClick={openCalendar}
-    >
-      {props.value
-        ? moment(props.value).format(props.displayFormat)
-        : props.placeholder ? props.placeholder : "Select a date"}
-    </button>
-  );
-};
-/* eslint-enable react/prop-types */
+class DatetimeField extends Component {
+  componentDidMount() {
+    this.props.isAutoFocusing && this.inputRef.focus();
+  }
 
-const DatetimeField = props => {
-  return (
-    <Datetime
-      className="datetime-field"
-      dateFormat={props.dateFormat}
-      timeFormat={props.timeFormat}
-      renderInput={(datetimeProps, openCalendar) => {
-        return renderInput({
-          openCalendar: openCalendar,
-          props: props,
-        });
-      }}
-      onChange={date => {
-        props.onChange(
-          props.name,
-          date.format(
-            `${props.dateFormat}${
-              props.timeFormat ? " " + props.timeFormat : ""
-            }`,
-          ),
-        );
-      }}
-    />
-  );
-};
+  render() {
+    return (
+      <Datetime
+        className="datetime-field"
+        dateFormat={this.props.dateFormat}
+        timeFormat={this.props.timeFormat}
+        renderInput={(datetimeProps, openCalendar) => {
+          return (
+            <input
+              type="text"
+              ref={input => {
+                this.inputRef = input;
+              }}
+              className="datetime-field__input"
+              onFocus={openCalendar}
+              placeholder={this.props.placeholder || "Select a date"}
+              value={
+                this.props.value &&
+                moment(this.props.value).format(this.props.displayFormat)
+              }
+            />
+          );
+        }}
+        onChange={date => {
+          this.props.onChange(
+            this.props.name,
+            date.format(
+              `${this.props.dateFormat}${
+                this.props.timeFormat ? " " + this.props.timeFormat : ""
+              }`,
+            ),
+          );
+        }}
+      />
+    );
+  }
+}
 
 DatetimeField.propTypes = {
   dateFormat: PropTypes.string.isRequired,
   displayFormat: PropTypes.string.isRequired,
+  isAutoFocusing: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
   timeFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
     .isRequired,
+  value: PropTypes.string,
 };
 
 DatetimeField.defaultProps = {

--- a/src/base/static/components/form-fields/types/datetime-field.scss
+++ b/src/base/static/components/form-fields/types/datetime-field.scss
@@ -2,20 +2,13 @@
 
 .datetime-field {
   width: $datetime-field-width;
-  border: none;
-  padding: $datetime-field-padding;
-  box-sizing: border-box;
 }
 
-.datetime-field__open-button {
-  font-size: 0.9em;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 5px 10px 5px 10px;
-  text-transform: uppercase;
-  background-image: linear-gradient(#a3c7d9, #699ab3);
-  box-shadow: -2px 2px 3px #ccc;
+.datetime-field__input {
+  padding: $datetime-field-padding;
+  width: 100%;
+  box-sizing: border-box;
+  border-style: solid;
 
   &:before {
     font-family: FontAwesome;

--- a/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
+++ b/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
@@ -25,6 +25,7 @@ exports[`InputForm renders input form 1`] = `
           "triggerTargets": undefined,
           "isVisible": true,
           "renderKey": "someCategorytest1",
+          "isAutoFocusing": undefined,
         }
       }
       key="someCategorytest1"
@@ -61,6 +62,7 @@ exports[`InputForm renders input form 1`] = `
           "triggerTargets": undefined,
           "isVisible": true,
           "renderKey": "someCategorytest2",
+          "isAutoFocusing": undefined,
         }
       }
       key="someCategorytest2"
@@ -97,6 +99,7 @@ exports[`InputForm renders input form 1`] = `
           "triggerTargets": undefined,
           "isVisible": true,
           "renderKey": "someCategorytest3",
+          "isAutoFocusing": undefined,
         }
       }
       key="someCategorytest3"

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -84,6 +84,9 @@ class InputForm extends Component {
           [constants.FIELD_RENDER_KEY]: prevFields.has(field.name)
             ? prevFields.get(field.name).get(constants.FIELD_RENDER_KEY) + "_"
             : this.selectedCategoryConfig.category + field.name,
+          [constants.FIELD_AUTO_FOCUS_KEY]: prevFields.get(
+            constants.FIELD_AUTO_FOCUS_KEY,
+          ),
         }),
       );
     }, OrderedMap());
@@ -114,7 +117,7 @@ class InputForm extends Component {
     );
 
     // Check if this field triggers the visibility of other fields(s)
-    if (fieldStatus.get(constants.FIELD_TRIGGER_VALUE_KEY)) {
+    if (fieldStatus.get(constants.FIELD_TRIGGER_VALUE_KEY) && !isInitializing) {
       const isVisible =
         fieldStatus.get(constants.FIELD_TRIGGER_VALUE_KEY) ===
         fieldStatus.get(constants.FIELD_VALUE_KEY);
@@ -132,14 +135,17 @@ class InputForm extends Component {
   }
 
   triggerFieldVisibility(targets, isVisible) {
-    targets.forEach(target => {
-      const fieldStatus = this.state.fields
-        .get(target)
-        .set(constants.FIELD_VISIBILITY_KEY, isVisible);
-
-      this.setState(({ fields }) => ({
-        fields: fields.set(target, fieldStatus),
-      }));
+    this.setState({
+      fields: this.state.fields.map((field, fieldName) => {
+        return targets.includes(fieldName)
+          ? field
+              .set(constants.FIELD_VISIBILITY_KEY, isVisible)
+              .set(
+                "isAutoFocusing",
+                targets.indexOf(fieldName) === 0 && isVisible,
+              )
+          : field;
+      }),
     });
   }
 

--- a/src/base/static/constants.js
+++ b/src/base/static/constants.js
@@ -52,6 +52,7 @@ export default {
   FIELD_VISIBILITY_KEY: "isVisible",
   FIELD_TRIGGER_VALUE_KEY: "trigger",
   FIELD_TRIGGER_TARGETS_KEY: "triggerTargets",
+  FIELD_AUTO_FOCUS_KEY: "isAutoFocusing",
 
   GEOMETRY_PROPERTY_NAME: "geometry",
   GEOMETRY_STYLE_PROPERTY_NAME: "style",

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -777,6 +777,10 @@ module.exports = Backbone.View.extend({
           self.setStoryLayerVisibility(model);
           center = model.get("story").panTo || center;
           zoom = model.get("story").zoom;
+
+          if (!self.hasBodyClass("right-sidebar-visible")) {
+            $("body").addClass("right-sidebar-visible");
+          }
         }
 
         if (layer.getLatLng) {

--- a/src/base/static/js/views/map-view.js
+++ b/src/base/static/js/views/map-view.js
@@ -51,6 +51,7 @@ module.exports = Backbone.View.extend({
       self.initGeolocation();
     }
 
+    self.map.on("click", this.centerMapOnClick, this);
     self.map.on("dragend", logUserPan);
     $(self.map.zoomControl._zoomInButton).click(logUserZoom);
     $(self.map.zoomControl._zoomOutButton).click(logUserZoom);
@@ -126,6 +127,10 @@ module.exports = Backbone.View.extend({
       }
     });
   }, // end initialize
+
+  centerMapOnClick(evt) {
+    this.map.panTo(evt.latlng, { animate: true });
+  },
 
   isClusterable(layerId) {
     // If no cluster config exists, we don't cluster any layers.

--- a/src/base/static/stylesheets/themes/default-theme/variables.scss
+++ b/src/base/static/stylesheets/themes/default-theme/variables.scss
@@ -152,9 +152,14 @@ $dropdown-field-autofill-background-color: $autofill-color;
   datetime-field.js
   Date/time picker
 */
-$datetime-field-width: 100%;
 $datetime-field-border: 0.25em solid $secondary-color;
+$datetime-field-border-radius: 0 0 0 0;
 $datetime-field-padding: 0.5em 0.5em 0.5em 0.5em;
+$datetime-field-margin: 0 0 0 0;
+$datetime-field-width: 100%;
+$datetime-field-autofill-background-color: $autofill-color;
+
+$rendered-datetime-field-margin-bottom: 5px;
 
 /*
   geocoding-field.js

--- a/src/flavors/snohomish/static/css/custom.css
+++ b/src/flavors/snohomish/static/css/custom.css
@@ -176,7 +176,8 @@
 }
 
 .textarea-field,
-.text-field {
+.text-field,
+.datetime-field__input {
   border-color: #779300;
   border-width: 4px;
 }
@@ -291,11 +292,6 @@
 
 .datetime-field__open-button {
   background-image: linear-gradient(#769300, #5e7306);
-}
-
-/* Datepicker plugin overrides */
-.rdtActive {
-  background-color: #02440b !important;
 }
 
 /* =Info modal


### PR DESCRIPTION
* Center the map on click
* Open the sidebar on route to a story chapter
* Change look of datetime fields from a button to a text input
* Disallow manual entry in datetime fields
* When triggering the visibility of one or more fields, allow for the option to auto-focus the first of the triggered fields
* Open the datepicker field on focus (not just on click). Note that as of this PR no other field types are configured to do anything when auto-focused.
  * combined with the feature above, the Snohomish flavor datepicker fields will now auto-open after selecting an action.