### PR TITLE
Refactor focused geometry

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -251,19 +251,21 @@ class MainMap extends Component {
           collectionId,
           createGeoJSONFromCollection({
             collection: this.props.places[collectionId],
-          }),
+          }).regularFeatures,
         );
       },
     );
     emitter.addListener(
       constants.PLACE_COLLECTION_FOCUS_PLACE_EVENT,
       ({ collectionId, modelId }) => {
-        this._map.updateLayerData(
+        const featureData = createGeoJSONFromCollection({
+          collection: this.props.places[collectionId],
+          modelIdToFocus: modelId,
+        });
+
+        this._map.focusPlaceLayerFeatures(
           collectionId,
-          createGeoJSONFromCollection({
-            collection: this.props.places[collectionId],
-            modelIdToFocus: modelId,
-          }),
+          featureData.focusedFeatures,
         );
       },
     );
@@ -275,7 +277,7 @@ class MainMap extends Component {
           createGeoJSONFromCollection({
             collection: this.props.places[collectionId],
             modelIdToHide: modelId,
-          }),
+          }).regularFeatures,
         );
       },
     );
@@ -288,8 +290,9 @@ class MainMap extends Component {
               collectionId,
               createGeoJSONFromCollection({
                 collection: this.props.places[collectionId],
-              }),
+              }).regularFeatures,
             );
+          this._map.unfocusAllPlaceLayerFeatures(collectionId);
         });
       },
     );
