### PR TITLE
fix(PlaceModel): omit submission_sets attribute from Place model submissions

### DIFF
--- a/src/base/static/js/models/place-model.js
+++ b/src/base/static/js/models/place-model.js
@@ -139,7 +139,7 @@ module.exports = Backbone.Model.extend({
     var attrs;
 
     if (method === "create" || method === "update") {
-      const keysToOmit = ["geometry"];
+      const keysToOmit = ["geometry", "submission_sets"];
       // NOTE(jalmogo): If we are updating the place model and there
       // is a submitter, we should omit the submitter from the payload so
       // that the api knows to keep using the same reference. Otherwise,


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/116

Follows the same pattern for how we handled issues with the `submitter` and `geometry` `Place` model keys post-Django 1.8.