### PR TITLE
Add ongoing option to datepicker field

### DIFF
--- a/src/base/static/components/atoms/input.js
+++ b/src/base/static/components/atoms/input.js
@@ -26,15 +26,15 @@ CheckboxInput.propTypes = {
 const DatetimeInput = props => {
   return (
     <input
-      className={classNames("datetime-input", props.classes)} 
-      type="text" 
+      className={classNames("datetime-input", props.classes)}
+      type="text"
       ref={props.childRef}
-      value={props.value} 
+      value={props.value}
       placeholder={props.placeholder}
       onFocus={props.onFocus}
     />
-  )
-}
+  );
+};
 
 DatetimeInput.propTypes = {
   childRef: PropTypes.func,
@@ -42,6 +42,6 @@ DatetimeInput.propTypes = {
   onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   value: PropTypes.string,
-}
+};
 
 export { CheckboxInput, DatetimeInput };

--- a/src/base/static/components/atoms/input.js
+++ b/src/base/static/components/atoms/input.js
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+
+const CheckboxInput = props => {
+  return (
+    <input
+      className={classNames("checkbox-input", props.classes)}
+      type="checkbox"
+      id={props.id}
+      name={props.name}
+      onChange={props.onChange}
+      checked={props.checked}
+    />
+  );
+};
+
+CheckboxInput.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  classes: PropTypes.string,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
+
+const DatetimeInput = props => {
+  return (
+    <input
+      className={classNames("datetime-input", props.classes)} 
+      type="text" 
+      ref={props.childRef}
+      value={props.value} 
+      placeholder={props.placeholder}
+      onFocus={props.onFocus}
+    />
+  )
+}
+
+DatetimeInput.propTypes = {
+  childRef: PropTypes.func,
+  classes: PropTypes.string,
+  onFocus: PropTypes.func,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+}
+
+export { CheckboxInput, DatetimeInput };

--- a/src/base/static/components/form-fields/field-definitions.js
+++ b/src/base/static/components/form-fields/field-definitions.js
@@ -218,6 +218,7 @@ export default {
         timeFormat={fieldConfig.time_format}
         dateFormat={fieldConfig.date_format}
         displayFormat={fieldConfig.display_format}
+        ongoingLabel={fieldConfig.ongoing_label}
       />
     ),
     getInitialValue: ({ value }) => value,

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -2,12 +2,15 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Datetime from "react-datetime";
 import moment from "moment";
+import classNames from "classnames";
 
 import "react-datetime/css/react-datetime.css";
 
 import constants from "../../../constants";
 
 import "./datetime-field.scss";
