### PR TITLE
Fix animated map transitions on mobile devices

### DIFF
--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1013,29 +1013,35 @@ export default (container, options) => {
     },
 
     fitBounds: (bounds, options) => {
-      map.fitBounds(bounds, options);
+      setTimeout(() => {
+        map.fitBounds(bounds, options);
+      }, 0);
     },
 
     fitLineStringCoords: (coordinates, options) => {
       // https://www.mapbox.com/mapbox-gl-js/example/zoomto-linestring
-      map.fitBounds(
-        coordinates.reduce(
-          (bounds, coord) => bounds.extend(coord),
-          new mapboxgl.LngLatBounds(coordinates[0], coordinates[0]),
-        ),
-        options,
-      );
+      setTimeout(() => {
+        map.fitBounds(
+          coordinates.reduce(
+            (bounds, coord) => bounds.extend(coord),
+            new mapboxgl.LngLatBounds(coordinates[0], coordinates[0]),
+          ),
+          options,
+        );
+      }, 0);
     },
 
     fitPolygonCoords: (coordinates, options) => {
       // https://www.mapbox.com/mapbox-gl-js/example/zoomto-linestring
-      map.fitBounds(
-        coordinates[0].reduce(
-          (bounds, coord) => bounds.extend(coord),
-          new mapboxgl.LngLatBounds(coordinates[0][0], coordinates[0][0]),
-        ),
-        options,
-      );
+      setTimeout(() => {
+        map.fitBounds(
+          coordinates[0].reduce(
+            (bounds, coord) => bounds.extend(coord),
+            new mapboxgl.LngLatBounds(coordinates[0][0], coordinates[0][0]),
+          ),
+          options,
+        );
+      }, 0);
     },
 
     hasLayer: layerId => {
@@ -1185,7 +1191,9 @@ export default (container, options) => {
       // devices.
       // TODO: Investigate this further.
       // See: https://github.com/jalMogo/mgmt/issues/85
-      map.jumpTo(options);
+      setTimeout(() => {
+        map.easeTo(options);
+      }, 0);
     },
 
     jumpTo: options => {
@@ -1193,7 +1201,9 @@ export default (container, options) => {
     },
 
     flyTo: options => {
-      map.flyTo(options);
+      setTimeout(() => {
+        map.flyTo(options);
+      }, 0);
     },
 
     invalidateSize: () => {

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1187,10 +1187,6 @@ export default (container, options) => {
     },
 
     easeTo: options => {
-      // NOTE: We use jumpTo here because easeTo works inconsistently on mobile
-      // devices.
-      // TODO: Investigate this further.
-      // See: https://github.com/jalMogo/mgmt/issues/85
       setTimeout(() => {
         map.easeTo(options);
       }, 0);


### PR DESCRIPTION
Addresses: https://github.com/jalMogo/mgmt/issues/85

Animated MapboxGL transitions (`map.easeTo`, `map.fitBounds`, and `map.flyTo`) work inconsistently on mobile devices (tested on iOS and Android). On mobile devices these methods will very often have no effect at all, but will also produce no error output. The only time they seem to work is on initial page load (for example, if you load directly to a slippy `/z/x/y` route).

This PR  fixes the issue by calling these methods inside a 0-length timeout. I know this is hacky, but this is the only fix I can find for the time being. This feels like a low-level problem perhaps caused by the complex set of dependencies we have in play at the moment. I say that because simple MapboxGL demos do not exhibit this problem when using `easeTo`, `fitBounds`, and `flyTo`. So maybe simplifying our front end will help with this issue down the road?

I wish I had a better fix in the meantime, but I'm pretty stumped by this. 🤔 