### PR TITLE
feat: form fields that trigger stage advance

### DIFF
--- a/src/base/static/components/form-fields/form-field.js
+++ b/src/base/static/components/form-fields/form-field.js
@@ -95,6 +95,10 @@ class FormField extends Component {
         .set(
           constants.FIELD_AUTO_FOCUS_KEY,
           this.props.fieldState.get(constants.FIELD_AUTO_FOCUS_KEY),
+        )
+        .set(
+          constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY,
+          this.props.fieldState.get(constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY),
         ),
       isInitializing: isInitializing,
     });

--- a/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
+++ b/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
@@ -26,6 +26,7 @@ exports[`InputForm renders input form 1`] = `
           "isVisible": true,
           "renderKey": "someCategorytest1",
           "isAutoFocusing": undefined,
+          "advanceStage": undefined,
         }
       }
       key="someCategorytest1"
@@ -63,6 +64,7 @@ exports[`InputForm renders input form 1`] = `
           "isVisible": true,
           "renderKey": "someCategorytest2",
           "isAutoFocusing": undefined,
+          "advanceStage": undefined,
         }
       }
       key="someCategorytest2"
@@ -100,6 +102,7 @@ exports[`InputForm renders input form 1`] = `
           "isVisible": true,
           "renderKey": "someCategorytest3",
           "isAutoFocusing": undefined,
+          "advanceStage": undefined,
         }
       }
       key="someCategorytest3"

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -87,6 +87,8 @@ class InputForm extends Component {
           [constants.FIELD_AUTO_FOCUS_KEY]: prevFields.get(
             constants.FIELD_AUTO_FOCUS_KEY,
           ),
+          [constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY]:
+            field.advance_stage_on_value,
         }),
       );
     }, OrderedMap());
@@ -132,6 +134,22 @@ class InputForm extends Component {
       updatingField: fieldName,
       isInitializing: isInitializing,
     }));
+
+    // Check if this field should advance the current stage.
+    if (
+      fieldStatus.get(constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY) ===
+        fieldStatus.get(constants.FIELD_VALUE_KEY) &&
+      !isInitializing
+    ) {
+      this.validateForm(() => {
+        scrollTo(this.props.containers, 0);
+        this.setState({
+          currentStage: this.state.currentStage + 1,
+          showValidityStatus: false,
+          formValidationErrors: new Set(),
+        });
+      });
+    }
   }
 
   triggerFieldVisibility(targets, isVisible) {

--- a/src/base/static/constants.js
+++ b/src/base/static/constants.js
@@ -54,6 +54,7 @@ export default {
   FIELD_TRIGGER_VALUE_KEY: "trigger",
   FIELD_TRIGGER_TARGETS_KEY: "triggerTargets",
   FIELD_AUTO_FOCUS_KEY: "isAutoFocusing",
+  FIELD_ADVANCE_STAGE_ON_VALUE_KEY: "advanceStage",
 
   GEOMETRY_PROPERTY_NAME: "geometry",
   GEOMETRY_STYLE_PROPERTY_NAME: "style",

--- a/src/flavors/snohomish/config.yml
+++ b/src/flavors/snohomish/config.yml
@@ -345,12 +345,15 @@ place:
 
         # FARM CATEGORY ########################################################
         - name: farm_no-farm
-          type: big_checkbox
+          type: big_toggle
           prompt: _( )
           display_prompt: _( )
+          advance_stage_on_value: no-farm
           content:
-            - label: _(I don't live on a farm)
+            - label: _(I don't live on a farm -- Proceed to next screen)
               value: no-farm
+            - label: _(I don't live on a farm -- Proceed to next screen)
+              value: farm
           optional: true
 
         # Mud & manure
@@ -571,12 +574,15 @@ place:
         # FOREST CATEGORY ######################################################
 
         - name: forest_no-forest
-          type: big_checkbox
+          type: big_toggle
           prompt: _( )
+          advance_stage_on_value: no-forest
           display_prompt: _( )
           content:
-            - label: _(I don't own/operate forestland)
+            - label: _(I don't own/operate forestland -- Proceed to next screen)
               value: no-forest
+            - label: _(I don't own/operate forestland -- Proceed to next screen)
+              value: forest
           optional: true
       
         # Maintain fuel-free zones
@@ -812,12 +818,15 @@ place:
         # SHORELINE CARTEGORY ##################################################
 
         - name: shoreline_no-shoreline
-          type: big_checkbox
+          type: big_toggle
+          advance_stage_on_value: no-shoreline
           prompt: _( )
           display_prompt: _( )
           content:
-            - label: _(I don't live alongside water)
+            - label: _(I don't live alongside water -- Proceed to next screen)
               value: no-shoreline
+            - label: _(I don't live alongside water -- Proceed to next screen)
+              value: shoreline
           optional: true
         
         # Consult professional
@@ -1063,12 +1072,15 @@ place:
         # URBAN CATEGORY #######################################################
 
         - name: urban-suburban_no-urban-suburban
-          type: big_checkbox
+          type: big_toggle
+          advance_stage_on_value: no-urban
           prompt: _( )
           display_prompt: _( )
           content:
-            - label: _(I don’t live in an urban/suburban area)
-              value: no-forest
+            - label: _(I don’t live in an urban/suburban area -- Proceed to next screen)
+              value: no-urban
+            - label: _(I don’t live in an urban/suburban area -- Proceed to next screen)
+              value: urban
           optional: true
 
         # Rain gardens

--- a/src/flavors/snohomish/static/css/custom.css
+++ b/src/flavors/snohomish/static/css/custom.css
@@ -190,6 +190,25 @@
   background-color: #779300;
 }
 
+.input-form__field-container[data-field-name="farm_no-farm"],
+.input-form__field-container[data-field-name="forest_no-forest"],
+.input-form__field-container[data-field-name="shoreline_no-shoreline"],
+.input-form__field-container[data-field-name="urban-suburban_no-urban-suburban"] {
+  background-color: #fff;
+  font-style: italic;
+  font-weight: bold;
+  padding-left: 20px;
+
+  .big-toggle-field__label:before {
+    font-style: normal;
+    background-color: #fff;
+  }
+
+  .big-toggle-field__label--toggled:before {
+    background-color: #779300;
+  }
+}
+
 .datetime-field {
   border-color: #779300;
 }
@@ -416,7 +435,7 @@
     background-position: 35px top;
   }
 
-  .place-form-visible { 
+  .place-form-visible {
     #main-btns-container {
       display: none;
     }


### PR DESCRIPTION
On multi-stage forms, add the ability for form fields to trigger stage advance on a certain field value. The immediate use case is to support the `snohomish` flavor.

To use this feature, add the following flag to a field config:

```
advance_stage_on_value: <value>
```
where `<value>` is one of the possible values of the field.

Note that this feature *must* be used on a multi-stage form. Also note that this feature won't work with checkboxes (because checkbox values are stored during runtime as immutable lists). Further refactoring could address this issue, but the priority is low so I'm not going to worry about it for now.