### PR TITLE
refactor(ducks): rename config ducks

### DIFF
--- a/src/base/static/state/ducks/map-config.js
+++ b/src/base/static/state/ducks/map-config.js
@@ -12,7 +12,7 @@ export const mapPlaceLayersSelector = state => {
 };
 
 // Actions:
-const SET_CONFIG = "map/SET_CONFIG";
+const SET_CONFIG = "map-config/SET";
 
 // Action creators:
 export function setMapConfig(config) {

--- a/src/base/static/state/ducks/place-config.js
+++ b/src/base/static/state/ducks/place-config.js
@@ -4,7 +4,7 @@ export const placeConfigSelector = state => {
 };
 
 // Actions:
-const SET_CONFIG = "place/SET_CONFIG";
+const SET_CONFIG = "place-config/SET";
 
 // Action creators:
 export function setPlaceConfig(config) {

--- a/src/base/static/state/reducers.js
+++ b/src/base/static/state/reducers.js
@@ -1,25 +1,27 @@
 import { combineReducers } from "redux";
+import mapReducer from "./ducks/map";
 import uiReducer from "./ducks/ui";
+import leftSidebarReducer from "./ducks/left-sidebar";
+import mapDrawingToolbarReducer from "./ducks/map-drawing-toolbar";
+
+import appConfigReducer from "./ducks/app-config";
 import mapConfigReducer from "./ducks/map-config";
 import placeConfigReducer from "./ducks/place-config";
 import storyConfigReducer from "./ducks/story-config";
-import leftSidebarReducer from "./ducks/left-sidebar";
 import rightSidebarConfigReducer from "./ducks/right-sidebar-config";
-import mapDrawingToolbarReducer from "./ducks/map-drawing-toolbar";
-import appConfigReducer from "./ducks/app-config";
-import mapReducer from "./ducks/map";
 import surveyConfigReducer from "./ducks/survey-config";
 
 const reducers = combineReducers({
-  ui: uiReducer,
-  mapConfig: mapConfigReducer,
   map: mapReducer,
+  ui: uiReducer,
+  leftSidebar: leftSidebarReducer,
+  mapDrawingToolbar: mapDrawingToolbarReducer,
+
+  appConfig: appConfigReducer,
+  mapConfig: mapConfigReducer,
   placeConfig: placeConfigReducer,
   storyConfig: storyConfigReducer,
-  leftSidebar: leftSidebarReducer,
   rightSidebarConfig: rightSidebarConfigReducer,
-  mapDrawingToolbar: mapDrawingToolbarReducer,
-  appConfig: appConfigReducer,
   surveyConfig: surveyConfigReducer,
 });
 


### PR DESCRIPTION
This PR should help us establish a distinction between our "config" ducks and our "ui" ducks.