### PR TITLE
Reduce number of Mapbox layers needed to render geojson sources

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -151,9 +151,11 @@ class MainMap extends Component {
     });
 
     // Handler for clearing in-progress drawing geometry.
-    this.props.router.on("route", () => {
-      this._map.drawDeleteGeometry();
-    });
+    if (this.props.mapConfig.options.drawing_enabled !== false) {
+      this.props.router.on("route", () => {
+        this._map.drawDeleteGeometry();
+      }, this);
+    }
 
     // Handlers for map drawing events.
     this.listeners.push(
@@ -384,7 +386,7 @@ class MainMap extends Component {
     this._map.remove();
 
     // Handler for clearing in-progress drawing geometry.
-    this.props.router.off("route");
+    this.props.router.off("route", null, this);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -152,9 +152,13 @@ class MainMap extends Component {
 
     // Handler for clearing in-progress drawing geometry.
     if (this.props.mapConfig.options.drawing_enabled !== false) {
-      this.props.router.on("route", () => {
-        this._map.drawDeleteGeometry();
-      }, this);
+      this.props.router.on(
+        "route",
+        () => {
+          this._map.drawDeleteGeometry();
+        },
+        this,
+      );
     }
 
     // Handlers for map drawing events.
@@ -561,6 +565,7 @@ MainMap.propTypes = {
   mapConfig: PropTypes.shape({
     geolocation_enabled: PropTypes.bool.isRequired,
     options: PropTypes.shape({
+      drawing_enabled: PropTypes.string,
       map: PropTypes.shape({
         center: PropTypes.shape({
           lat: PropTypes.number.isRequired,

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -274,6 +274,11 @@ const configRuleToFillLayer = (layerConfig, i) => {
           fallbackOutlineOpacity,
         ],
       },
+      filter: appendFilters(layerConfig.filter, [
+        "==",
+        ["geometry-type"],
+        "Polygon",
+      ]),
     },
   ];
 };

--- a/src/flavors/pbdurham/config.yml
+++ b/src/flavors/pbdurham/config.yml
@@ -89,6 +89,8 @@ map:
 
     - id: durham-council-wards
       type: json
+      feature_types:
+        - "Polygon"
       source: https://opendata.arcgis.com/datasets/27378f34cfca45ed8176bfae422d2204_2.geojson
       rules:
          - line-paint:
@@ -97,6 +99,8 @@ map:
 
     - id: durham-existing-trails
       type: json
+      feature_types:
+        - "LineString"
       source: https://opendata.arcgis.com/datasets/01d2237eb7c74fe4aed42d8c3160cf6f_2.geojson
       rules:
          - line-paint:
@@ -105,6 +109,8 @@ map:
 
     - id: durham-proposed-trails
       type: json
+      feature_types:
+        - "LineString"
       source: https://opendata.arcgis.com/datasets/dd4e8c97915f46a6adf086ddf8ac82a5_1.geojson
       rules:
          - line-paint:
@@ -122,6 +128,8 @@ map:
     - id: pbdurham
       url: https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/pbdurham
       type: place
+      feature_types:
+        - "Point"
       slug: idea
       is_visible_default: true
       focus_rules:

--- a/src/flavors/pbdurham/config.yml
+++ b/src/flavors/pbdurham/config.yml
@@ -48,8 +48,7 @@ map:
     control:
       showCompass: true
       position: "top-left"
-    draw:
-      is_drawing_disabled: true
+    drawing_enabled: false
 
   layers:
     - id: osm

--- a/src/flavors/pbdurham/config.yml
+++ b/src/flavors/pbdurham/config.yml
@@ -48,6 +48,8 @@ map:
     control:
       showCompass: true
       position: "top-left"
+    draw:
+      is_drawing_disabled: false
 
   layers:
     - id: osm

--- a/src/flavors/pbdurham/config.yml
+++ b/src/flavors/pbdurham/config.yml
@@ -49,7 +49,7 @@ map:
       showCompass: true
       position: "top-left"
     draw:
-      is_drawing_disabled: false
+      is_drawing_disabled: true
 
   layers:
     - id: osm


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/102

We've been creating a lot more mapbox layers than we need to, which can be a hit on performance according to [Mapbox best practices](https://www.mapbox.com/help/mapbox-gl-js-performance/#combine-layers). 

This PR introduces two strategies for controlling the number of mapbox layers created:
* allow the config to declare which feature types are expected in a geojson source
* allow the config to declare that drawing is not supported for a given flavor, saving us from instantiating the `mapbox-gl-draw` plugin and the layers it creates to support drawing