### PR TITLE
chore(package.json): remove unused static-eval dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17869,14 +17869,6 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
-    "static-eval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-1.1.1.tgz",
-      "integrity": "sha1-yoEwIQNUzxPZpyK8fpI3eEV7sZI=",
-      "requires": {
-        "escodegen": "1.9.1"
-      }
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "redux": "^4.0.0",
     "s3-website": "^3.2.2",
     "shelljs": "^0.5.3",
-    "static-eval": "^1.1.1",
     "togeojson": "^0.16.0",
     "webpack": "^3.10.0"
   },


### PR DESCRIPTION
This should remove the

>We found a potential security vulnerability in one of your dependencies. 

warning on the repo.