### PR TITLE
Gzip index files

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -106,6 +106,16 @@ function updateMetadata() {
         };
         return copyObjectPromise(buildParams(filepath, params));
       }),
+    )
+    .concat(
+      glob.sync("./www/index*").map(filepath => {
+        // All index files are gzipped
+        filepath = path.relative("./www", filepath);
+        params = {
+          ContentEncoding: "gzip",
+        };
+        return copyObjectPromise(buildParams(filepath, params));
+      }),
     );
 
   return Promise.all(updatePromises);

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -12,6 +12,7 @@ const glob = require("glob");
 const colors = require("colors");
 const Spritesmith = require("spritesmith");
 const shell = require("shelljs");
+const zlib = require("zlib");
 
 const transformCommonFormElements = require("../src/base/static/utils/config-loader-utils")
   .transformCommonFormElements;
@@ -373,7 +374,14 @@ activeLanguages.forEach(language => {
     outputBasePath,
     (language.code == "en_US" ? "index" : language.code) + ".html",
   );
-  fs.writeFileSync(outputIndexFilename, outputIndexFile);
+
+  if (process.env.NODE_ENV === "production") {
+    zlib.gzip(outputIndexFile, (error, result) => {
+      fs.writeFileSync(outputIndexFilename, result);
+    });
+  } else {
+    fs.writeFileSync(outputIndexFilename, outputIndexFile);
+  }
 });
 
 // (6) Move static image assets to the dist/ folder. Copy base project assets


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/94

Gzip our index.html files. According to the Lighthouse diagnostic tool, gzipping index files (which contain compiled template and config content) could save as much as 2 seconds on page load time. Running Lighthouse on this branch confirms that estimate. We're shipping almost 350K fewer bytes by compressing!

The need for compressing our index files will mostly go away when we finish the React port and flavor abstraction, but I think the near-term gain of a 2-second savings on load time is worth introducing a bit more complexity to the current build setup.