### PR TITLE
fix(AppView): remove scrollTo logic in showPanel()

### DIFF
--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -774,19 +774,6 @@ export default Backbone.View.extend({
     this.$panelContent.html(markup);
     this.$panel.show();
 
-    if (!preventScrollToTop) {
-      // will be "mobile" or "desktop", as defined in default.css
-      var layout = Util.getPageLayout();
-      if (layout === "desktop") {
-        // For desktop, the panel content is scrollable
-        this.$panelContent.scrollTo(0, 0);
-      } else {
-        // Scroll to the top of window when showing new content on mobile. Does
-        // nothing on desktop. (Except when embedded in a scrollable site.)
-        window.scrollTo(0, 0);
-      }
-    }
-
     this.setBodyClass("content-visible");
 
     $(Shareabouts).trigger("panelshow", [


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/109

The call to `$panelContent.scrollTo()` in the `showPanel()` method in `AppView` causes an error in Safari and misalignment of the content panel. I'm not completely sure why, but I thought it would just be easier to remove this legacy code since it isn't doing very much for us, and the `AppView` is getting refactored soon anyway.