### PR TITLE
Quick fixes for issues with clicked-on places on mobile devices

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -402,27 +402,32 @@ class MainMap extends Component {
       });
 
       // Bind map interaction events for this place layer.
-      this._map.bindPlaceLayerEvent("click", layer.id, clickedOnLayer => {
-        if (clickedOnLayer.properties[constants.CUSTOM_URL_PROPERTY_NAME]) {
-          this.props.router.navigate(
-            `/${clickedOnLayer.properties[constants.CUSTOM_URL_PROPERTY_NAME]}`,
-            {
-              trigger: true,
-            },
-          );
-        } else {
-          this.props.router.navigate(
-            `/${
-              clickedOnLayer.properties[constants.DATASET_SLUG_PROPERTY_NAME]
-            }/${clickedOnLayer.properties.id}`,
-            { trigger: true },
-          );
-        }
-      });
-      this._map.bindPlaceLayerEvent("mouseenter", layer.id, () => {
+      this._map.bindPlaceLayerEvents(
+        layer.id,
+        clickedOnLayer => {
+          if (clickedOnLayer.properties[constants.CUSTOM_URL_PROPERTY_NAME]) {
+            this.props.router.navigate(
+              `/${
+                clickedOnLayer.properties[constants.CUSTOM_URL_PROPERTY_NAME]
+              }`,
+              {
+                trigger: true,
+              },
+            );
+          } else {
+            this.props.router.navigate(
+              `/${
+                clickedOnLayer.properties[constants.DATASET_SLUG_PROPERTY_NAME]
+              }/${clickedOnLayer.properties.id}`,
+              { trigger: true },
+            );
+          }
+        },
+      );
+      this._map.bindPlaceLayerEvents(["mouseenter"], layer.id, () => {
         this._map.setCursor("pointer");
       });
-      this._map.bindPlaceLayerEvent("mouseleave", layer.id, () => {
+      this._map.bindPlaceLayerEvents(["mouseleave"], layer.id, () => {
         this._map.setCursor("");
       });
     } else {

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -403,6 +403,7 @@ class MainMap extends Component {
 
       // Bind map interaction events for this place layer.
       this._map.bindPlaceLayerEvents(
+        ["click", "touchstart"],
         layer.id,
         clickedOnLayer => {
           if (clickedOnLayer.properties[constants.CUSTOM_URL_PROPERTY_NAME]) {

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -910,26 +910,28 @@ export default (container, options) => {
       map.on(event, layerId, callback);
     },
 
-    bindPlaceLayerEvent: (eventName, layerId, callback) => {
-      layersCache[layerId].forEach(mapProviderLayer => {
-        let targetLayer = null;
-        !mapProviderLayer.id.includes(CLUSTER_LAYER_IDENTIFIER) &&
-          map.on(eventName, mapProviderLayer.id, evt => {
-            if (eventName === "click") {
-              // For click events, we query rendered features here to obtain a
-              // single array of layers below the clicked-on point. The first
-              // entry in this array corresponds to the topmost rendered feature.
-              // We skip this work for other events (like mouseenter), since we
-              // don't make use of information about the layer under the cursor
-              // in those cases.
-              targetLayer = map.queryRenderedFeatures([
-                evt.point.x,
-                evt.point.y,
-              ])[0];
-            }
+    bindPlaceLayerEvents: (eventNames, layerId, callback) => {
+      eventNames.forEach(eventName => {
+        layersCache[layerId].forEach(mapProviderLayer => {
+          let targetLayer = null;
+          !mapProviderLayer.id.includes(CLUSTER_LAYER_IDENTIFIER) &&
+            map.on(eventName, mapProviderLayer.id, evt => {
+              if (eventName === "click" || eventName === "touchstart") {
+                // For click and touchstart events, we query rendered features
+                // here to obtain a single array of layers below the clicked-on
+                // point. The first entry in this array corresponds to the
+                // topmost rendered feature. We skip this work for other events
+                // (like mouseenter), since we don't make use of information
+                // about the layer under the cursor in those cases.
+                targetLayer = map.queryRenderedFeatures([
+                  evt.point.x,
+                  evt.point.y,
+                ])[0];
+              }
 
-            callback(targetLayer);
-          });
+              callback(targetLayer);
+            });
+        });
       });
     },
 
@@ -1179,7 +1181,11 @@ export default (container, options) => {
     },
 
     easeTo: options => {
-      map.easeTo(options);
+      // NOTE: We use jumpTo here because easeTo works inconsistently on mobile
+      // devices.
+      // TODO: Investigate this further.
+      // See: https://github.com/jalMogo/mgmt/issues/85
+      map.jumpTo(options);
     },
 
     jumpTo: options => {


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/84
Addresses: https://github.com/jalMogo/mgmt/issues/85

Two mobile MapboxGL issues have cropped up:
* Click events are not registered at all on touch devices. It is not possible to click on places and open detail views on mobile devices as far as I can tell.
* `map.easeTo`'s behavior is inconsistent on touch devices, sometimes failing to center on the point it's supposed to.

We fix these issues by:
* Listening for `touchstart` events in addition to `click` events. This allows us to interact with places on touch devices, but I am not at all certain why this change is needed. Mapbox documentation and examples suggest that `click` events should work on touch devices. I'm merging this fix, but this needs more investigation.
* Swapping `easeTo` for `jumpTo` for the time being. This fixes the issue with `easeTo` but also needs more investigation.
