### PR TITLE
Fix animated map transitions on mobile devices (again)

### DIFF
--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1235,9 +1235,9 @@ export default (container, options) => {
     },
 
     easeTo: options => {
-      setTimeout(() => {
-        map.flyTo(options);
-      }, 0);
+      requestAnimationFrame(() => {
+        map.easeTo(options);
+      });
     },
 
     jumpTo: options => {
@@ -1245,9 +1245,9 @@ export default (container, options) => {
     },
 
     flyTo: options => {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         map.flyTo(options);
-      }, 0);
+      });
     },
 
     invalidateSize: () => {


### PR DESCRIPTION
Addresses: https://github.com/jalMogo/mgmt/issues/85

Mobile map transitions have been acting up again-- `flyTo` and `easeTo` are not consistently re-centering the map.

Instead of placing these methods inside a 0-length timeout, this PR puts them inside a callback to `requestAnimationFrame()`, which seems to work better.

As with https://github.com/mapseed/platform/pull/1012, however, I still don't understand the root cause of the need to wrap `easeTo` and `flyTo` in callbacks to make them work on touch devices.