### PR TITLE
chore(package.json): add new deploy scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "homepage": "https://github.com/smartercleanup/platform",
   "scripts": {
     "start": "node scripts/static-build.js && webpack-dev-server",
+    "deploy": "node scripts/deploy.js",
+    "build-deploy": "npm run build && npm run deploy",
     "test": "jest --verbose --config ./jest.config.js",
     "test:watch": "jest --watch --verbose --config ./jest.watch.config.js",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -5,6 +5,7 @@ const path = require("path");
 if (!process.env.DEPLOY_DOMAIN) {
   throw "Set the DEPLOY_DOMAIN environment variable to the S3 bucket you want to deploy Mapseed to.";
 }
+// eslint-disable-next-line no-console
 console.log(`Updating website: ${process.env.DEPLOY_DOMAIN}`);
 const config = {
   domain: process.env.DEPLOY_DOMAIN,

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -3,8 +3,9 @@ const glob = require("glob");
 const path = require("path");
 
 if (!process.env.DEPLOY_DOMAIN) {
-  throw "Set the DEPLOY_DOMAIN environment variable to the domain you want to deploy Mapseed to.";
+  throw "Set the DEPLOY_DOMAIN environment variable to the S3 bucket you want to deploy Mapseed to.";
 }
+console.log(`Updating website: ${process.env.DEPLOY_DOMAIN}`);
 const config = {
   domain: process.env.DEPLOY_DOMAIN,
   region: process.env.DEPLOY_REGION || "us-west-2",


### PR DESCRIPTION
This simplifies the deployment process, so that we can set the `FLAVOR` and `DEPLOY_DOMAIN` env vars in our `.env` file, then run `npm run build-deploy`, to build and deploy our bundle.

ie:
```
FLAVOR=snohomish
DEPLOY_DOMAIN=snohomishcd.mapseed.org
```

Of course, this assumes that `API_ROOT`, `<flavor>SITE_URL`, and other env vars have been correctly set in the `.env` file.