### PR TITLE
Fix spritesheets on low-DPI devices

### DIFF
--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -461,6 +461,10 @@ Spritesmith.run({ src: markers }, (err, result) => {
   }
 
   fs.writeFileSync(
+    path.resolve(distMarkersPath, "spritesheet.png"),
+    result.image,
+  );
+  fs.writeFileSync(
     path.resolve(distMarkersPath, "spritesheet@1x.png"),
     result.image,
   );
@@ -484,6 +488,10 @@ Spritesmith.run({ src: markers }, (err, result) => {
     {},
   );
 
+  fs.writeFileSync(
+    path.resolve(distMarkersPath, "spritesheet.json"),
+    JSON.stringify(coordinates),
+  );
   fs.writeFileSync(
     path.resolve(distMarkersPath, "spritesheet@1x.json"),
     JSON.stringify(coordinates),

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -465,10 +465,6 @@ Spritesmith.run({ src: markers }, (err, result) => {
     result.image,
   );
   fs.writeFileSync(
-    path.resolve(distMarkersPath, "spritesheet@1x.png"),
-    result.image,
-  );
-  fs.writeFileSync(
     // For high-resolution devices; Mapbox expects this file.
     path.resolve(distMarkersPath, "spritesheet@2x.png"),
     result.image,
@@ -490,10 +486,6 @@ Spritesmith.run({ src: markers }, (err, result) => {
 
   fs.writeFileSync(
     path.resolve(distMarkersPath, "spritesheet.json"),
-    JSON.stringify(coordinates),
-  );
-  fs.writeFileSync(
-    path.resolve(distMarkersPath, "spritesheet@1x.json"),
     JSON.stringify(coordinates),
   );
   fs.writeFileSync(


### PR DESCRIPTION
We were missing `spritesheet.json` and `spritesheet.png` in our build files. We were using `spritesheet@1.json` and `spritesheet@1.png` for low-res devices instead; this was apparently wrong, as discussed here: https://www.mapbox.com/mapbox-gl-js/style-spec/#sprite