### PR TITLE
feat(mapboxgl-provider): add support for feature labels

### DIFF
--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -283,6 +283,14 @@ const configRuleToFillLayer = (layerConfig, i) => {
   ];
 };
 
+const configRuleToLabelLayer = (layerConfig, i) => ({
+  id: `${layerConfig.baseLayerId}_label_${i}`,
+  source: layerConfig.source,
+  type: "symbol",
+  layout: layerConfig["label-layout"] || {},
+  paint: layerConfig["label-paint"] || {},
+});
+
 const DEFAULT_STYLE_NAME = "Mapseed default style";
 const CLUSTER_LAYER_IDENTIFIER = "__mapseed-clusters__";
 const FOCUSED_SOURCE_IDENTIFIER = "__mapseed-focused-source__";
@@ -544,7 +552,7 @@ export default (container, options) => {
     focus_rules = [],
     // Unless otherwise specified, we assume we need to create provider layers
     // for all feature types.
-    feature_types = ["Point", "LineString", "Polygon"],
+    feature_types = ["Point", "LineString", "Polygon", "Label"],
     popup_content,
   }) => {
     sourcesCache[id] = {
@@ -589,6 +597,11 @@ export default (container, options) => {
           ? rules
               .map(configRuleToFillLayer)
               .reduce((flat, toFlatten) => flat.concat(toFlatten), [])
+          : [],
+      )
+      .concat(
+        feature_types.includes("Label")
+          ? rules.map(configRuleToLabelLayer)
           : [],
       );
 

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -118,6 +118,8 @@ map:
       type: place
       slug: demo
       is_visible_default: true
+      feature_types:
+        - "Point"
       focus_rules:
         - filter:
             - "all"
@@ -391,6 +393,8 @@ map:
       type: json
       is_visible_default: true
       source: https://raw.githubusercontent.com/mapseed/data/master/Rose-Foundation-Grants-since-Fall-2013.geojson
+      feature_types:
+        - "Point"
       rules:
         - filter:
             - ">="
@@ -406,12 +410,27 @@ map:
       type: json      
       is_visible_default: true
       source: "https://raw.githubusercontent.com/mapseed/data/master/scorecard.geojson"
+      feature_types:
+        - "Label"
+        - "Polygon"
       rules:
         - filter:
             - "=="
             - - "get" 
               - "LID_Checklist_Master_score"
             - 5
+          label-paint:
+            text-halo-color: "#fff"
+            text-halo-width: 1
+          label-layout:
+            text-field:
+              - "get"
+              - "CITYNAME"
+            text-size: 14
+            text-allow-overlap: false
+            text-offset:
+              - 0
+              - 2
           fill-paint:
             fill-color: "#fef0d9"
             fill-opacity: 0.6


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/125

Add support for labels on features. Use the `label-layout` and `label-paint` keys to set `layout` and `paint` properties for label layers. If using the `feature_types` key to restrict the types of mapboxl layers generated for a given config layer, add `Layer` to the list of feature types so labels will appear.

Sample config setup:

```
- id: sample-json-b
  type: json      
  is_visible_default: true
  source: "https://raw.githubusercontent.com/mapseed/data/master/scorecard.geojson"
  feature_types:
    - "Label"
    - "Polygon"
  rules:
    - filter:
        - "=="
        - - "get" 
          - "LID_Checklist_Master_score"
        - 5
      label-paint:
       text-halo-color: "#fff"
       text-halo-width: 1
     label-layout:
        text-field:
          - "get"
          - "CITYNAME"
        text-size: 14
        text-allow-overlap: false
        text-offset:
          - 0
          - 2
      fill-paint:
        fill-color: "#fef0d9"
        fill-opacity: 0.6
        fill-outline-color: "#000000"
```