### PR TITLE
Fix broken AppView import and tests

### DIFF
--- a/src/base/static/components/place-detail/metadata-bar.js
+++ b/src/base/static/components/place-detail/metadata-bar.js
@@ -46,8 +46,7 @@ const MetadataBar = props => {
             props.placeModel.get(constants.MODEL_ID_PROPERTY_NAME)
           }
           className="place-detail-metadata-bar__created-datetime"
-        >
-        </a>
+        />
         <p className="place-detail-metadata-bar__survey-count">
           {props.surveyModels.size}{" "}
           {props.surveyModels.size === 1

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -1,10 +1,10 @@
 /*globals Backbone jQuery _ */
 
-var PlaceModel = require("./models/place-model.js");
-var Util = require("./utils.js");
-var PlaceCollection = require("./models/place-collection.js");
-var ActionCollection = require("./models/action-collection.js");
-var AppView = require("mapseed-app-view");
+import PlaceModel from "./models/place-model.js";
+import Util from "./utils.js";
+import PlaceCollection from "./models/place-collection.js";
+import ActionCollection from "./models/action-collection.js";
+import AppView from "mapseed-app-view";
 
 // Global-namespace Util
 Shareabouts.Util = Util;

--- a/src/flavors/augusta/static/js/views/app-view.js
+++ b/src/flavors/augusta/static/js/views/app-view.js
@@ -19,7 +19,9 @@ import config from "config";
 import { setConfig } from "../../../../../base/static/state/ducks/config";
 import UserMenu from "../../../../../base/static/components/molecules/user-menu";
 
-import AppView, { store } from "../../../../../base/static/js/views/app-view.js";
+import AppView, {
+  store,
+} from "../../../../../base/static/js/views/app-view.js";
 const PlaceCounterView = require("../../../../../base/static/js/views/place-counter-view");
 const PagesNavView = require("../../../../../base/static/js/views/pages-nav-view");
 const MapView = require("../../../../../base/static/js/views/map-view");

--- a/src/flavors/bathgate/static/js/views/app-view.js
+++ b/src/flavors/bathgate/static/js/views/app-view.js
@@ -19,7 +19,9 @@ import config from "config";
 import { setConfig } from "../../../../../base/static/state/ducks/config";
 import UserMenu from "../../../../../base/static/components/molecules/user-menu";
 
-import AppView, { store } from "../../../../../base/static/js/views/app-view.js";
+import AppView, {
+  store,
+} from "../../../../../base/static/js/views/app-view.js";
 const PlaceCounterView = require("../../../../../base/static/js/views/place-counter-view");
 const PagesNavView = require("../../../../../base/static/js/views/pages-nav-view");
 const MapView = require("../../../../../base/static/js/views/map-view");

--- a/src/flavors/hull/static/js/views/app-view.js
+++ b/src/flavors/hull/static/js/views/app-view.js
@@ -19,7 +19,9 @@ import config from "config";
 import { setConfig } from "../../../../../base/static/state/ducks/config";
 import UserMenu from "../../../../../base/static/components/molecules/user-menu";
 
-import AppView, { store } from "../../../../../base/static/js/views/app-view.js";
+import AppView, {
+  store,
+} from "../../../../../base/static/js/views/app-view.js";
 const PlaceCounterView = require("../../../../../base/static/js/views/place-counter-view");
 const PagesNavView = require("../../../../../base/static/js/views/pages-nav-view");
 const MapView = require("../../../../../base/static/js/views/map-view");

--- a/src/flavors/manzanares/static/js/views/app-view.js
+++ b/src/flavors/manzanares/static/js/views/app-view.js
@@ -19,7 +19,9 @@ import config from "config";
 import { setConfig } from "../../../../../base/static/state/ducks/config";
 import UserMenu from "../../../../../base/static/components/molecules/user-menu";
 
-import AppView, { store } from "../../../../../base/static/js/views/app-view.js";
+import AppView, {
+  store,
+} from "../../../../../base/static/js/views/app-view.js";
 const PlaceCounterView = require("../../../../../base/static/js/views/place-counter-view");
 const PagesNavView = require("../../../../../base/static/js/views/pages-nav-view");
 const MapView = require("../../../../../base/static/js/views/map-view");

--- a/src/flavors/williams/static/js/views/app-view.js
+++ b/src/flavors/williams/static/js/views/app-view.js
@@ -19,7 +19,9 @@ import config from "config";
 import { setConfig } from "../../../../../base/static/state/ducks/config";
 import UserMenu from "../../../../../base/static/components/molecules/user-menu";
 
-import AppView, { store } from "../../../../../base/static/js/views/app-view.js";
+import AppView, {
+  store,
+} from "../../../../../base/static/js/views/app-view.js";
 const PlaceCounterView = require("../../../../../base/static/js/views/place-counter-view");
 const PagesNavView = require("../../../../../base/static/js/views/pages-nav-view");
 const MapView = require("../../../../../base/static/js/views/map-view");


### PR DESCRIPTION
The changes made here: https://github.com/mapseed/platform/blob/847a2858e323fbca575b1b04500ccd0e0298430a/src/base/static/js/views/app-view.js#L1032 are causing an error in routes.js, where "AppView is not a constructor". This is because the node modules syntax is affected by the es6 export syntax, that is used in AppView.

This PR fixes that issue. We should be using es6 import syntax for all future development.

This PR also fixes the tests that were broken in this commit: https://github.com/mapseed/platform/commit/d20ba4c0b0dd3ae426cf5334ef51773631fbcb76