### PR TITLE
fix(MainMap): correct filter expression for focused features

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -285,7 +285,7 @@ class MainMap extends Component {
           // TODO: Support multiple focused features simultaneously.
           const focusedFeatures = createGeoJSONFromCollection(
             this.props.places[collectionId].filter(
-              model => model.get(constants.MODEL_ID_PROPERTY_NAME) !== modelId,
+              model => model.get(constants.MODEL_ID_PROPERTY_NAME) === modelId,
             ),
           );
 


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/106

I'm not sure how this happened, but somehow the filter expression used to identify the model for a clicked-on feature got reversed, such that clicking on a place focuses all other places on the map. This PR fixes that issue.