### PR TITLE
Fix toggle/checkbox/radio hover issue

### DIFF
--- a/.modernizrrc.js
+++ b/.modernizrrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "feature-detects": ["touchevents"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -464,6 +464,12 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
       "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
     },
+    "autolinker": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=",
+      "dev": true
+    },
     "autoprefixer": {
       "version": "6.7.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
@@ -4699,6 +4705,12 @@
         "escape-string-regexp": "1.0.5"
       }
     },
+    "file": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz",
+      "integrity": "sha1-w9/Y+M81Na5FXCtCPC5SY112tNM=",
+      "dev": true
+    },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
@@ -4788,6 +4800,12 @@
         "make-dir": "1.2.0",
         "pkg-dir": "2.0.0"
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -9782,6 +9800,67 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "modernizr": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/modernizr/-/modernizr-3.6.0.tgz",
+      "integrity": "sha512-CC6hAvMDNlfSqaGt2EgU3/4ufAIKJYgZePt6rj6vEFqr7rsr6KVhl1PZ7E974E4JvlfmxAPIObUKwb/bqO22cA==",
+      "dev": true,
+      "requires": {
+        "doctrine": "1.2.3",
+        "file": "0.2.2",
+        "find-parent-dir": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "remarkable": "^1.6.2",
+        "requirejs": "2.1.22",
+        "yargs": "7.0.2"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.3.tgz",
+          "integrity": "sha1-auxrvWLPid1JjK5wwO2fSdqHOmo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.0.2.tgz",
+          "integrity": "sha1-EVuX3xMhgj6Lhkjolox4JSEiH2c=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         }
       }
@@ -16080,6 +16159,34 @@
         }
       }
     },
+    "remarkable": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
+      "dev": true,
+      "requires": {
+        "argparse": "~0.1.15",
+        "autolinker": "~0.15.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+          "dev": true,
+          "requires": {
+            "underscore": "~1.7.0",
+            "underscore.string": "~2.4.0"
+          }
+        },
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+          "dev": true
+        }
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -16183,6 +16290,12 @@
           "dev": true
         }
       }
+    },
+    "requirejs": {
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.22.tgz",
+      "integrity": "sha1-3Xj9LTQYDA1ixyS1uK68BmTgNm8=",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -17779,6 +17892,12 @@
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "dev": true
     },
+    "underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -18570,6 +18689,16 @@
             "camelcase": "3.0.0"
           }
         }
+      }
+    },
+    "webpack-modernizr-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-modernizr-loader/-/webpack-modernizr-loader-4.0.1.tgz",
+      "integrity": "sha512-z//IXQElhMgZSyw2HzV/q13661QxhO8gcHgyGdVML+2PTxFKwMF1AYVX6Vu9vab7tvFPeJ2/gsG2mKC5BwirUA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "modernizr": "^3.5.0"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "watchify": "^3.4.0",
     "wax-on": "^1.2.0",
     "webpack-dev-server": "^2.11.2",
+    "webpack-modernizr-loader": "^4.0.1",
     "yaml-loader": "^0.5.0"
   }
 }

--- a/src/base/static/components/form-fields/types/big-checkbox-field.js
+++ b/src/base/static/components/form-fields/types/big-checkbox-field.js
@@ -8,8 +8,6 @@ import "./big-checkbox-field.scss";
 
 import { isTouchDevice } from "../../../utils/misc-utils";
 
