### PR TITLE
Correctly position map when deeplinking

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -87,6 +87,12 @@ class MainMap extends Component {
     // Instantiate the map.
     this._map = MapProvider(props.container, props.mapConfig.options);
 
+    // Set initial map position state.
+    this.props.setMapPosition({
+      center: this.props.mapConfig.options.map.center,
+      zoom: this.props.mapConfig.options.map.zoom,
+    });
+
     this._map.on({
       event: "load",
       callback: () => {


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/90

When deeplinking to a place our initial map state was not being correctly set in Redux. This PR corrects the issue.