### PR TITLE
Add browser update plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1760,6 +1760,11 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "browser-update": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/browser-update/-/browser-update-3.1.13.tgz",
+      "integrity": "sha1-kmT5iJFW4vu939T9l15p0Dg2nG0="
+    },
     "browserify": {
       "version": "16.1.1",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
+    "browser-update": "^3.1.13",
     "classnames": "^2.2.5",
     "compass-importer": "^0.4.1",
     "dotenv": "^4.0.0",

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -35,7 +35,7 @@ var Util = require("../utils.js");
 browserUpdate({
   required: {
     e: 13, // Edge >= 13.0
-    i: 10, // IE >= 10.0
+    i: 11, // IE >= 11.0
     f: 50, // Firefox >= 50.0
     s: 10, // Safari >= 10.0
     c: 62, // Chrome >= 62.0

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import emitter from "../../utils/emitter";
 import languageModule from "../../language-module";
+import browserUpdate from "browser-update";
 
 import { Provider } from "react-redux";
 import { createStore } from "redux";
@@ -30,6 +31,16 @@ const store = createStore(
 // END REACT PORT SECTION //////////////////////////////////////////////////////
 
 var Util = require("../utils.js");
+
+browserUpdate({
+  required: {
+    e: 13, // Edge >= 13.0
+    i: 10, // IE >= 10.0
+    f: 50, // Firefox >= 50.0
+    s: 10, // Safari >= 10.0
+    c: 62, // Chrome >= 62.0
+  },
+});
 
 // Views
 var MapView = require("mapseed-map-view");

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -34,11 +34,11 @@ var Util = require("../utils.js");
 
 browserUpdate({
   required: {
-    e: 13, // Edge >= 13.0
+    e: -2, // Edge, last 2 versions
     i: 11, // IE >= 11.0
-    f: 50, // Firefox >= 50.0
-    s: 10, // Safari >= 10.0
-    c: 62, // Chrome >= 62.0
+    f: -2, // Firefox, last 2 versions
+    s: -2, // Safari, last 2 versions
+    c: -2, // Chrome, last 2 versions
   },
 });
 


### PR DESCRIPTION
Add the [browser-update](https://www.npmjs.com/package/browser-update) plugin to notify users with old browsers that they need to upgrade.

Current minimum versions are as follows:
  * Edge: last 2 versions
  * IE: >= 11
  * Firefox: last 2 versions
  * Safari: last 2 versions
  * Chrome: last 2 versions

These versions have been tested with the Snohomish production flavor via [browserling](https://www.browserling.com/) (and in the case of Safari 10 via my personal machine).

Question: These versions are somewhat arbitrary-- would it be better to have a policy like "last 2 versions" instead?