### PR TITLE
Fix lingering hover styling for checkboxes on touch devices

### DIFF
--- a/src/base/static/components/form-fields/types/big-checkbox-field.scss
+++ b/src/base/static/components/form-fields/types/big-checkbox-field.scss
@@ -39,14 +39,18 @@
     width: 2.5em;
     background-color: $big-checkbox-field-hover-icon-background-color;
   }
+}
 
-  &:hover {
-    color: $big-checkbox-field-hover-label-color;
+@media (hover: hover) {
+  .big-checkbox-field__label {
+    &:hover {
+      color: $big-checkbox-field-hover-label-color;
 
-    &:before {
-      content: $big-checkbox-field-icon;
-      text-indent: 0.9em;
-      color: $big-checkbox-field-hover-icon-color;
+      &:before {
+        content: $big-checkbox-field-icon;
+        text-indent: 0.9em;
+        color: $big-checkbox-field-hover-icon-color;
+      }
     }
   }
 }

--- a/src/base/static/components/form-fields/types/big-radio-field.scss
+++ b/src/base/static/components/form-fields/types/big-radio-field.scss
@@ -39,14 +39,18 @@
     width: 2.5em;
     background-color: $big-radio-field-hover-icon-background-color;
   }
+}
 
-  &:hover {
-    color: $big-radio-field-hover-label-color;
+@media (hover: hover) {
+  .big-radio-field__label {
+    &:hover {
+      color: $big-radio-field-hover-label-color;
 
-    &:before {
-      content: $big-radio-field-icon;
-      text-indent: 0.9em;
-      color: $big-radio-field-hover-icon-color;
+      &:before {
+        content: $big-radio-field-icon;
+        text-indent: 0.9em;
+        color: $big-radio-field-hover-icon-color;
+      }
     }
   }
 }

--- a/src/base/static/components/form-fields/types/big-toggle-field.scss
+++ b/src/base/static/components/form-fields/types/big-toggle-field.scss
@@ -36,14 +36,18 @@
     width: 2.5em;
     background-color: $big-toggle-field-hover-icon-background-color;
   }
+}
 
-  &:hover {
-    color: $big-toggle-field-hover-label-text-color;
+@media (hover: hover) {
+  .big-toggle-field__label {
+    &:hover {
+      color: $big-toggle-field-hover-label-text-color;
 
-    &:before {
-      content: $big-toggle-field-icon;
-      text-indent: 0.9em;
-      color: $big-toggle-field-hover-icon-color;
+      &:before {
+        content: $big-toggle-field-icon;
+        text-indent: 0.9em;
+        color: $big-toggle-field-hover-icon-color;
+      }
     }
   }
 }


### PR DESCRIPTION
Checkboxes, radio fields, and toggles have a CSS `:hover` style that works incorrectly on touch devices: When a checkbox, etc. is checked and then un-checked, the hover style lingers until another touch event occurs.

This PR uses a CSS feature query to ignore the `:hover` styling on devices that don't support it.