### PR TITLE
[Port map] Add geolocation and clustering

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -119,7 +119,7 @@ class MainMap extends Component {
     });
 
     if (props.mapConfig.geolocation_enabled) {
-      // TODO
+      this._map.addControl(this._map.getGeolocateControl(), "top-left");
     }
   }
 
@@ -275,22 +275,6 @@ class MainMap extends Component {
   }
 
   clearFilter() {
-    // TODO
-  }
-
-  reverseGeocodeMapCenter() {
-    // TODO
-  }
-
-  initGeolocation() {
-    // TODO
-  }
-
-  onClickGeolocate(evt) {
-    // TODO
-  }
-
-  geolocate() {
     // TODO
   }
 

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -118,6 +118,7 @@ const configRuleToFillLayer = (layerConfig, i) => {
 };
 
 const DEFAULT_STYLE_NAME = "Mapseed default style";
+const CLUSTER_LAYER_IDENTIFIER = "__mapseed-clusters__";
 
 /**
  * @typedef {Object } MapboxStyle - Defines the visual appearance of the map
@@ -132,6 +133,7 @@ const defaultStyle = {
   sprite: `${window.location.protocol}//${
     window.location.host
   }/static/css/images/markers/spritesheet`,
+  glyphs: "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
 };
 
 export default (container, options) => {
@@ -340,15 +342,13 @@ export default (container, options) => {
     ];
   };
 
-  const createGeoJSONLayer = ({ id, source, rules }) => {
+  const createGeoJSONLayer = ({ id, source, cluster = {}, rules }) => {
     sourcesCache[id] = {
       type: "geojson",
       data: source,
-      /////
-      cluster: true,
-      clusterRadius: 50,
-      clusterMaxZoom: 14,
-      /////
+      cluster: !!cluster.is_enabled,
+      clusterRadius: cluster.cluster_radius || 50,
+      clusterMaxZoom: cluster.cluster_max_zoom || 14,
     };
     map.addSource(id, sourcesCache[id]);
 
@@ -365,6 +365,31 @@ export default (container, options) => {
       .map(configRuleToSymbolLayer)
       .concat(rules.map(configRuleToLineLayer))
       .concat(rules.map(configRuleToFillLayer));
+
+    if (cluster.is_enabled) {
+      // https://www.mapbox.com/mapbox-gl-js/example/cluster/
+      layersCache[id] = layersCache[id].concat([
+        {
+          id: `${id}${CLUSTER_LAYER_IDENTIFIER}`,
+          source: id,
+          type: "circle",
+          filter: cluster.filter || ["has", "point_count"],
+          paint: cluster.paint || {},
+        },
+        {
+          id: `${id}${CLUSTER_LAYER_IDENTIFIER}count`,
+          source: id,
+          type: "symbol",
+          filter: cluster.filter || ["has", "point_count"],
+          // TODO: We might want to make this configurable at some point.
+          layout: {
+            "text-field": "{point_count_abbreviated}",
+            "text-font": ["Arial Unicode MS Bold"],
+            "text-size": 15,
+          },
+        },
+      ]);
+    }
   };
 
   const map = new mapboxgl.Map(options.map);
@@ -411,25 +436,26 @@ export default (container, options) => {
     bindPlaceLayerEvent: (eventName, layerId, callback) => {
       layersCache[layerId].forEach(mapProviderLayer => {
         let targetLayer = null;
-        map.on(eventName, mapProviderLayer.id, evt => {
-          if (eventName === "click") {
-            // For click events, we query rendered features here to obtain a
-            // single array of layers below the clicked-on point. The first
-            // entry in this array corresponds to the topmost rendered feature.
-            // We skip this work for other events (like mouseenter), since we
-            // don't make use of information about the layer under the cursor
-            // in those cases.
-            targetLayer = map.queryRenderedFeatures(
-              [evt.point.x, evt.point.y],
-              {
-                // Limit these click listeners to place geometry.
-                filter: ["==", ["get", "type"], "place"],
-              },
-            )[0];
-          }
+        !mapProviderLayer.id.includes(CLUSTER_LAYER_IDENTIFIER) &&
+          map.on(eventName, mapProviderLayer.id, evt => {
+            if (eventName === "click") {
+              // For click events, we query rendered features here to obtain a
+              // single array of layers below the clicked-on point. The first
+              // entry in this array corresponds to the topmost rendered feature.
+              // We skip this work for other events (like mouseenter), since we
+              // don't make use of information about the layer under the cursor
+              // in those cases.
+              targetLayer = map.queryRenderedFeatures(
+                [evt.point.x, evt.point.y],
+                {
+                  // Limit these click listeners to place geometry.
+                  filter: ["==", ["get", "type"], "place"],
+                },
+              )[0];
+            }
 
-          callback(targetLayer);
-        });
+            callback(targetLayer);
+          });
       });
     },
 

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -344,6 +344,11 @@ export default (container, options) => {
     sourcesCache[id] = {
       type: "geojson",
       data: source,
+      /////
+      cluster: true,
+      clusterRadius: 50,
+      clusterMaxZoom: 14,
+      /////
     };
     map.addSource(id, sourcesCache[id]);
 
@@ -438,6 +443,10 @@ export default (container, options) => {
 
     getMap: () => {
       return map;
+    },
+
+    getGeolocateControl: () => {
+      return new mapboxgl.GeolocateControl();
     },
 
     getCanvas: () => {

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -35,8 +35,6 @@ app:
 map:
 # Settings for map and layer configs
   geolocation_enabled: true
-  geolocation_onload: false
-  geocode_bounding_box: [46.500, -124, 48.5, -119] # south, west, north, east
 
   options:
     map:

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -134,6 +134,30 @@ map:
     - id: demo
       url: https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/demo
       type: place
+      cluster:
+        is_enabled: true
+        cluster_max_zoom: 14
+        cluster_radius: 50
+        paint:
+          circle-color:
+            - "step"
+            - - "get"
+              - "point_count"
+            - "#51bbd6"
+            - 1
+            - "#f1f075"
+            - 10
+            - "#f28cb1"
+          circle-radius:
+            - "step"
+            - - "get"
+              - "point_count"
+            - 10
+            - 1
+            - 20
+            - 10
+            - 30
+
       slug: demo
       is_visible_default: true
       rules:
@@ -506,63 +530,23 @@ map:
     - id: sample-json-a
       type: json
       is_visible_default: true
-      source: https://raw.githubusercontent.com/mapseed/data/master/Farmers_Markets_in_Washington.geojson
+      source: https://raw.githubusercontent.com/mapseed/data/master/Rose-Foundation-Grants-since-Fall-2013.geojson
+      cluster:
+        is_enabled: true
+        cluster_max_zoom: 14
+        cluster_radius: 200
+        paint:
+          circle-color: "#caffca"
+          circle-radius: 30
       rules:
         - filter:
-            - "all"
-            - - "<="
-              - - "zoom"
-              - 6
-            - - "=="
-              - - "get"
-                - "WICcash"
-              - "Y"
-          symbol-layout:
-            icon-image: "marker-dot-conserve-water.png"
-            icon-size: 0.5
-            icon-anchor: "center"
-            icon-allow-overlap: true
-        - filter:
-             - "all"
-             - - ">"
-               - - "zoom"
-               - 6
-             - - "=="
-               - - "get"
-                 - "WICcash"
-               - "Y"
+            - ">="
+            - - "zoom"
+            - 1
           symbol-layout:
             icon-image: "marker-conserve-water.png"
             icon-size: 0.5
-            icon-anchor: "bottom"
-            icon-allow-overlap: true
-        - filter:
-            - "all"
-            - - "<="
-              - - "zoom"
-              - 6
-            - - "=="
-              - - "get"
-                - "WICcash"
-              - "N"
-          symbol-layout:
-            icon-image: "marker-dot-commute-low-carbon.png"
-            icon-size: 0.5
             icon-anchor: "center"
-            icon-allow-overlap: true
-        - filter:
-             - "all"
-             - - ">"
-               - - "zoom"
-               - 6
-             - - "=="
-               - - "get"
-                 - "WICcash"
-               - "N"
-          symbol-layout:
-            icon-image: "marker-commute-low-carbon.png"
-            icon-size: 0.5
-            icon-anchor: "bottom"
             icon-allow-overlap: true
 
     - id: sample-json-b


### PR DESCRIPTION
### Geolocation
To enable, set the `geolocation_enabled: true` flag in the `map` section of the config. Note that the `geolocation_onload` and `geocode_bounding_box` parameters have been removed and will no longer do anything.

### Clustering
Clustering must be enabled on a layer-by-layer basis. Clustering is supported for any GeoJSON `Point` layer (including Mapseed place layers). Note that if you enable clustering on a layer with mixed geometry, non-`Point` features will be hidden.

To enable clustering for a layer, add the following to the layer's config:

```
cluster:
  is_enabled: true
  cluster_max_zoom: 14
  cluster_radius: 200
  paint:
    circle-color: "#caffca"
    circle-radius: 30
```

Cluster `paint` properties support step expressions for controlling cluster size, color, etc. based on number of points clustered. See: https://www.mapbox.com/mapbox-gl-js/example/cluster/ for an example.