### PR TITLE
fixes for django 1.8

### DIFF
--- a/src/base/static/js/models/attachment-model.js
+++ b/src/base/static/js/models/attachment-model.js
@@ -53,7 +53,9 @@ module.exports = Backbone.Model.extend({
       progressHandler = Util.wrapHandler("progress", this, options.progress),
       myXhr = $.ajaxSettings.xhr();
 
-    formData.append("file", blob);
+    if (blob) {
+      formData.append("file", blob);
+    }
     formData.append("name", name);
     formData.append("type", type);
     formData.append("visible", visible);

--- a/src/base/static/js/models/place-model.js
+++ b/src/base/static/js/models/place-model.js
@@ -139,10 +139,19 @@ module.exports = Backbone.Model.extend({
     var attrs;
 
     if (method === "create" || method === "update") {
+      const keysToOmit = ["geometry"];
+      // If we are updating the place model and there is a submitter,
+      // we should omit the submitter from the payload so that the api
+      // knows to keep using the same reference.
+      // Note that the api doesn't allow, and shouldn't allow, for
+      // updating the submitter via the place model.
+      if (method === "update" && model.get("submitter")) {
+        keysToOmit.push("submitter");
+      }
       attrs = {
         type: "Feature",
         geometry: model.get("geometry"),
-        properties: _.omit(model.toJSON(), "geometry"),
+        properties: _.omit(model.toJSON(), keysToOmit),
       };
 
       options.data = JSON.stringify(attrs);

--- a/src/base/static/js/models/place-model.js
+++ b/src/base/static/js/models/place-model.js
@@ -140,11 +140,15 @@ module.exports = Backbone.Model.extend({
 
     if (method === "create" || method === "update") {
       const keysToOmit = ["geometry"];
-      // If we are updating the place model and there is a submitter,
-      // we should omit the submitter from the payload so that the api
-      // knows to keep using the same reference.
-      // Note that the api doesn't allow, and shouldn't allow, for
-      // updating the submitter via the place model.
+      // NOTE(jalmogo): If we are updating the place model and there
+      // is a submitter, we should omit the submitter from the payload so
+      // that the api knows to keep using the same reference. Otherwise,
+      // the api thinks we are posting a brand new submitter.
+      // Ideally, the api shouldn't allow for
+      // creating new submitters when creating/updating a Place.
+      // And we should be referencing the submitter by url
+      // on the Place, and storing a collection of Submitters,
+      // instead of hanging a submitter object off of the Place.
       if (method === "update" && model.get("submitter")) {
         keysToOmit.push("submitter");
       }

--- a/src/base/static/js/models/submission-collection.js
+++ b/src/base/static/js/models/submission-collection.js
@@ -1,6 +1,8 @@
 var PaginatedCollection = require("./paginated-collection");
+const SubmissionModel = require("./submission-model");
 
 module.exports = PaginatedCollection.extend({
+  model: SubmissionModel,
   initialize: function(models, options) {
     this.options = options;
   },

--- a/src/base/static/js/models/submission-model.js
+++ b/src/base/static/js/models/submission-model.js
@@ -1,0 +1,18 @@
+module.exports = Backbone.Model.extend({
+  sync: function(method, model, options) {
+    if (method === "update" && model.get("submitter")) {
+      // NOTE(jalmogo): If we are updating the place model and there
+      // is a submitter, we should omit the submitter from the payload so
+      // that the api knows to keep using the same reference. Otherwise,
+      // the api thinks we are posting a brand new submitter.
+      // Ideally, the api shouldn't allow for
+      // creating new submitters when creating/updating a Place.
+      // And we should be referencing the submitter by url
+      // on the Place, and storing a collection of Submitters,
+      // instead of hanging a submitter object off of the Place.
+      model.unset("submitter");
+    }
+
+    return Backbone.sync(method, model, options);
+  },
+});


### PR DESCRIPTION
Addresses: https://github.com/jalMogo/mgmt/issues/32

Addresses the following, outlined in the issue above:
 - Getting a 400 when editing a Place that was submitted by a logged in user
 - Getting a 400 when editing a Submission that was submitted by a logged in user
 - Getting a 400 when adding/deleting an Attachment as an admin

This PR should be fine to deploy as-is, but to be safe, I think we should deploy it along with the new 1.8 API.