### PR TITLE
refactor: remove direct imports of config object

### DIFF
--- a/src/base/static/components/form-fields/types/geocoding-field.js
+++ b/src/base/static/components/form-fields/types/geocoding-field.js
@@ -2,12 +2,13 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import Spinner from "react-spinner";
+import { connect } from "react-redux";
 
 import emitter from "../../../utils/emitter";
 import { translate } from "react-i18next";
 import "./geocoding-field.scss";
 
-import { map as mapConfig } from "config";
+import { mapConfigSelector } from "../../../state/ducks/map-config";
 
 // TODO: Consolidate Util methods used here.
 const Util = require("../../../js/utils.js");
@@ -19,8 +20,10 @@ class GeocodingField extends Component {
       isGeocoding: false,
       isWithGeocodingError: false,
     };
-    this.geocodingEngine = mapConfig.geocoding_engine || "MapQuest";
-    this.hint = mapConfig.geocode_bounding_box || mapConfig.geocode_hint;
+    this.geocodingEngine = this.props.mapConfig.geocoding_engine || "MapQuest";
+    this.hint =
+      this.props.mapConfig.geocode_bounding_box ||
+      this.props.mapConfig.geocode_hint;
   }
 
   componentDidUpdate(prevProps) {
@@ -98,6 +101,7 @@ class GeocodingField extends Component {
 }
 
 GeocodingField.propTypes = {
+  mapConfig: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
@@ -106,4 +110,10 @@ GeocodingField.propTypes = {
   value: PropTypes.string,
 };
 
-export default translate("GeocodingField")(GeocodingField);
+const mapStateToProps = state => ({
+  mapConfig: mapConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(
+  translate("GeocodingField")(GeocodingField),
+);

--- a/src/base/static/components/input-form/__tests__/input-form.test.js
+++ b/src/base/static/components/input-form/__tests__/input-form.test.js
@@ -6,6 +6,8 @@ import constants from "../../../constants";
 import WarningMessagesContainer from "../../ui-elements/warning-messages-container";
 import { OrderedMap, Map } from "immutable";
 
+import { place as placeConfig } from "config";
+
 jest.mock("../../../utils/scroll-helpers");
 
 describe("InputForm", () => {
@@ -22,6 +24,7 @@ describe("InputForm", () => {
       off: () => {},
       getCenter: () => {},
     },
+    placeConfig: placeConfig,
     places: {},
     router: {
       on: () => {},

--- a/src/base/static/components/input-form/form-category-menu-wrapper.js
+++ b/src/base/static/components/input-form/form-category-menu-wrapper.js
@@ -37,8 +37,10 @@ class FormCategoryMenuWrapper extends Component {
   onCategoryChange(selectedCategory) {
     this.setState({
       selectedCategory: selectedCategory,
-      isShowingCategorySelector: !getCategoryConfig(this.props.placeConfig, selectedCategory)
-        .multi_stage,
+      isShowingCategorySelector: !getCategoryConfig(
+        this.props.placeConfig,
+        selectedCategory,
+      ).multi_stage,
     });
   }
 

--- a/src/base/static/components/input-form/form-category-menu-wrapper.js
+++ b/src/base/static/components/input-form/form-category-menu-wrapper.js
@@ -1,9 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
 
 import InputFormCategorySelector from "./input-form-category-selector";
 
-import { place as placeConfig } from "config";
+import { placeConfigSelector } from "../../state/ducks/place-config";
 import { getCategoryConfig } from "../../utils/config-utils";
 
 const Util = require("../../js/utils.js");
@@ -11,7 +12,7 @@ const Util = require("../../js/utils.js");
 class FormCategoryMenuWrapper extends Component {
   constructor(props) {
     super(props);
-    this.visibleCategoryConfigs = placeConfig.place_detail
+    this.visibleCategoryConfigs = this.props.placeConfig.place_detail
       .filter(config => config.includeOnForm)
       .filter(config => {
         return !(
@@ -36,7 +37,7 @@ class FormCategoryMenuWrapper extends Component {
   onCategoryChange(selectedCategory) {
     this.setState({
       selectedCategory: selectedCategory,
-      isShowingCategorySelector: !getCategoryConfig(selectedCategory)
+      isShowingCategorySelector: !getCategoryConfig(this.props.placeConfig, selectedCategory)
         .multi_stage,
     });
   }
@@ -69,6 +70,7 @@ FormCategoryMenuWrapper.propTypes = {
   showNewPin: PropTypes.func.isRequired,
   hideNewPin: PropTypes.func.isRequired,
   hidePanel: PropTypes.func.isRequired,
+  placeConfig: PropTypes.object.isRequired,
   places: PropTypes.objectOf(PropTypes.instanceOf(Backbone.Collection)),
   router: PropTypes.instanceOf(Backbone.Router),
   customHooks: PropTypes.oneOfType([
@@ -80,4 +82,8 @@ FormCategoryMenuWrapper.propTypes = {
   customComponents: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
 };
 
-export default FormCategoryMenuWrapper;
+const mapStateToProps = state => ({
+  placeConfig: placeConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(FormCategoryMenuWrapper);

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -16,9 +16,10 @@ import { extractEmbeddedImages } from "../../utils/embedded-images";
 import { scrollTo } from "../../utils/scroll-helpers";
 import "./index.scss";
 
-import { map as mapConfig } from "config";
 import { getCategoryConfig } from "../../utils/config-utils";
 import { mapPositionSelector } from "../../state/ducks/map";
+import { mapConfigSelector } from "../../state/ducks/map-config";
+import { placeConfigSelector } from "../../state/ducks/place-config";
 import {
   activeMarkerSelector,
   geometryStyleSelector,
@@ -96,7 +97,10 @@ class InputForm extends Component {
   }
 
   initializeForm(selectedCategory) {
-    this.selectedCategoryConfig = getCategoryConfig(selectedCategory);
+    this.selectedCategoryConfig = getCategoryConfig(
+      this.props.placeConfig,
+      selectedCategory,
+    );
     this.isWithCustomGeometry =
       this.selectedCategoryConfig.fields.findIndex(
         field => field.type === constants.MAP_DRAWING_TOOLBAR_TYPENAME,
@@ -205,7 +209,7 @@ class InputForm extends Component {
     collection.add(
       {
         location_type: this.selectedCategoryConfig.category,
-        datasetSlug: mapConfig.layers.find(
+        datasetSlug: this.props.mapConfig.layers.find(
           layer => this.selectedCategoryConfig.dataset === layer.id,
         ).slug,
         datasetId: this.selectedCategoryConfig.dataset,
@@ -461,6 +465,7 @@ InputForm.propTypes = {
   isSingleCategory: PropTypes.bool,
   mapPosition: PropTypes.object,
   onCategoryChange: PropTypes.func,
+  placeConfig: PropTypes.object.isRequired,
   places: PropTypes.object.isRequired,
   renderCount: PropTypes.number,
   router: PropTypes.object.isRequired,
@@ -473,7 +478,9 @@ InputForm.propTypes = {
 const mapStateToProps = state => ({
   activeMarker: activeMarkerSelector(state),
   geometryStyle: geometryStyleSelector(state),
+  mapConfig: mapConfigSelector(state),
   mapPosition: mapPositionSelector(state),
+  placeConfig: placeConfigSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -463,6 +463,7 @@ InputForm.propTypes = {
   isFormSubmitting: PropTypes.bool,
   isLeavingForm: PropTypes.bool,
   isSingleCategory: PropTypes.bool,
+  mapConfig: PropTypes.object.isRequired,
   mapPosition: PropTypes.object,
   onCategoryChange: PropTypes.func,
   placeConfig: PropTypes.object.isRequired,

--- a/src/base/static/components/input-form/input-form-category-button.js
+++ b/src/base/static/components/input-form/input-form-category-button.js
@@ -1,8 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import { connect } from "react-redux";
 
 import { getCategoryConfig } from "../../utils/config-utils";
+import { placeConfigSelector } from "../../state/ducks/place-config";
+
 import "./input-form-category-button.scss";
 
 const InputFormCategoryButton = props => {
@@ -18,7 +21,10 @@ const InputFormCategoryButton = props => {
       "input-form-category-button__label-text--active": props.isSelected,
     }),
   };
-  const categoryConfig = getCategoryConfig(props.categoryName);
+  const categoryConfig = getCategoryConfig(
+    props.placeConfig,
+    props.categoryName,
+  );
 
   return (
     <div className={cn.base}>
@@ -57,6 +63,11 @@ InputFormCategoryButton.propTypes = {
   isSingleCategory: PropTypes.bool.isRequired,
   onCategoryChange: PropTypes.func.isRequired,
   onExpandCategories: PropTypes.func.isRequired,
+  placeConfig: PropTypes.object.isRequired,
 };
 
-export default InputFormCategoryButton;
+const mapStateToProps = state => ({
+  placeConfig: placeConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(InputFormCategoryButton);

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { fromJS, List, Map } from "immutable";
+import { connect } from "react-redux";
 
 import PromotionBar from "./promotion-bar";
 import MetadataBar from "./metadata-bar";
@@ -21,13 +22,18 @@ const SubmissionCollection = require("../../js/models/submission-collection.js")
 import constants from "../../constants";
 import { scrollTo } from "../../utils/scroll-helpers";
 
+// NOTE: These pieces of the config are imported directly here because they
+// don't require translation, which is ok for now.
+// TODO: Eventually dissolve these imports.
 import {
-  survey as surveyConfig,
-  support as supportConfig,
-  place as placeConfig,
   custom_hooks as customHooks,
   custom_components as customComponents,
 } from "config";
+
+import { surveyConfigSelector } from "../../state/ducks/survey-config";
+import { supportConfigSelector } from "../../state/ducks/support-config";
+import { placeConfigSelector } from "../../state/ducks/place-config";
+
 import { getCategoryConfig } from "../../utils/config-utils";
 const Util = require("../../js/utils.js");
 
@@ -57,8 +63,8 @@ class PlaceDetail extends Component {
   constructor(props) {
     super(props);
 
-    this.surveyType = surveyConfig.submission_type;
-    this.supportType = supportConfig.submission_type;
+    this.surveyType = this.props.surveyConfig.submission_type;
+    this.supportType = this.props.supportConfig.submission_type;
     if (!this.props.model.submissionSets[this.surveyType]) {
       this.props.model.submissionSets[
         this.surveyType
@@ -77,6 +83,7 @@ class PlaceDetail extends Component {
     }
 
     this.categoryConfig = getCategoryConfig(
+      this.props.placeConfig,
       this.props.model.get(constants.LOCATION_TYPE_PROPERTY_NAME),
     );
 
@@ -265,7 +272,7 @@ class PlaceDetail extends Component {
         this.state.placeModel.get(constants.SHOW_METADATA_PROPERTY_NAME) ===
         false
       ) &&
-      !placeConfig.hide_metadata_bar;
+      !this.props.placeConfig.hide_metadata_bar;
     // TODO: dissolve when flavor abstraction is ready
     let fieldSummary;
     if (
@@ -416,11 +423,20 @@ PlaceDetail.propTypes = {
   }),
   isGeocodingBarEnabled: PropTypes.bool,
   model: PropTypes.instanceOf(Backbone.Model),
+  placeConfig: PropTypes.object.isRequired,
   places: PropTypes.objectOf(PropTypes.instanceOf(Backbone.Collection)),
   router: PropTypes.instanceOf(Backbone.Router),
   scrollToResponseId: PropTypes.string,
+  supportConfig: PropTypes.object.isRequired,
+  surveyConfig: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   userToken: PropTypes.string.isRequired,
 };
 
-export default translate("PlaceDetail")(PlaceDetail);
+const mapStateToProps = state => ({
+  surveyConfig: surveyConfigSelector(state),
+  supportConfig: supportConfigSelector(state),
+  placeConfig: placeConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(translate("PlaceDetail")(PlaceDetail));

--- a/src/base/static/components/place-detail/metadata-bar.js
+++ b/src/base/static/components/place-detail/metadata-bar.js
@@ -1,18 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
 
 import Avatar from "../ui-elements/avatar";
 import SubmitterName from "../ui-elements/submitter-name";
 import { translate, Trans } from "react-i18next";
 
 import constants from "../../constants";
-import { place as placeConfig, survey as surveyConfig } from "config";
+
+import { placeConfigSelector } from "../../state/ducks/place-config";
+import { surveyConfigSelector } from "../../state/ducks/survey-config";
 
 import "./metadata-bar.scss";
 
 const MetadataBar = props => {
   // TODO: place type label replacement; fix in editor PR
-  const actionText = placeConfig.action_text;
+  const actionText = props.placeConfig.action_text;
 
   return (
     <div className="place-detail-metadata-bar">
@@ -44,8 +47,8 @@ const MetadataBar = props => {
         <p className="place-detail-metadata-bar__survey-count">
           {props.surveyModels.size}{" "}
           {props.surveyModels.size === 1
-            ? surveyConfig.response_name
-            : surveyConfig.response_plural_name}
+            ? props.surveyConfig.response_name
+            : props.surveyConfig.response_plural_name}
         </p>
       </div>
     </div>
@@ -54,9 +57,16 @@ const MetadataBar = props => {
 
 MetadataBar.propTypes = {
   avatarSrc: PropTypes.string,
+  placeConfig: PropTypes.object.isRequired,
   placeModel: PropTypes.object.isRequired,
   surveyModels: PropTypes.object.isRequired,
   submitter: PropTypes.object.isRequired,
+  surveyConfig: PropTypes.object.isRequired,
 };
 
-export default translate("MetadataBar")(MetadataBar);
+const mapStateToProps = state => ({
+  placeConfig: placeConfigSelector(state),
+  surveyConfig: surveyConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(translate("MetadataBar")(MetadataBar));

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -23,6 +23,7 @@ import {
   geometryStyleSelector,
   geometryStyleProps,
 } from "../../state/ducks/map-drawing-toolbar";
+import { placeConfigSelector } from "../../state/ducks/place-config";
 
 import { getCategoryConfig } from "../../utils/config-utils";
 
@@ -33,6 +34,7 @@ class PlaceDetailEditor extends Component {
     super(props);
 
     this.categoryConfig = getCategoryConfig(
+      this.props.placeConfig,
       this.props.placeModel.get(constants.LOCATION_TYPE_PROPERTY_NAME),
     );
 
@@ -306,6 +308,7 @@ PlaceDetailEditor.propTypes = {
   onAttachmentModelRemove: PropTypes.func.isRequired,
   onModelIO: PropTypes.func.isRequired,
   onPlaceModelSave: PropTypes.func.isRequired,
+  placeConfig: PropTypes.object.isRequired,
   placeModel: PropTypes.object.isRequired,
   places: PropTypes.object,
   router: PropTypes.object,
@@ -315,6 +318,7 @@ PlaceDetailEditor.propTypes = {
 const mapStateToProps = state => ({
   activeMarker: activeMarkerSelector(state),
   geometryStyle: geometryStyleSelector(state),
+  placeConfig: placeConfigSelector(state),
 });
 
 export default connect(mapStateToProps)(

--- a/src/base/static/components/place-detail/survey-response-editor.js
+++ b/src/base/static/components/place-detail/survey-response-editor.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { Map, OrderedMap } from "immutable";
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import { connect } from "react-redux";
 
 import FormField from "../form-fields/form-field";
 import Avatar from "../ui-elements/avatar";
@@ -9,9 +10,11 @@ import ActionTime from "../ui-elements/action-time";
 import SubmitterName from "../ui-elements/submitter-name";
 import { EditorButton } from "../atoms/buttons";
 
-import { survey as surveyConfig, place as placeConfig } from "config";
 import { translate } from "react-i18next";
 import constants from "../../constants";
+
+import { surveyConfigSelector } from "../../state/ducks/survey-config"
+import { placeConfigSelector } from "../../state/ducks/place-config"
 
 import "./survey-response-editor.scss";
 
@@ -19,7 +22,7 @@ class SurveyResponseEditor extends Component {
   constructor(props) {
     super(props);
 
-    const fields = surveyConfig.items
+    const fields = this.props.surveyConfig.items
       // NOTE: In the editor, we have to strip out the submit field here,
       // otherwise, since we don't render it at all, it will always be invalid.
       .filter(field => field.type !== constants.SUBMIT_FIELD_TYPENAME)
@@ -100,7 +103,7 @@ class SurveyResponseEditor extends Component {
               ? this.props.t("notSaved")
               : this.props.t("saved")}
           </em>
-          {surveyConfig.items
+          {this.props.surveyConfig.items
             .filter(field => field.type !== constants.SUBMIT_FIELD_TYPENAME)
             .map(fieldConfig => (
               <FormField
@@ -128,7 +131,7 @@ class SurveyResponseEditor extends Component {
             <SubmitterName
               className="place-detail-survey-response__submitter-name"
               submitter={this.props.submitter}
-              anonymousName={placeConfig.anonymous_name}
+              anonymousName={this.props.placeConfig.anonymous_name}
             />
             <ActionTime time={this.props.attributes.get("updated_datetime")} />
           </div>
@@ -144,10 +147,19 @@ SurveyResponseEditor.propTypes = {
   modelId: PropTypes.number.isRequired,
   onSurveyModelRemove: PropTypes.func.isRequired,
   onSurveyModelSave: PropTypes.func.isRequired,
+  placeConfig: PropTypes.object.isRequired,
   submitter: PropTypes.shape({
     avatar_url: PropTypes.string,
   }),
+  surveyConfig: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
 };
 
-export default translate("SurveyResponseEditor")(SurveyResponseEditor);
+const mapStateToProps = state => ({
+  placeConfig: placeConfigSelector(state),
+  surveyConfig: surveyConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(
+  translate("SurveyResponseEditor")(SurveyResponseEditor),
+);

--- a/src/base/static/components/place-detail/survey-response-editor.js
+++ b/src/base/static/components/place-detail/survey-response-editor.js
@@ -13,8 +13,8 @@ import { EditorButton } from "../atoms/buttons";
 import { translate } from "react-i18next";
 import constants from "../../constants";
 
-import { surveyConfigSelector } from "../../state/ducks/survey-config"
-import { placeConfigSelector } from "../../state/ducks/place-config"
+import { surveyConfigSelector } from "../../state/ducks/survey-config";
+import { placeConfigSelector } from "../../state/ducks/place-config";
 
 import "./survey-response-editor.scss";
 

--- a/src/base/static/components/place-detail/survey-response.js
+++ b/src/base/static/components/place-detail/survey-response.js
@@ -1,11 +1,14 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
 
 import Avatar from "../ui-elements/avatar";
 import SubmitterName from "../ui-elements/submitter-name";
 import constants from "../../constants";
 
-import { survey as surveyConfig, place as placeConfig } from "config";
+import { surveyConfigSelector } from "../../state/ducks/survey-config";
+import { placeConfigSelector } from "../../state/ducks/place-config";
+
 import "./survey-response.scss";
 
 class SurveyResponse extends Component {
@@ -22,7 +25,7 @@ class SurveyResponse extends Component {
         ref={response => (this.responseRef = response)}
       >
         <div className="place-detail-survey-response__body">
-          {surveyConfig.items
+          {this.props.surveyConfig.items
             .filter(
               field =>
                 field.type !== constants.SUBMIT_FIELD_TYPENAME &&
@@ -52,7 +55,7 @@ class SurveyResponse extends Component {
                   constants.NAME_PROPERTY_NAME,
                 ])
               }
-              anonymousName={placeConfig.anonymous_name}
+              anonymousName={this.props.placeConfig.anonymous_name}
             />
           </div>
         </div>
@@ -65,8 +68,15 @@ SurveyResponse.propTypes = {
   attributes: PropTypes.object.isRequired,
   modelId: PropTypes.number.isRequired,
   onMountTargetResponse: PropTypes.func.isRequired,
+  placeConfig: PropTypes.object.isRequired,
   scrollToResponseId: PropTypes.string,
   submitter: PropTypes.object.isRequired,
+  surveyConfig: PropTypes.object.isRequired,
 };
 
-export default SurveyResponse;
+const mapStateToProps = state => ({
+  surveyConfig: surveyConfigSelector(state),
+  placeConfig: placeConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(SurveyResponse);

--- a/src/base/static/components/ui-elements/submitter-name.js
+++ b/src/base/static/components/ui-elements/submitter-name.js
@@ -1,20 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import { connect } from "react-redux";
 
-import { place as placeConfig } from "config";
+import { placeConfigSelector } from "../../state/ducks/place-config";
 
 const SubmitterName = props => {
   return (
     <strong className={classNames("submitter-name", props.className)}>
-      {props.submitterName || placeConfig.anonymous_name}
+      {props.submitterName || props.placeConfig.anonymous_name}
     </strong>
   );
 };
 
 SubmitterName.propTypes = {
   className: PropTypes.string,
+  placeConfig: PropTypes.object.isRequired,
   submitterName: PropTypes.string,
 };
 
-export default SubmitterName;
+const mapStateToProps = state => ({
+  placeConfig: placeConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(SubmitterName);

--- a/src/base/static/components/ui-elements/support-button.js
+++ b/src/base/static/components/ui-elements/support-button.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import { connect } from "react-redux";
 
 import SecondaryButton from "./secondary-button";
-import { support as supportConfig } from "config";
+import { supportConfigSelector } from "../../state/ducks/support-config";
 
 import "./support-button.scss";
 
@@ -15,7 +16,7 @@ const SupportButton = props => {
       })}
       onClick={props.onClickSupport}
     >
-      {props.numSupports || ""} {supportConfig.submit_btn_text}
+      {props.numSupports || ""} {props.supportConfig.submit_btn_text}
     </SecondaryButton>
   );
 };
@@ -25,6 +26,11 @@ SupportButton.propTypes = {
   isSupported: PropTypes.bool.isRequired,
   numSupports: PropTypes.number,
   onClickSupport: PropTypes.func.isRequired,
+  supportConfig: PropTypes.object.isRequired,
 };
 
-export default SupportButton;
+const mapStateToProps = state => ({
+  supportConfig: supportConfigSelector(state),
+});
+
+export default connect(mapStateToProps)(SupportButton);

--- a/src/base/static/components/vv-input-form/index.js
+++ b/src/base/static/components/vv-input-form/index.js
@@ -10,6 +10,7 @@ import constants from "./constants";
 import "./index.scss";
 
 import { mapPositionSelector } from "../../../static/state/ducks/map";
+import { placeConfigSelector } from "../../state/ducks/place-config";
 
 import { getCategoryConfig } from "../../utils/config-utils";
 
@@ -38,7 +39,10 @@ class VVInputForm extends Component {
       isMapPositioned: false,
     };
 
-    this.selectedCategoryConfig = getCategoryConfig(props.selectedCategory);
+    this.selectedCategoryConfig = getCategoryConfig(
+      props.placeConfig,
+      props.selectedCategory,
+    );
   }
 
   componentWillUpdate(prevProps) {
@@ -157,6 +161,7 @@ VVInputForm.propTypes = {
   hideSpotlightMask: PropTypes.func.isRequired,
   mapPosition: PropTypes.object,
   onCategoryChange: PropTypes.func.isRequired,
+  placeConfig: PropTypes.object.isRequired,
   selectedCategory: PropTypes.string.isRequired,
   showNewPin: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
@@ -164,6 +169,7 @@ VVInputForm.propTypes = {
 
 const mapStateToProps = state => ({
   mapPosition: mapPositionSelector(state),
+  placeConfig: placeConfigSelector(state),
 });
 
 export default connect(mapStateToProps)(translate("VVInputForm")(VVInputForm));

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -32,6 +32,7 @@ import {
   setLayerStatus,
   mapLayerStatusesSelector,
 } from "../../state/ducks/map";
+import { setSupportConfig } from "../../state/ducks/support-config";
 
 import MainMap from "../../components/organisms/main-map";
 import InputForm from "../../components/input-form";
@@ -86,6 +87,7 @@ export default Backbone.View.extend({
     store.dispatch(setStoryConfig(this.options.storyConfig));
     store.dispatch(setAppConfig(this.options.appConfig));
     store.dispatch(setSurveyConfig(this.options.surveyConfig));
+    store.dispatch(setSupportConfig(this.options.supportConfig));
 
     const storeState = store.getState();
     const flavorTheme = storeState.appConfig.theme;

--- a/src/base/static/state/ducks/support-config.js
+++ b/src/base/static/state/ducks/support-config.js
@@ -1,0 +1,28 @@
+// Selectors:
+export const supportConfigSelector = state => {
+  return state.supportConfig;
+};
+
+// Actions:
+const SET_CONFIG = "support/SET_CONFIG";
+
+// Action creators:
+export function setSupportConfig(config) {
+  return { type: SET_CONFIG, payload: config };
+}
+
+// Reducers:
+// TODO(luke): refactor our current implementation in AppView to use
+const INITIAL_STATE = null;
+
+export default function reducer(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case SET_CONFIG:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/base/static/state/reducers.js
+++ b/src/base/static/state/reducers.js
@@ -10,6 +10,7 @@ import placeConfigReducer from "./ducks/place-config";
 import storyConfigReducer from "./ducks/story-config";
 import rightSidebarConfigReducer from "./ducks/right-sidebar-config";
 import surveyConfigReducer from "./ducks/survey-config";
+import supportConfigReducer from "./ducks/support-config";
 
 const reducers = combineReducers({
   map: mapReducer,
@@ -23,6 +24,7 @@ const reducers = combineReducers({
   storyConfig: storyConfigReducer,
   rightSidebarConfig: rightSidebarConfigReducer,
   surveyConfig: surveyConfigReducer,
+  supportConfig: surveyConfigReducer,
 });
 
 export default reducers;

--- a/src/base/static/utils/config-utils.js
+++ b/src/base/static/utils/config-utils.js
@@ -1,6 +1,4 @@
-import { place as placeConfig } from "config";
-
-const getCategoryConfig = categoryName => {
+const getCategoryConfig = (placeConfig, categoryName) => {
   return (
     placeConfig.place_detail.find(
       categoryConfig => categoryConfig.category === categoryName,

--- a/src/flavors/augusta/static/js/views/app-view.js
+++ b/src/flavors/augusta/static/js/views/app-view.js
@@ -12,10 +12,6 @@ import reducer from "../../../../../base/static/state/reducers";
 import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
 import { ThemeProvider } from "emotion-theming";
 import theme from "../../../../../theme";
-// TODO(luke): This should be the only instance of our config singleton.
-// Eventually, it will be removed once we start fetching the config
-// from the api:
-import config from "config";
 
 import { setMapConfig } from "../../../../../base/static/state/ducks/map-config";
 import { setPlaceConfig } from "../../../../../base/static/state/ducks/place-config";
@@ -23,6 +19,8 @@ import { setStoryConfig } from "../../../../../base/static/state/ducks/story-con
 import { setLeftSidebarConfig } from "../../../../../base/static/state/ducks/left-sidebar";
 import { setRightSidebarConfig } from "../../../../../base/static/state/ducks/right-sidebar-config";
 import { setAppConfig } from "../../../../../base/static/state/ducks/app-config";
+import { setSurveyConfig } from "../../../../../base/static/state/ducks/survey-config";
+import { setSupportConfig } from "../../../../../state/ducks/support-config";
 
 import MainMap from "../../../../../base/static/components/organisms/main-map";
 import RightSidebar from "../../../../../base/static/components/templates/right-sidebar";
@@ -57,12 +55,14 @@ module.exports = AppView.extend({
     Shareabouts.deferredCollections = [];
     // TODO(luke): move this into "componentDidMount" when App becomes a
     // component:
-    store.dispatch(setMapConfig(config.map));
-    store.dispatch(setPlaceConfig(config.place));
-    store.dispatch(setLeftSidebarConfig(config.left_sidebar));
-    store.dispatch(setRightSidebarConfig(config.right_sidebar));
-    store.dispatch(setStoryConfig(config.story));
-    store.dispatch(setAppConfig(config.app));
+    store.dispatch(setMapConfig(this.options.mapConfig));
+    store.dispatch(setPlaceConfig(this.options.placeConfig));
+    store.dispatch(setLeftSidebarConfig(this.options.leftSidebarConfig));
+    store.dispatch(setRightSidebarConfig(this.options.rightSidebarConfig));
+    store.dispatch(setStoryConfig(this.options.storyConfig));
+    store.dispatch(setAppConfig(this.options.appConfig));
+    store.dispatch(setSurveyConfig(this.options.surveyConfig));
+    store.dispatch(setSupportConfig(this.options.supportConfig));
 
     const storeState = store.getState();
     const flavorTheme = storeState.appConfig.theme;

--- a/src/flavors/bathgate/static/js/views/app-view.js
+++ b/src/flavors/bathgate/static/js/views/app-view.js
@@ -12,10 +12,6 @@ import reducer from "../../../../../base/static/state/reducers";
 import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
 import { ThemeProvider } from "emotion-theming";
 import theme from "../../../../../theme";
-// TODO(luke): This should be the only instance of our config singleton.
-// Eventually, it will be removed once we start fetching the config
-// from the api:
-import config from "config";
 
 import { setMapConfig } from "../../../../../base/static/state/ducks/map-config";
 import { setPlaceConfig } from "../../../../../base/static/state/ducks/place-config";
@@ -23,6 +19,8 @@ import { setStoryConfig } from "../../../../../base/static/state/ducks/story-con
 import { setLeftSidebarConfig } from "../../../../../base/static/state/ducks/left-sidebar";
 import { setRightSidebarConfig } from "../../../../../base/static/state/ducks/right-sidebar-config";
 import { setAppConfig } from "../../../../../base/static/state/ducks/app-config";
+import { setSurveyConfig } from "../../../../../base/static/state/ducks/survey-config";
+import { setSupportConfig } from "../../../../../state/ducks/support-config";
 
 import MainMap from "../../../../../base/static/components/organisms/main-map";
 import RightSidebar from "../../../../../base/static/components/templates/right-sidebar";
@@ -57,12 +55,14 @@ module.exports = AppView.extend({
     Shareabouts.deferredCollections = [];
     // TODO(luke): move this into "componentDidMount" when App becomes a
     // component:
-    store.dispatch(setMapConfig(config.map));
-    store.dispatch(setPlaceConfig(config.place));
-    store.dispatch(setLeftSidebarConfig(config.left_sidebar));
-    store.dispatch(setRightSidebarConfig(config.right_sidebar));
-    store.dispatch(setStoryConfig(config.story));
-    store.dispatch(setAppConfig(config.app));
+    store.dispatch(setMapConfig(this.options.mapConfig));
+    store.dispatch(setPlaceConfig(this.options.placeConfig));
+    store.dispatch(setLeftSidebarConfig(this.options.leftSidebarConfig));
+    store.dispatch(setRightSidebarConfig(this.options.rightSidebarConfig));
+    store.dispatch(setStoryConfig(this.options.storyConfig));
+    store.dispatch(setAppConfig(this.options.appConfig));
+    store.dispatch(setSurveyConfig(this.options.surveyConfig));
+    store.dispatch(setSupportConfig(this.options.supportConfig));
 
     const storeState = store.getState();
     const flavorTheme = storeState.appConfig.theme;

--- a/src/flavors/hull/static/js/views/app-view.js
+++ b/src/flavors/hull/static/js/views/app-view.js
@@ -12,10 +12,6 @@ import reducer from "../../../../../base/static/state/reducers";
 import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
 import { ThemeProvider } from "emotion-theming";
 import theme from "../../../../../theme";
-// TODO(luke): This should be the only instance of our config singleton.
-// Eventually, it will be removed once we start fetching the config
-// from the api:
-import config from "config";
 
 import { setMapConfig } from "../../../../../base/static/state/ducks/map-config";
 import { setPlaceConfig } from "../../../../../base/static/state/ducks/place-config";
@@ -23,6 +19,8 @@ import { setStoryConfig } from "../../../../../base/static/state/ducks/story-con
 import { setLeftSidebarConfig } from "../../../../../base/static/state/ducks/left-sidebar";
 import { setRightSidebarConfig } from "../../../../../base/static/state/ducks/right-sidebar-config";
 import { setAppConfig } from "../../../../../base/static/state/ducks/app-config";
+import { setSurveyConfig } from "../../../../../base/static/state/ducks/survey-config";
+import { setSupportConfig } from "../../../../../state/ducks/support-config";
 
 import MainMap from "../../../../../base/static/components/organisms/main-map";
 import RightSidebar from "../../../../../base/static/components/templates/right-sidebar";
@@ -57,12 +55,14 @@ module.exports = AppView.extend({
     Shareabouts.deferredCollections = [];
     // TODO(luke): move this into "componentDidMount" when App becomes a
     // component:
-    store.dispatch(setMapConfig(config.map));
-    store.dispatch(setPlaceConfig(config.place));
-    store.dispatch(setLeftSidebarConfig(config.left_sidebar));
-    store.dispatch(setRightSidebarConfig(config.right_sidebar));
-    store.dispatch(setStoryConfig(config.story));
-    store.dispatch(setAppConfig(config.app));
+    store.dispatch(setMapConfig(this.options.mapConfig));
+    store.dispatch(setPlaceConfig(this.options.placeConfig));
+    store.dispatch(setLeftSidebarConfig(this.options.leftSidebarConfig));
+    store.dispatch(setRightSidebarConfig(this.options.rightSidebarConfig));
+    store.dispatch(setStoryConfig(this.options.storyConfig));
+    store.dispatch(setAppConfig(this.options.appConfig));
+    store.dispatch(setSurveyConfig(this.options.surveyConfig));
+    store.dispatch(setSupportConfig(this.options.supportConfig));
 
     const storeState = store.getState();
     const flavorTheme = storeState.appConfig.theme;

--- a/src/flavors/manzanares/static/js/views/app-view.js
+++ b/src/flavors/manzanares/static/js/views/app-view.js
@@ -12,10 +12,6 @@ import reducer from "../../../../../base/static/state/reducers";
 import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
 import { ThemeProvider } from "emotion-theming";
 import theme from "../../../../../theme";
-// TODO(luke): This should be the only instance of our config singleton.
-// Eventually, it will be removed once we start fetching the config
-// from the api:
-import config from "config";
 
 import { setMapConfig } from "../../../../../base/static/state/ducks/map-config";
 import { setPlaceConfig } from "../../../../../base/static/state/ducks/place-config";
@@ -23,6 +19,8 @@ import { setStoryConfig } from "../../../../../base/static/state/ducks/story-con
 import { setLeftSidebarConfig } from "../../../../../base/static/state/ducks/left-sidebar";
 import { setRightSidebarConfig } from "../../../../../base/static/state/ducks/right-sidebar-config";
 import { setAppConfig } from "../../../../../base/static/state/ducks/app-config";
+import { setSurveyConfig } from "../../../../../base/static/state/ducks/survey-config";
+import { setSupportConfig } from "../../../../../state/ducks/support-config";
 
 import MainMap from "../../../../../base/static/components/organisms/main-map";
 import RightSidebar from "../../../../../base/static/components/templates/right-sidebar";
@@ -57,12 +55,14 @@ module.exports = AppView.extend({
     Shareabouts.deferredCollections = [];
     // TODO(luke): move this into "componentDidMount" when App becomes a
     // component:
-    store.dispatch(setMapConfig(config.map));
-    store.dispatch(setPlaceConfig(config.place));
-    store.dispatch(setLeftSidebarConfig(config.left_sidebar));
-    store.dispatch(setRightSidebarConfig(config.right_sidebar));
-    store.dispatch(setStoryConfig(config.story));
-    store.dispatch(setAppConfig(config.app));
+    store.dispatch(setMapConfig(this.options.mapConfig));
+    store.dispatch(setPlaceConfig(this.options.placeConfig));
+    store.dispatch(setLeftSidebarConfig(this.options.leftSidebarConfig));
+    store.dispatch(setRightSidebarConfig(this.options.rightSidebarConfig));
+    store.dispatch(setStoryConfig(this.options.storyConfig));
+    store.dispatch(setAppConfig(this.options.appConfig));
+    store.dispatch(setSurveyConfig(this.options.surveyConfig));
+    store.dispatch(setSupportConfig(this.options.supportConfig));
 
     const storeState = store.getState();
     const flavorTheme = storeState.appConfig.theme;

--- a/src/flavors/williams/static/js/views/app-view.js
+++ b/src/flavors/williams/static/js/views/app-view.js
@@ -12,10 +12,6 @@ import reducer from "../../../../../base/static/state/reducers";
 import mapseedApiClient from "../../../../../base/static/client/mapseed-api-client";
 import { ThemeProvider } from "emotion-theming";
 import theme from "../../../../../theme";
-// TODO(luke): This should be the only instance of our config singleton.
-// Eventually, it will be removed once we start fetching the config
-// from the api:
-import config from "config";
 
 import { setMapConfig } from "../../../../../base/static/state/ducks/map-config";
 import { setPlaceConfig } from "../../../../../base/static/state/ducks/place-config";
@@ -23,6 +19,8 @@ import { setStoryConfig } from "../../../../../base/static/state/ducks/story-con
 import { setLeftSidebarConfig } from "../../../../../base/static/state/ducks/left-sidebar";
 import { setRightSidebarConfig } from "../../../../../base/static/state/ducks/right-sidebar-config";
 import { setAppConfig } from "../../../../../base/static/state/ducks/app-config";
+import { setSurveyConfig } from "../../../../../base/static/state/ducks/survey-config";
+import { setSupportConfig } from "../../../../../state/ducks/support-config";
 
 import MainMap from "../../../../../base/static/components/organisms/main-map";
 import RightSidebar from "../../../../../base/static/components/templates/right-sidebar";
@@ -57,12 +55,14 @@ module.exports = AppView.extend({
     Shareabouts.deferredCollections = [];
     // TODO(luke): move this into "componentDidMount" when App becomes a
     // component:
-    store.dispatch(setMapConfig(config.map));
-    store.dispatch(setPlaceConfig(config.place));
-    store.dispatch(setLeftSidebarConfig(config.left_sidebar));
-    store.dispatch(setRightSidebarConfig(config.right_sidebar));
-    store.dispatch(setStoryConfig(config.story));
-    store.dispatch(setAppConfig(config.app));
+    store.dispatch(setMapConfig(this.options.mapConfig));
+    store.dispatch(setPlaceConfig(this.options.placeConfig));
+    store.dispatch(setLeftSidebarConfig(this.options.leftSidebarConfig));
+    store.dispatch(setRightSidebarConfig(this.options.rightSidebarConfig));
+    store.dispatch(setStoryConfig(this.options.storyConfig));
+    store.dispatch(setAppConfig(this.options.appConfig));
+    store.dispatch(setSurveyConfig(this.options.surveyConfig));
+    store.dispatch(setSupportConfig(this.options.supportConfig));
 
     const storeState = store.getState();
     const flavorTheme = storeState.appConfig.theme;


### PR DESCRIPTION
There were a lot of places in the codebase where we were still importing parts of the config directly (i.e. not going through Redux). As discussed in https://github.com/jalMogo/mgmt/issues/154, this creates problems for the localization system.

This PR cleans up this problem.