@@ -391,7 +394,8 @@ class MainMap extends Component {
     if (layer.type === "place") {
       layer.source = createGeoJSONFromCollection({
         collection: this.props.places[layer.id],
-      });
+      }).regularFeatures;
+
       this._map.addLayer({
         layer: layer,
         isBasemap: isBasemap,

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -59,23 +59,18 @@ map:
       url: https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/demo2
       type: place
       slug: demo2
-      rules:
-        # "observation2" location_type
+      focus_rules:
         - filter:
-            - "all"
-            - - "=="
-              - - "get"
-                - "location_type"
-              - "observation2"
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - true
+          - "=="
+          - - "get"
+            - "location_type"
+          - "observation2"
           symbol-layout:
             icon-image: "marker-observation.png"
             icon-size: 1.2
             icon-anchor: "bottom"
+      rules:
+        # "observation2" location_type
         - filter:
             - "all"
             - - "=="
@@ -85,11 +80,6 @@ map:
             - - "<"
               - - "zoom"
               - 11
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-observation.png"
             icon-size: 0.5
@@ -106,11 +96,6 @@ map:
             - - "<"
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-observation.png"
             icon-size: 0.75
@@ -124,11 +109,6 @@ map:
             - - ">="
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-observation.png"
             icon-size: 0.9
@@ -138,22 +118,59 @@ map:
       type: place
       slug: demo
       is_visible_default: true
-      rules:
-        # "demo" location_type
+      focus_rules:
         - filter:
             - "all"
             - - "=="
               - - "get"
                 - "location_type"
               - "demo"
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - true
           symbol-layout:
             icon-size: 1.2
             icon-anchor: "bottom"
+        - filter:
+            - "all"
+            - - "=="
+              - - "get"
+                - "location_type"
+              - "complaint"
+          symbol-layout:
+            icon-image: "marker-complaint.png"
+            icon-size: 1.2
+            icon-anchor: "bottom"
+        - filter:
+            - "all"
+            - - "=="
+              - - "get"
+                - "location_type"
+              - "question"
+          symbol-layout:
+            icon-image: "marker-question.png"
+            icon-size: 1.2
+            icon-anchor: "bottom"
+        - filter:
+            - "all"
+            - - "=="
+              - - "get"
+                - "location_type"
+              - "idea"
+          symbol-layout:
+            icon-image: "marker-idea.png"
+            icon-size: 1.2
+            icon-anchor: "bottom"
+        - filter:
+            - "all"
+            - - "=="
+              - - "get"
+                - "location_type"
+              - "observation"
+          symbol-layout:
+            icon-image: "marker-observation.png"
+            icon-size: 1.2
+            icon-anchor: "bottom"
+
+      rules:
+        # "demo" location_type
         - filter:
             - "all"
             - - "=="
@@ -163,11 +180,6 @@ map:
             - - "<"
               - - "zoom"
               - 11
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-size: 0.5
             icon-anchor: "center"
@@ -183,11 +195,6 @@ map:
             - - "<"
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-size: 0.75
             icon-anchor: "center"
@@ -200,11 +207,6 @@ map:
             - -  ">="
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-size: 0.9
             icon-anchor: "center"
@@ -216,29 +218,9 @@ map:
               - - "get"
                 - "location_type"
               - "complaint"
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - true
-          symbol-layout:
-            icon-image: "marker-complaint.png"
-            icon-size: 1.2
-            icon-anchor: "bottom"
-        - filter:
-            - "all"
-            - - "=="
-              - - "get"
-                - "location_type"
-              - "complaint"
             - - "<"
               - - "zoom"
               - 11
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-complaint.png"
             icon-size: 0.5
@@ -255,11 +237,6 @@ map:
             - - "<"
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-complaint.png"
             icon-size: 0.75
@@ -273,11 +250,6 @@ map:
             - - ">="
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-complaint.png"
             icon-size: 0.9
@@ -290,29 +262,9 @@ map:
               - - "get"
                 - "location_type"
               - "question"
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - true
-          symbol-layout:
-            icon-image: "marker-question.png"
-            icon-size: 1.2
-            icon-anchor: "bottom"
-        - filter:
-            - "all"
-            - - "=="
-              - - "get"
-                - "location_type"
-              - "question"
             - - "<"
               - - "zoom"
               - 11
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-question.png"
             icon-size: 0.5
@@ -329,11 +281,6 @@ map:
             - - "<"
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-question.png"
             icon-size: 0.75
@@ -347,11 +294,6 @@ map:
             - - ">="
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-question.png"
             icon-size: 0.9
@@ -364,29 +306,9 @@ map:
               - - "get"
                 - "location_type"
               - "idea"
-            - -  "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - true
-          symbol-layout:
-            icon-image: "marker-idea.png"
-            icon-size: 1.2
-            icon-anchor: "bottom"
-        - filter:
-            - "all"
-            - - "=="
-              - - "get"
-                - "location_type"
-              - "idea"
             - - "<"
               - - "zoom"
               - 11
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-idea.png"
             icon-size: 0.5
@@ -403,11 +325,6 @@ map:
             - - "<"
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-idea.png"
             icon-size: 0.75
@@ -421,11 +338,6 @@ map:
             - - ">="
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-idea.png"
             icon-size: 0.9
@@ -438,29 +350,9 @@ map:
               - - "get"
                 - "location_type"
               - "observation"
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - true
-          symbol-layout:
-            icon-image: "marker-observation.png"
-            icon-size: 1.2
-            icon-anchor: "bottom"
-        - filter:
-            - "all"
-            - - "=="
-              - - "get"
-                - "location_type"
-              - "observation"
             - - "<"
               - - "zoom"
               - 11
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-observation.png"
             icon-size: 0.5
@@ -477,11 +369,6 @@ map:
             - - "<"
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-observation.png"
             icon-size: 0.75
@@ -495,11 +382,6 @@ map:
             - - ">="
               - - "zoom"
               - 14
-            - - "=="
-              - - "get"
-                - "isFocused"
-              - - "to-boolean"
-                - false
           symbol-layout:
             icon-image: "marker-observation.png"
             icon-size: 0.9


### PR DESCRIPTION
This PR elevates the concept of "focused" geometry styles, which has been part of Mapseed/Shareabouts since the beginning, to a first-class member of the layer abstraction.

To do this we introduce a dedicated Mapbox source for focused geometry, we create dedicated Mapbox layers to render that source as needed, and we create a new `focus_styles` section of the layer config to hold styles for focused geometry.

This solves several problems:

* Focused geometry now renders consistently on top of non-focused geometry in the same dataset. Previously there was no way to guarantee that a piece of focused geometry would render on top of its unfocused neighbors.
* Config style rules are (hopefully) simplified by removing an arbitrary and obscure dependence on the `isFocused` geometry attribute to determine whether a feature was focused.
* Performance is potentially improved (though there's still more we could do here) by using separate layers and sources for focused geometry.
* We introduce the ability to set focus styles for linestring and polygonal geometry, which has never been possible in the app before.

### Caveats
* Focus style rules are currently only applicable to Mapseed place layers. Eventually we might want to extend this concept to other layer types.