### PR TITLE
fix(MainMap): replace emitter event with redux action

### DIFF
--- a/src/base/static/client/mapseed-api-client.js
+++ b/src/base/static/client/mapseed-api-client.js
@@ -1,10 +1,8 @@
-import emitter from "../utils/emitter";
-import constants from "../constants";
-
 const getPlaceCollections = async ({
   placeParams,
   placeCollections,
   mapConfig,
+  setLayerStatus,
 }) => {
   const $progressContainer = $("#map-progress");
   const $currentProgress = $("#map-progress .current-progress");
@@ -61,8 +59,15 @@ const getPlaceCollections = async ({
         }
       },
 
-      success: function() {
-        emitter.emit(constants.PLACE_COLLECTION_LOADED_EVENT, collectionId);
+      success: function(fetchedCollection, response, options) {
+        // Mark the layer as "loaded" so the map can render it:
+        setLayerStatus(collectionId, {
+          status: "loaded",
+          type: "place",
+          isBasemap: false,
+          isVisible: !!mapConfig.layers.find(layer => layer.id === collectionId)
+            .is_visible_default,
+        });
         // TODO: layer loading event; fix in layer UI PR
       },
 

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -260,17 +260,6 @@ class MainMap extends Component {
 
     // Handlers for Mapseed place collections.
     this.listeners.push(
-      emitter.addListener(constants.PLACE_COLLECTION_LOADED_EVENT, layerId => {
-        this.props.setLayerStatus(layerId, {
-          status: "loaded",
-          type: "place",
-          isBasemap: false,
-          isVisible: !!this.props.layers.find(layer => layer.id === layerId)
-            .is_visible_default,
-        });
-      }),
-    );
-    this.listeners.push(
       emitter.addListener(
         constants.PLACE_COLLECTION_ADD_PLACE_EVENT,
         collectionId => {

--- a/src/base/static/constants.js
+++ b/src/base/static/constants.js
@@ -98,7 +98,6 @@ export default {
   PLACE_COLLECTION_FOCUS_PLACE_EVENT: "place-collection:focus-place",
   PLACE_COLLECTION_ADD_PLACE_EVENT: "place-collection:add-place",
   PLACE_COLLECTION_REMOVE_PLACE_EVENT: "place-collection:remove-place",
-  PLACE_COLLECTION_LOADED_EVENT: "place-collection:loaded",
 
   PLACE_MODEL_IO_START_ACTION: "place:io-start",
   PLACE_MODEL_IO_END_SUCCESS_ACTION: "place:io-end-success",

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -351,6 +351,8 @@ export default Backbone.View.extend({
       placeParams,
       placeCollections: self.places,
       mapConfig: self.options.mapConfig,
+      setLayerStatus: (layerId, layerStatus) =>
+        store.dispatch(setLayerStatus(layerId, layerStatus)),
     });
 
     if (this.options.rightSidebarConfig.is_enabled) {


### PR DESCRIPTION
This PR ports our `PLACE_COLLECTION_LOADED_EVENT` event to a Redux dispatch.

This pattern should simplify our app so that MainMap isn't responsible for listening to events and updating the Redux store.