### PR TITLE
fix(MainMap): unbind event listeners when component unmounts

### DIFF
--- a/src/base/static/libs/maps/abstract-provider.js
+++ b/src/base/static/libs/maps/abstract-provider.js
@@ -118,6 +118,13 @@ const abstractMethods = {
   },
 
   /**
+   * Remove the map.
+   */
+  remove: function() {
+    notImplemented();
+  },
+
+  /**
    * Remove the passed layer from the map.
    */
   removeLayer: function(/*layer*/) {

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1117,6 +1117,10 @@ export default (container, options) => {
         );
     },
 
+    remove: () => {
+      map.remove();
+    },
+
     removeLayer: layer => {
       layer &&
         layersCache[layer.id] &&


### PR DESCRIPTION
We should be unsubscribing all event listeners when a React component unmounts. This PR does that.

This will allow us to unmount/remount the MainMap component, which isn't being done now, but will be done in the near future as we progress with the React port and port the ListView, for example.