+
+const ONGOING_VALUE = "ONGOING";
 
 class DatetimeField extends Component {
   componentDidMount() {
@@ -22,19 +25,46 @@ class DatetimeField extends Component {
         timeFormat={this.props.timeFormat}
         renderInput={(datetimeProps, openCalendar) => {
           return (
-            <input
-              type="text"
-              ref={input => {
-                this.inputRef = input;
-              }}
-              className="datetime-field__input"
-              onFocus={openCalendar}
-              placeholder={this.props.placeholder || "Select a date"}
-              value={
-                this.props.value &&
-                moment(this.props.value).format(this.props.displayFormat)
-              }
-            />
+            <div className="datetime-field__input-wrapper">
+              {this.props.ongoingLabel && (
+                <label
+                  className={classNames("datetime-field__label-ongoing", {
+                    "datetime-field__label-ongoing--toggled":
+                      this.props.value === ONGOING_VALUE,
+                  })}
+                >
+                  <input
+                    className="datetime-field__input-ongoing"
+                    type="checkbox"
+                    checked={this.props.value === ONGOING_VALUE}
+                    onChange={e =>
+                      this.props.onChange(
+                        this.props.name,
+                        e.target.checked ? ONGOING_VALUE : "",
+                      )
+                    }
+                  />
+                  <em>{this.props.ongoingLabel}</em>
+                </label>
+              )}
+              <input
+                type="text"
+                ref={input => {
+                  this.inputRef = input;
+                }}
+                className="datetime-field__input"
+                onFocus={openCalendar}
+                placeholder={this.props.placeholder || "Select a date"}
+                value={
+                  (this.props.value &&
+                    this.props.value !== ONGOING_VALUE &&
+                    moment(this.props.value).format(
+                      this.props.displayFormat,
+                    )) ||
+                  ""
+                }
+              />
+            </div>
           );
         }}
         closeOnSelect={true}
@@ -59,6 +89,7 @@ DatetimeField.propTypes = {
   isAutoFocusing: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  ongoingLabel: PropTypes.string,
   placeholder: PropTypes.string,
   timeFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
     .isRequired,

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -6,6 +6,8 @@ import classNames from "classnames";
 
 import "react-datetime/css/react-datetime.css";
 
+import { CheckboxInput, DatetimeInput } from "../../atoms/input";
+
 import constants from "../../../constants";
 
 import "./datetime-field.scss";
@@ -38,9 +40,8 @@ class DatetimeField extends Component {
                       this.props.value === this.ongoingValue,
                   })}
                 >
-                  <input
-                    className="datetime-field__input-ongoing"
-                    type="checkbox"
+                  <CheckboxInput
+                    classes="datetime-field__input-ongoing"
                     checked={this.props.value === this.ongoingValue}
                     onChange={e =>
                       this.props.onChange(
@@ -52,12 +53,12 @@ class DatetimeField extends Component {
                   <em>{this.props.ongoingLabel}</em>
                 </label>
               )}
-              <input
+              <DatetimeInput
                 type="text"
-                ref={input => {
+                childRef={input => {
                   this.inputRef = input;
                 }}
-                className="datetime-field__input"
+                classes="datetime-field__input"
                 onFocus={openCalendar}
                 placeholder={this.props.placeholder || "Select a date"}
                 value={

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -16,6 +16,7 @@ import "./datetime-field.scss";
 // datetime selection.
 // TODO: Support the ability for field components to write to multiple backend
 // data fields of different data types.
+// https://github.com/mapseed/platform/issues/990
 const ONGOING_DATETIME = "9999-12-31 23:59:59";
 
 class DatetimeField extends Component {

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -10,11 +10,16 @@ import constants from "../../../constants";
 
 import "./datetime-field.scss";
 
-const ONGOING_VALUE = "ONGOING";
+// HACK: We use a far-future timestamp to represent the notion of an "ongoing"
+// datetime selection.
+// TODO: Support the ability for field components to write to multiple backend
+// data fields of different data types.
+const ONGOING_DATETIME = "9999-12-31 23:59:59";
 
 class DatetimeField extends Component {
   componentDidMount() {
     this.props.isAutoFocusing && this.inputRef.focus();
+    this.ongoingValue = moment(ONGOING_DATETIME).format(this.props.dateFormat);
   }
 
   render() {
@@ -30,17 +35,17 @@ class DatetimeField extends Component {
                 <label
                   className={classNames("datetime-field__label-ongoing", {
                     "datetime-field__label-ongoing--toggled":
-                      this.props.value === ONGOING_VALUE,
+                      this.props.value === this.ongoingValue,
                   })}
                 >
                   <input
                     className="datetime-field__input-ongoing"
                     type="checkbox"
-                    checked={this.props.value === ONGOING_VALUE}
+                    checked={this.props.value === this.ongoingValue}
                     onChange={e =>
                       this.props.onChange(
                         this.props.name,
-                        e.target.checked ? ONGOING_VALUE : "",
+                        e.target.checked ? this.ongoingValue : "",
                       )
                     }
                   />
@@ -57,7 +62,7 @@ class DatetimeField extends Component {
                 placeholder={this.props.placeholder || "Select a date"}
                 value={
                   (this.props.value &&
-                    this.props.value !== ONGOING_VALUE &&
+                    this.props.value !== this.ongoingValue &&
                     moment(this.props.value).format(
                       this.props.displayFormat,
                     )) ||

--- a/src/base/static/components/form-fields/types/datetime-field.scss
+++ b/src/base/static/components/form-fields/types/datetime-field.scss
@@ -26,12 +26,13 @@
 
   &:before {
     content: "";
-    max-height: 1.2em;
-    height: 1.2em;
+    max-height: 1.5em;
+    line-height: 1.5em;
+    height: 1.5em;
     background-color: #fff;
     border: 4px solid #000;
-    width: 1.2em;
-    text-indent: 0.2em;
+    width: 1.5em;
+    text-indent: 0.4em;
     color: #000;
   }
 

--- a/src/base/static/components/form-fields/types/datetime-field.scss
+++ b/src/base/static/components/form-fields/types/datetime-field.scss
@@ -5,8 +5,8 @@
 }
 
 .datetime-field__input {
-  padding: $datetime-field-padding;
   width: 100%;
+  padding: $datetime-field-padding;
   box-sizing: border-box;
   border-style: solid;
 
@@ -15,4 +15,41 @@
     content: "\F073";
     margin-right: 10px;
   }
+}
+
+.datetime-field__label-ongoing {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  text-indent: 0.7em;
+
+  &:before {
+    content: "";
+    max-height: 1.2em;
+    height: 1.2em;
+    background-color: #fff;
+    border: 4px solid #000;
+    width: 1.2em;
+    text-indent: 0.2em;
+    color: #000;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:hover:before {
+    content: "✔";
+  }
+}
+
+.datetime-field__label-ongoing--toggled {
+  &:before {
+    content: "✔";
+  }
+}
+
+.datetime-field__input-ongoing {
+  display: none;
 }

--- a/src/flavors/snohomish/config.yml
+++ b/src/flavors/snohomish/config.yml
@@ -374,6 +374,7 @@ place:
               value: no
         - name: farm_rotational-grazing-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -398,6 +399,7 @@ place:
               value: no
         - name: farm_fencing-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -422,6 +424,7 @@ place:
               value: no
         - name: farm_off-stream-watering-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -451,6 +454,7 @@ place:
             ]          
         - name: farm_livestock-heavy-use-areas-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -475,6 +479,7 @@ place:
               value: no
         - name: farm_gutters-diversion-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -499,6 +504,7 @@ place:
               value: no
         - name: farm_soil-testing-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -523,6 +529,7 @@ place:
               value: no
         - name: farm_manure-storage-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -556,6 +563,7 @@ place:
           hidden_default: true
         - name: farm_other-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -603,6 +611,7 @@ place:
               value: no
         - name: forest_protected-buffers-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -627,6 +636,7 @@ place:
               value: no
         - name: forest_restored-buffers-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -651,6 +661,7 @@ place:
               value: no
         - name: forest_left-trees-snags-etc-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -674,6 +685,7 @@ place:
               value: no
         - name: forest_maintain-roads-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -698,6 +710,7 @@ place:
               value: no
         - name: forest_reduce-harvest-compaction-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -722,6 +735,7 @@ place:
               value: no
         - name: forest_fish-passage-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -746,6 +760,7 @@ place:
               value: no
         - name: forest_logging-slash-etc-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -770,6 +785,7 @@ place:
               value: no
         - name: forest_stewardship-plan-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -801,6 +817,7 @@ place:
           hidden_default: true
         - name: forest_other-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -847,6 +864,7 @@ place:
               value: no
         - name: shoreline_left-slope-vegetation-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -871,6 +889,7 @@ place:
               value: no
         - name: shoreline_slope-native-buffer-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -900,6 +919,7 @@ place:
               value: no
         - name: shoreline_remove-noxious-weeds-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -924,6 +944,7 @@ place:
               value: no
         - name: shoreline_left-dead-trees-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -948,6 +969,7 @@ place:
               value: no
         - name: shoreline_impervious-surfaces-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -972,6 +994,7 @@ place:
               value: no
         - name: shoreline_relocated-slope-structures-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -996,6 +1019,7 @@ place:
               value: no
         - name: shoreline_grass-clippings-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1025,6 +1049,7 @@ place:
             ]              
         - name: shoreline_removed-armoring-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1055,6 +1080,7 @@ place:
           hidden_default: true
         - name: shoreline_other-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1106,6 +1132,7 @@ place:
               value: no
         - name: urban_rain-gardens-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1130,6 +1157,7 @@ place:
               value: no
         - name: urban_rain-barrels-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1159,6 +1187,7 @@ place:
               value: no
         - name: urban_rain-beds-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1188,6 +1217,7 @@ place:
               value: no
         - name: urban_natural-yard-care-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1212,6 +1242,7 @@ place:
               value: no
         - name: general_wildlife-backyard-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1236,6 +1267,7 @@ place:
               value: no
         - name: urban_pollinator-habitat-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1260,6 +1292,7 @@ place:
               value: no
         - name: urban_water-conservation-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1284,6 +1317,7 @@ place:
               value: no
         - name: urban_compost-mulch-soil-amendments-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1308,6 +1342,7 @@ place:
               value: no
         - name: urban_food-garden-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1332,6 +1367,7 @@ place:
               value: no
         - name: urban_drainage-concerns-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)
@@ -1362,6 +1398,7 @@ place:
           hidden_default: true
         - name: urban_other-datetime
           type: datetime
+          ongoing_label: "_(I perform this action regularly)"
           date_format: "YYYY-MM"
           display_format: "MMMM YYYY"
           prompt: _(Approximately when did you last complete this action?)

--- a/src/flavors/snohomish/static/css/custom.css
+++ b/src/flavors/snohomish/static/css/custom.css
@@ -137,6 +137,11 @@
 //  width: 70px;
 //}
 
+.input-form__field-prompt {
+  font-weight: 900;
+  font-size: 1.1em;
+}
+
 .input-form__field-container[data-field-type="datetime"],
 .input-form__field-container[data-field-type="big_toggle"] {
   background-color: #efefef;
@@ -182,7 +187,22 @@
   text-indent: 0.7em;
 }
 
-.big-toggle-field__label--toggled:hover:before {
+.datetime-field__label-ongoing:before {
+  background-color: #efefef;
+  border: 4px solid #779300;
+}
+
+.datetime-field__label-ongoing--toggled:before {
+  background-color: #779300;
+  color: #fff;
+}
+
+.datetime-field__label-ongoing:hover:before {
+  color: #779300;
+}
+
+.big-toggle-field__label--toggled:hover:before,
+.datetime-field__label-ongoing--toggled:hover:before {
   color: #fff;
 }
 


### PR DESCRIPTION
Add an optional "ongoing" checkbox to the datepicker input field. Update `snohomish` flavor to use this feature.

To enable the ongoing option, add the following line to the config for a `datetime` field:
```
ongoing_label: _(Label for ongoing checkbox)
```
If the `ongoing_label` attribute is not present, the ongoing option will not be displayed.

The UI looks like this:

<img width="468" alt="screen shot 2018-08-12 at 1 13 23 pm" src="https://user-images.githubusercontent.com/9222338/44006019-a8c8e364-9e31-11e8-9b1c-bc55b3f0c1d8.png">

Date entry and "ongoing" entry are mutually exclusive: if the "ongoing" checkbox is selected, any date entered in the date field is cleared. If a date is entered, the "ongoing" checkbox is unselected.

A special far-future date (`9999-12-31 23:59:59`) is used to represent an ongoing date selection in the database.