### PR TITLE
Snohomish flavor tweaks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
     "Handlebars": false,
     "Shareabouts": false,
     "moment": false,
-    "L": false
+    "L": false,
+    "ga": false
   },
   "env": {
     "browser": true,

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -1,4 +1,4 @@
-require("dotenv").config({ path: "src/.env" });
+require("dotenv").config({ path: "src/.env-production" });
 const path = require("path");
 const fs = require("fs-extra");
 const yaml = require("js-yaml");
@@ -233,6 +233,20 @@ activeLanguages.forEach(language => {
     thisConfig.app.api_root = process.env.API_ROOT;
   }
 
+  // Determine if we should include Google Analytics for this flavor.
+  // Analytics ids are defined in the .env file, and follow this format:
+  // <FLAVOR>_GOOGLE_ANALYTICS_ID
+  // We only include analytics on production builds.
+  let googleAnalyticsId = "";
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env[flavor.toUpperCase() + "_GOOGLE_ANALYTICS_ID"]
+  ) {
+    log("Including Google Analytics for " + flavor);
+    googleAnalyticsId =
+      process.env[flavor.toUpperCase() + "_GOOGLE_ANALYTICS_ID"];
+  }
+
   // Resolve fields of type common_form_element.
   thisConfig.place.place_detail = transformCommonFormElements(
     thisConfig.place.place_detail,
@@ -336,7 +350,7 @@ activeLanguages.forEach(language => {
       mapboxToken: process.env.MAPBOX_TOKEN || "",
       clickyAnalyticsId: process.env.CLICKY_ANALYTICS_ID || "",
       mapQuestKey: process.env.MAPQUEST_KEY || "",
-      googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID || "",
+      googleAnalyticsId: googleAnalyticsId,
       googleAnalyticsDomain: process.env.GOOGLE_ANALYTICS_DOMAIN || "auto",
     },
     languageCode: language.code,

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -1,4 +1,4 @@
-require("dotenv").config({ path: "src/.env-production" });
+require("dotenv").config({ path: "src/.env" });
 const path = require("path");
 const fs = require("fs-extra");
 const yaml = require("js-yaml");

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -37,6 +37,7 @@ class DatetimeField extends Component {
             />
           );
         }}
+        closeOnSelect={true}
         onChange={date => {
           this.props.onChange(
             this.props.name,

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -311,7 +311,6 @@ Shareabouts.Util = Util;
 
     recordGoogleAnalyticsHit(route) {
       if (ga) {
-        console.log("recording", route)
         ga("set", "page", route);
         ga("send", "pageview");
       }

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -182,6 +182,7 @@ Shareabouts.Util = Util;
     },
 
     viewMap: function(zoom, lat, lng) {
+      this.recordGoogleAnalyticsHit("/");
       if (this.appView.mapView.locationTypeFilter) {
         // If there's a filter applied, actually go to that filtered route.
         this.navigate("/filter/" + this.appView.mapView.locationTypeFilter, {
@@ -194,10 +195,12 @@ Shareabouts.Util = Util;
     },
 
     newPlace: function() {
+      this.recordGoogleAnalyticsHit("/new");
       this.appView.newPlace();
     },
 
     viewLandmark: function(modelId, responseId) {
+      this.recordGoogleAnalyticsHit("/" + modelId);
       this.appView.viewPlaceOrLandmark({
         modelId: modelId,
         responseId: responseId,
@@ -206,6 +209,7 @@ Shareabouts.Util = Util;
     },
 
     viewPlace: function(datasetSlug, modelId, responseId) {
+      this.recordGoogleAnalyticsHit(`/${datasetSlug}/${modelId}`);
       this.appView.viewPlaceOrLandmark({
         datasetSlug: datasetSlug,
         modelId: modelId,
@@ -217,10 +221,12 @@ Shareabouts.Util = Util;
     editPlace: function() {},
 
     viewPage: function(slug) {
+      this.recordGoogleAnalyticsHit("/page/" + slug);
       this.appView.viewPage(slug);
     },
 
     showList: function() {
+      this.recordGoogleAnalyticsHit("/list");
       this.appView.showListView();
     },
 
@@ -300,6 +306,14 @@ Shareabouts.Util = Util;
         } else {
           this.navigate("/", { trigger: false });
         }
+      }
+    },
+
+    recordGoogleAnalyticsHit(route) {
+      if (ga) {
+        console.log("recording", route)
+        ga("set", "page", route);
+        ga("send", "pageview");
       }
     },
   });

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -310,7 +310,7 @@ Shareabouts.Util = Util;
     },
 
     recordGoogleAnalyticsHit(route) {
-      if (ga) {
+      if (typeof ga !== "undefined") {
         ga("set", "page", route);
         ga("send", "pageview");
       }

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -339,12 +339,13 @@
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
     ga('create', '{{ settings.googleAnalyticsId }}', '{{ settings.googleAnalyticsDomain }}');
     // Set the language-code
     ga('set', 'dimension2', '{{ languageCode }}');
   </script>
   {{/if}}
+
   {{#if settings.clickyAnalyticsId}}
   <a title="Google Analytics Alternative" href="https://clicky.com/{{ settings.clickyAnalyticsId }}"><img alt="Google Analytics Alternative" src="//static.getclicky.com/media/links/badge.gif" border="0" /></a>
   <script type="text/javascript">

--- a/src/flavors/snohomish/config.yml
+++ b/src/flavors/snohomish/config.yml
@@ -166,10 +166,10 @@ sidebar:
       basemaps:
         - id: osm-hot
           title: _(Outdoors)
-          visibleDefault: true
+          visibleDefault: false
         - id: satellite
           title: _(Satellite View)
-          visibleDefault: false
+          visibleDefault: true
         - id: light-nolabels
           title: _(Light)
           visibleDefault: false

--- a/src/flavors/snohomish/jstemplates/pages-nav.html
+++ b/src/flavors/snohomish/jstemplates/pages-nav.html
@@ -1,0 +1,27 @@
+{{# has_pages }}
+<a href="#" id="nav-btn">&equiv;</a>
+{{/ has_pages }}
+<nav class="access" role="article">
+  <ul class="menu">
+    {{# pages }}
+
+      {{> pages-nav-item }}
+
+    {{/ pages }}
+    <!-- BEGIN CUSTOM CODE -->
+    <li class="menu-item">
+      <a class="btn btn-block btn-secondary show-layer-panel" href="#">{{#_}}Layers{{/_}}</a>
+    </li>
+    <!-- END CUSTOM CODE -->
+  </ul>
+</nav>
+
+<!-- BEGIN CUSTOM CODE -->
+<!-- <nav class="list-toggle-nav">
+  <a class="list-toggle-btn btn btn-block">
+  	<span class="show-the-map is-visuallyhidden">{{ show_map_button_label }}</span>
+  	<span class="is-screen-reader-text">/</span>
+  	<span class="show-the-list">{{ show_list_button_label }}</span>
+  </a>
+</nav> -->
+<!-- END CUSTOM CODE -->

--- a/src/flavors/snohomish/static/css/custom.css
+++ b/src/flavors/snohomish/static/css/custom.css
@@ -435,12 +435,8 @@
     }
 
     /* TODO: update this if we add more page header links */
-    .menu-item:nth-child(2) {
+    .menu-item:nth-child(3) {
       border-right: none !important;
-    }
-
-    .menu-item:last {
-      border-right: none;
     }
   }
 

--- a/src/flavors/snohomish/static/css/custom.css
+++ b/src/flavors/snohomish/static/css/custom.css
@@ -248,8 +248,8 @@
 .form-stage-header-bar__icon {
   position: absolute;
   bottom: 0;
-  width: 400px;
-  left: 40px;
+  width: 100%;
+  left: 50px;
 }
 
 .form-stage-header-bar__header {
@@ -262,11 +262,11 @@
 }
 
 .form-stage-header-bar__description {
-  padding-left: 60px;
+  padding-left: 15%;
   padding-right: 50px;
   font-size: 1.3em;
   font-weight: 200;
-  margin-bottom: 40px;
+  margin-bottom: 55px;
 }
 
 .datetime-field__open-button {
@@ -426,6 +426,14 @@
   }
 }
 
+//@media only screen and (max-width: 30em) {
+//  .form-stage-header-bar__description {
+//    padding-left: 40px;
+//    padding-right: 50px;
+//    margin-bottom: 40px;
+//  }
+//}
+
 // Screen sizes above 60em width
 @media only screen and (min-width: 60em) {
   .menu {
@@ -441,7 +449,7 @@
   }
 
   #pages-nav-container {
-    margin-left: 550px;
+    margin-left: 500px;
   }
 
   #site-header {

--- a/src/flavors/snohomish/static/js/views/app-view.js
+++ b/src/flavors/snohomish/static/js/views/app-view.js
@@ -1,7 +1,26 @@
 const AppView = require("../../../../../base/static/js/views/app-view.js");
 const Util = require("../../../../../base/static/js/utils.js");
+// BEGIN CUSTOM CODE
+import emitter from "../../../../../base/static/utils/emitter";
+// END CUSTOM CODE
 
 module.exports = AppView.extend({
+  events: {
+    "click #add-place": "onClickAddPlaceBtn",
+    "click .close-btn": "onClickClosePanelBtn",
+    "click .right-sidebar__collapse-btn": "onToggleSidebarVisibility",
+    "click .list-toggle-btn": "toggleListView",
+    // BEGIN CUSTOM CODE
+    "click .show-layer-panel": "showLayerPanel",
+    // END CUSTOM CODE
+  },
+
+  // BEGIN CUSTOM CODE
+  showLayerPanel: () => {
+    emitter.emit("nav-layer-btn:toggle");
+  },
+  // END CUSTOM CODE
+
   viewPage: function(slug) {
     var pageConfig = Util.findPageConfig(this.options.pagesConfig, {
         slug: slug,

--- a/src/flavors/snohomish/static/js/views/sidebar-view.js
+++ b/src/flavors/snohomish/static/js/views/sidebar-view.js
@@ -1,0 +1,14 @@
+const SidebarView = require("../../../../../base/static/js/views/sidebar-view.js");
+import emitter from "../../../../../base/static/utils/emitter";
+
+module.exports = SidebarView.extend({
+  initialize: function() {
+    var self = this;
+
+    // BEGIN CUSTOM CODE
+    emitter.addListener("nav-layer-btn:toggle", () => {
+      self.sidebar.toggle("gis-layers-pane");
+    });
+    // END CUSTOM CODE
+  },
+});


### PR DESCRIPTION
**IN PROGRESS**

* Close datetime picker on select
* Add google analytics tracking for client-side routing
    * To enable analytics tracking for a given flavor, you need to have a `.env` key that follows this pattern: `<FLAVOR>_GOOGLE_ANALYTICS_ID=UA-XXXXX-Y`, where `UA-XXXXX-Y` is the Google Analytics id. For example, to enable analytics tracking for the `snohomish` flavor: `SNOHOMISH_GOOGLE_ANALYTICS_ID=UA-12345-6`
* Add layer panel toggle in header
* Design tweaks