### PR TITLE
Enable webpack filesystem polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "homepage": "https://github.com/smartercleanup/platform",
   "scripts": {
-    "start": "node scripts/static-build.js && webpack-dev-server",
+    "start": "node scripts/static-build.js && webpack-dev-server --progress",
     "test": "jest --verbose --config ./jest.config.js",
     "test:watch": "jest --watch --verbose --config ./jest.watch.config.js",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
     "build-js": "webpack -d",
-    "build-js-production": "NODE_ENV=production webpack -p",
+    "build-js-production": "NODE_ENV=production webpack -p --progress",
     "watch-js": "webpack -d --watch",
     "build": "npm run build-js-production && NODE_ENV=production node scripts/static-build.js",
     "prettier": "prettier --write \"{src,scripts}/**/*.{js,jsx}\""

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,6 +76,11 @@ const theme = process.env.THEME ? process.env.THEME : "default-theme";
 
 module.exports = {
   entry: entryPoints,
+  watchOptions: {
+    aggregateTimeout: 300,
+    poll: 1000,
+    ignored: /node_modules/,
+  },
   output: {
     path: path.join(outputBasePath, "dist"),
     filename:


### PR DESCRIPTION
To fix issues with webpack not responding to filesystem changes in development, enable polling. The options enabled are described here: https://webpack.js.org/configuration/watch/.

Also add the `--progress` flag so we get better feedback during initial and incremental builds.