### PR TITLE
fix(deploy.js): don't clobber cache-control header

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -94,22 +94,13 @@ function updateMetadata() {
       filepath = path.relative("./www", filepath);
       params = {
         CacheControl: "no-cache, must-revalidate, max-age=0",
+        ContentEncoding: "gzip",
       };
       return copyObjectPromise(buildParams(filepath, params));
     })
     .concat(
       glob.sync("./www/**/*.gz").map(filepath => {
         // Ensure gzipped files have "Content-Encoding" set
-        filepath = path.relative("./www", filepath);
-        params = {
-          ContentEncoding: "gzip",
-        };
-        return copyObjectPromise(buildParams(filepath, params));
-      }),
-    )
-    .concat(
-      glob.sync("./www/index*").map(filepath => {
-        // All index files are gzipped
         filepath = path.relative("./www", filepath);
         params = {
           ContentEncoding: "gzip",


### PR DESCRIPTION
Silly mistake-- we were using a separate `params` block to add the `ContentEncoding` header to gzipped index files, which clobbered the previously-set `CacheControl` param. As a result `index.html` files were being improperly cached by CloudFront. This PR fixes that.