### PR TITLE
fix(AppView): import errors related to mixing es6 and commonjs module syntax

### DIFF
--- a/src/flavors/central-puget-sound/static/js/views/app-view.js
+++ b/src/flavors/central-puget-sound/static/js/views/app-view.js
@@ -1,9 +1,9 @@
 // BEGIN CUSTOM CODE
-const AppView = require("../../../../../base/static/js/views/app-view.js");
+import AppView from "../../../../../base/static/js/views/app-view.js";
 import emitter from "../../../../../base/static/utils/emitter";
 // END CUSTOM CODE
 
-module.exports = AppView.extend({
+export default AppView.extend({
   events: {
     "click #add-place": "onClickAddPlaceBtn",
     "click .close-btn": "onClickClosePanelBtn",

--- a/src/flavors/pugetsound/static/js/views/app-view.js
+++ b/src/flavors/pugetsound/static/js/views/app-view.js
@@ -1,9 +1,9 @@
 // BEGIN CUSTOM CODE
-const AppView = require("../../../../../base/static/js/views/app-view.js");
+import AppView from "../../../../../base/static/js/views/app-view.js";
 import emitter from "../../../../../base/static/utils/emitter";
 // END CUSTOM CODE
 
-module.exports = AppView.extend({
+export default AppView.extend({
   events: {
     "click #add-place": "onClickAddPlaceBtn",
     "click .close-btn": "onClickClosePanelBtn",

--- a/src/flavors/snohomish/static/js/views/app-view.js
+++ b/src/flavors/snohomish/static/js/views/app-view.js
@@ -1,10 +1,10 @@
-const AppView = require("../../../../../base/static/js/views/app-view.js");
+import AppView from "../../../../../base/static/js/views/app-view.js";
 const Util = require("../../../../../base/static/js/utils.js");
 // BEGIN CUSTOM CODE
 import emitter from "../../../../../base/static/utils/emitter";
 // END CUSTOM CODE
 
-module.exports = AppView.extend({
+export default AppView.extend({
   events: {
     "click #add-place": "onClickAddPlaceBtn",
     "click .close-btn": "onClickClosePanelBtn",


### PR DESCRIPTION
Since AppView was refactored to use the es6 module syntax, it was causing the CPS, PugetSound, and Snohomish flavors builds to fail. This PR fixes those import errors. 

I believe the equivalent fix using the commonJS syntax would be something like this:

```javascript
const AppView = require("../../../../../base/static/js/views/app-view.js").default;
```

but moving forward, we should avoid using the commonJS syntax and start using the es6 module syntax.