-const IS_TOUCH_DEVICE = isTouchDevice();
-
 class BigCheckboxField extends Component {
   onChange(evt) {
     const idx = this.props.checkboxGroupState.indexOf(evt.target.value);
@@ -35,7 +33,7 @@ class BigCheckboxField extends Component {
         />
         <label
           className={classNames("big-checkbox-field__label", {
-            "big-checkbox-field__label--hoverable": !IS_TOUCH_DEVICE,
+            "big-checkbox-field__label--hoverable": !isTouchDevice,
             "big-checkbox-field__label--toggled": isChecked,
             "big-checkbox-field__label--has-autofill":
               this.props.hasAutofill && isChecked,

--- a/src/base/static/components/form-fields/types/big-checkbox-field.js
+++ b/src/base/static/components/form-fields/types/big-checkbox-field.js
@@ -6,6 +6,10 @@ import classNames from "classnames";
 import CheckboxField from "./checkbox-field";
 import "./big-checkbox-field.scss";
 
+import { isTouchDevice } from "../../../utils/misc-utils";
+
+const IS_TOUCH_DEVICE = isTouchDevice();
+
 class BigCheckboxField extends Component {
   onChange(evt) {
     const idx = this.props.checkboxGroupState.indexOf(evt.target.value);
@@ -18,13 +22,6 @@ class BigCheckboxField extends Component {
 
   render() {
     const isChecked = this.props.checkboxGroupState.includes(this.props.value);
-    const cn = {
-      label: classNames("big-checkbox-field__label", {
-        "big-checkbox-field__label--toggled": isChecked,
-        "big-checkbox-field__label--has-autofill":
-          this.props.hasAutofill && isChecked,
-      }),
-    };
 
     return (
       <div className="big-checkbox-field">
@@ -36,7 +33,15 @@ class BigCheckboxField extends Component {
           checked={isChecked}
           onChange={this.onChange.bind(this)}
         />
-        <label className={cn.label} htmlFor={this.props.id}>
+        <label
+          className={classNames("big-checkbox-field__label", {
+            "big-checkbox-field__label--hoverable": !IS_TOUCH_DEVICE,
+            "big-checkbox-field__label--toggled": isChecked,
+            "big-checkbox-field__label--has-autofill":
+              this.props.hasAutofill && isChecked,
+          })}
+          htmlFor={this.props.id}
+        >
           {this.props.label}
         </label>
       </div>

--- a/src/base/static/components/form-fields/types/big-checkbox-field.scss
+++ b/src/base/static/components/form-fields/types/big-checkbox-field.scss
@@ -41,16 +41,15 @@
   }
 }
 
-@media (hover: hover) {
-  .big-checkbox-field__label {
-    &:hover {
-      color: $big-checkbox-field-hover-label-color;
+.big-checkbox-field__label--hoverable {
+  &:hover {
+    color: $big-checkbox-field-hover-label-color;
 
-      &:before {
-        content: $big-checkbox-field-icon;
-        text-indent: 0.9em;
-        color: $big-checkbox-field-hover-icon-color;
-      }
+    &:before {
+      font-family: FontAwesome;
+      content: $big-checkbox-field-icon;
+      text-indent: 0.7em;
+      color: $big-checkbox-field-hover-icon-color;
     }
   }
 }
@@ -64,9 +63,10 @@
   color: $big-checkbox-field-selected-label-color;
 
   &:before {
+    font-family: FontAwesome;
     content: $big-checkbox-field-icon;
     background-color: $big-checkbox-field-selected-icon-background-color;
-    text-indent: 0.9em;
+    text-indent: 0.7em;
     color: $big-checkbox-field-selected-icon-color;
   }
 }

--- a/src/base/static/components/form-fields/types/big-radio-field.js
+++ b/src/base/static/components/form-fields/types/big-radio-field.js
@@ -5,15 +5,11 @@ import classNames from "classnames";
 import RadioField from "./radio-field";
 import "./big-radio-field.scss";
 
-const BigRadioField = props => {
-  const cn = {
-    label: classNames("big-radio-field__label", {
-      "big-radio-field__label--toggled": props.checked,
-      "big-radio-field__label--has-autofill":
-        props.hasAutofill && props.checked,
-    }),
-  };
+import { isTouchDevice } from "../../../utils/misc-utils";
 
+const IS_TOUCH_DEVICE = isTouchDevice();
+
+const BigRadioField = props => {
   return (
     <div className="big-radio-field">
       <RadioField
@@ -24,7 +20,15 @@ const BigRadioField = props => {
         value={props.value}
         onChange={e => props.onChange(e.target.name, e.target.value)}
       />
-      <label className={cn.label} htmlFor={props.id}>
+      <label
+        className={classNames("big-radio-field__label", {
+          "big-radio-field__label--hoverable": !IS_TOUCH_DEVICE,
+          "big-radio-field__label--toggled": props.checked,
+          "big-radio-field__label--has-autofill":
+            props.hasAutofill && props.checked,
+        })}
+        htmlFor={props.id}
+      >
         {props.label}
       </label>
     </div>

--- a/src/base/static/components/form-fields/types/big-radio-field.js
+++ b/src/base/static/components/form-fields/types/big-radio-field.js
@@ -7,8 +7,6 @@ import "./big-radio-field.scss";
 
 import { isTouchDevice } from "../../../utils/misc-utils";
 
-const IS_TOUCH_DEVICE = isTouchDevice();
-
 const BigRadioField = props => {
   return (
     <div className="big-radio-field">
@@ -22,7 +20,7 @@ const BigRadioField = props => {
       />
       <label
         className={classNames("big-radio-field__label", {
-          "big-radio-field__label--hoverable": !IS_TOUCH_DEVICE,
+          "big-radio-field__label--hoverable": !isTouchDevice,
           "big-radio-field__label--toggled": props.checked,
           "big-radio-field__label--has-autofill":
             props.hasAutofill && props.checked,

--- a/src/base/static/components/form-fields/types/big-radio-field.scss
+++ b/src/base/static/components/form-fields/types/big-radio-field.scss
@@ -41,16 +41,15 @@
   }
 }
 
-@media (hover: hover) {
-  .big-radio-field__label {
-    &:hover {
-      color: $big-radio-field-hover-label-color;
+.big-radio-field__label--hoverable {
+  &:hover {
+    color: $big-radio-field-hover-label-color;
 
-      &:before {
-        content: $big-radio-field-icon;
-        text-indent: 0.9em;
-        color: $big-radio-field-hover-icon-color;
-      }
+    &:before {
+      font-family: FontAwesome;
+      content: $big-radio-field-icon;
+      text-indent: 0.7em;
+      color: $big-radio-field-hover-icon-color;
     }
   }
 }
@@ -64,9 +63,10 @@
   color: $big-radio-field-selected-label-color;
 
   &:before {
+    font-family: FontAwesome;
     content: $big-radio-field-icon;
     background-color: $big-radio-field-selected-icon-background-color;
-    text-indent: 0.9em;
+    text-indent: 0.7em;
     color: $big-radio-field-selected-icon-color;
   }
 }

--- a/src/base/static/components/form-fields/types/big-toggle-field.js
+++ b/src/base/static/components/form-fields/types/big-toggle-field.js
@@ -5,14 +5,11 @@ import classNames from "classnames";
 import ToggleField from "./toggle-field";
 import "./big-toggle-field.scss";
 
-const BigToggleField = props => {
-  const cn = {
-    label: classNames("big-toggle-field__label", {
-      "big-toggle-field__label--toggled": props.checked,
-      "big-toggle-field__label--has-autofill": props.hasAutofill,
-    }),
-  };
+import { isTouchDevice } from "../../../utils/misc-utils";
 
+const IS_TOUCH_DEVICE = isTouchDevice();
+
+const BigToggleField = props => {
   return (
     <div className="big-toggle-field">
       <ToggleField
@@ -25,7 +22,14 @@ const BigToggleField = props => {
           props.onChange(e.target.name, props.values[e.target.checked ? 0 : 1])
         }
       />
-      <label className={cn.label} htmlFor={props.id}>
+      <label
+        className={classNames("big-toggle-field__label", {
+          "big-toggle-field__label--hoverable": !IS_TOUCH_DEVICE,
+          "big-toggle-field__label--toggled": props.checked,
+          "big-toggle-field__label--has-autofill": props.hasAutofill,
+        })}
+        htmlFor={props.id}
+      >
         {props.checked ? props.labels[0] : props.labels[1]}
       </label>
     </div>

--- a/src/base/static/components/form-fields/types/big-toggle-field.js
+++ b/src/base/static/components/form-fields/types/big-toggle-field.js
@@ -7,8 +7,6 @@ import "./big-toggle-field.scss";
 
 import { isTouchDevice } from "../../../utils/misc-utils";
 
-const IS_TOUCH_DEVICE = isTouchDevice();
-
 const BigToggleField = props => {
   return (
     <div className="big-toggle-field">
@@ -24,7 +22,7 @@ const BigToggleField = props => {
       />
       <label
         className={classNames("big-toggle-field__label", {
-          "big-toggle-field__label--hoverable": !IS_TOUCH_DEVICE,
+          "big-toggle-field__label--hoverable": !isTouchDevice,
           "big-toggle-field__label--toggled": props.checked,
           "big-toggle-field__label--has-autofill": props.hasAutofill,
         })}

--- a/src/base/static/components/form-fields/types/big-toggle-field.scss
+++ b/src/base/static/components/form-fields/types/big-toggle-field.scss
@@ -38,16 +38,15 @@
   }
 }
 
-@media (hover: hover) {
-  .big-toggle-field__label {
-    &:hover {
-      color: $big-toggle-field-hover-label-text-color;
+.big-toggle-field__label--hoverable {
+  &:hover {
+    color: $big-toggle-field-hover-label-text-color;
 
-      &:before {
-        content: $big-toggle-field-icon;
-        text-indent: 0.9em;
-        color: $big-toggle-field-hover-icon-color;
-      }
+    &:before {
+      font-family: FontAwesome;
+      content: $big-toggle-field-icon;
+      text-indent: 0.9em;
+      color: $big-toggle-field-hover-icon-color;
     }
   }
 }
@@ -61,6 +60,7 @@
   color: $big-toggle-field-selected-label-color;
 
   &:before {
+    font-family: FontAwesome;
     content: $big-toggle-field-icon;
     background-color: $big-toggle-field-selected-icon-background-color;
     text-indent: 0.9em;

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -13,8 +13,6 @@ import constants from "../../../constants";
 
 import "./datetime-field.scss";
 
-const IS_TOUCH_DEVICE = isTouchDevice();
-
 // HACK: We use a far-future timestamp to represent the notion of an "ongoing"
 // datetime selection.
 // TODO: Support the ability for field components to write to multiple backend
@@ -40,7 +38,7 @@ class DatetimeField extends Component {
               {this.props.ongoingLabel && (
                 <label
                   className={classNames("datetime-field__label-ongoing", {
-                    "datetime-field__label-ongoing--hoverable": !IS_TOUCH_DEVICE,
+                    "datetime-field__label-ongoing--hoverable": !isTouchDevice,
                     "datetime-field__label-ongoing--toggled":
                       this.props.value === this.ongoingValue,
                   })}

--- a/src/base/static/components/form-fields/types/datetime-field.js
+++ b/src/base/static/components/form-fields/types/datetime-field.js
@@ -7,10 +7,13 @@ import classNames from "classnames";
 import "react-datetime/css/react-datetime.css";
 
 import { CheckboxInput, DatetimeInput } from "../../atoms/input";
+import { isTouchDevice } from "../../../utils/misc-utils";
 
 import constants from "../../../constants";
 
 import "./datetime-field.scss";
+
+const IS_TOUCH_DEVICE = isTouchDevice();
 
 // HACK: We use a far-future timestamp to represent the notion of an "ongoing"
 // datetime selection.
@@ -37,6 +40,7 @@ class DatetimeField extends Component {
               {this.props.ongoingLabel && (
                 <label
                   className={classNames("datetime-field__label-ongoing", {
+                    "datetime-field__label-ongoing--hoverable": !IS_TOUCH_DEVICE,
                     "datetime-field__label-ongoing--toggled":
                       this.props.value === this.ongoingValue,
                   })}

--- a/src/base/static/components/form-fields/types/datetime-field.scss
+++ b/src/base/static/components/form-fields/types/datetime-field.scss
@@ -35,7 +35,9 @@
     text-indent: 0.3em;
     color: #000;
   }
+}
 
+.datetime-field__label-ongoing--hoverable {
   &:hover {
     cursor: pointer;
   }

--- a/src/base/static/components/form-fields/types/datetime-field.scss
+++ b/src/base/static/components/form-fields/types/datetime-field.scss
@@ -32,7 +32,7 @@
     background-color: #fff;
     border: 4px solid #000;
     width: 1.5em;
-    text-indent: 0.4em;
+    text-indent: 0.3em;
     color: #000;
   }
 
@@ -41,13 +41,15 @@
   }
 
   &:hover:before {
-    content: "✔";
+    font-family: FontAwesome;
+    content: $datetime-field-ongoing-icon;
   }
 }
 
 .datetime-field__label-ongoing--toggled {
   &:before {
-    content: "✔";
+    font-family: FontAwesome;
+    content: $datetime-field-ongoing-icon;
   }
 }
 

--- a/src/base/static/stylesheets/themes/default-theme/variables.scss
+++ b/src/base/static/stylesheets/themes/default-theme/variables.scss
@@ -30,7 +30,7 @@ $autofill-color: #ffffe0;
 // ICONS
 // -----------------------------------------------------------------------------
 $icon-search: "\F002";
-$icon-check-mark: "✔";
+$icon-check-mark: "\F00C";
 $icon-hamburger: "\F03A";
 $icon-solid-star: "\F005";
 $icon-heart-filled: "\F004";
@@ -152,6 +152,7 @@ $dropdown-field-autofill-background-color: $autofill-color;
   datetime-field.js
   Date/time picker
 */
+$datetime-field-ongoing-icon: $icon-check-mark;
 $datetime-field-border: 0.25em solid $secondary-color;
 $datetime-field-border-radius: 0 0 0 0;
 $datetime-field-padding: 0.5em 0.5em 0.5em 0.5em;
@@ -190,7 +191,7 @@ $big-radio-field-label-font-size: 1.15em;
 $big-radio-field-label-text-color: $light-gray;
 $big-radio-field-label-padding: 8px 10px 8px 60px;
 $big-radio-field-label-margin: 5px 0 0 0;
-$big-radio-field-line-height: 2.1em;
+$big-radio-field-line-height: 1.4em;
 $big-radio-field-hover-label-color: $very-dark-gray;
 $big-radio-field-label-border-radius: 4px;
 $big-radio-field-selected-icon-color: #ffffff;

--- a/src/base/static/utils/misc-utils.js
+++ b/src/base/static/utils/misc-utils.js
@@ -1,13 +1,5 @@
-const isTouchDevice = () => {
-  if (
-    window.ontouchstart ||
-    // eslint-disable-next-line no-undef
-    (window.DocumentTouch && document instanceof DocumentTouch)
-  ) {
-    return true;
-  }
+import modernizr from "../../../../.modernizrrc.js";
 
-  return false;
-};
+const isTouchDevice = () => modernizr.touchevents;
 
 export { isTouchDevice };

--- a/src/base/static/utils/misc-utils.js
+++ b/src/base/static/utils/misc-utils.js
@@ -1,5 +1,5 @@
 import modernizr from "../../../../.modernizrrc.js";
 
-const isTouchDevice = () => modernizr.touchevents;
+const isTouchDevice = modernizr.touchevents;
 
 export { isTouchDevice };

--- a/src/base/static/utils/misc-utils.js
+++ b/src/base/static/utils/misc-utils.js
@@ -1,0 +1,13 @@
+const isTouchDevice = () => {
+  if (
+    window.ontouchstart ||
+    // eslint-disable-next-line no-undef
+    (window.DocumentTouch && document instanceof DocumentTouch)
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export { isTouchDevice };

--- a/src/flavors/snohomish/static/css/custom.css
+++ b/src/flavors/snohomish/static/css/custom.css
@@ -171,8 +171,8 @@
   border: 4px solid #779300;
 }
 
-.big-toggle-field__label:hover:before {
-  text-indent: 0.7em;
+.big-toggle-field__label--hoverable:hover:before {
+  text-indent: 0.5em;
   color: #779300;
 }
 
@@ -184,7 +184,7 @@
   background-color: #efefef;
   border: 4px solid #779300;
   width: 2em;
-  text-indent: 0.7em;
+  text-indent: 0.5em;
 }
 
 .datetime-field__label-ongoing:before {
@@ -197,12 +197,12 @@
   color: #fff;
 }
 
-.datetime-field__label-ongoing:hover:before {
+.datetime-field__label-ongoing--hoverable:hover:before {
   color: #779300;
 }
 
-.big-toggle-field__label--toggled:hover:before,
-.datetime-field__label-ongoing--toggled:hover:before {
+.big-toggle-field__label--toggled.big-toggle-field__label--hoverable:hover:before,
+.datetime-field__label-ongoing--toggled.datetime-field__label-ongoing--hoverable:hover:before {
   color: #fff;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,6 +92,10 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.modernizrrc\.js$/,
+        loader: "webpack-modernizr-loader",
+      },
+      {
         test: /locales/,
         loader: "i18next-resource-store-loader",
         query: {


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/39

Fix a bug where the hover icon on radio, checkbox, and toggle form fields does not appear in Firefox. The bug was caused by a CSS4 feature (media feature queries to detect the presence of a touch device) not yet supported in FF.

Instead of using CSS to detect touch devices we now do so in the javascript.

This PR introduces `Modernizr` to the project (in a very lightweight form just for detecting the presence of touch devices). Detection of touch devices seems nitpicky enough that we want to outsource this to a third-party tool like `Modernizr`.

We use the [`webpack-modernizr-plugin`](https://www.npmjs.com/package/webpack-modernizr-loader) to integrate a lightweight build of `Modernizr` into our bundle.

For background context, the need to detect touch devices and change hover behavior stems from the fact that the `:hover` CSS pseudoselector causes hover styles to remain after a checkbox or toggle is unchecked on a mobile device. This "ghost" hover style will remain until another touch event is detected. This creates a usability problem because it's unclear to the user if the checkbox in question has actually been unchecked.