### PR TITLE
fix(AppView): fix a regression that prevents routing to the default page

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -252,14 +252,15 @@ class MainMap extends Component {
     this._map.on({ event: "movestart", callback: this.props.onMovestart });
     this._map.on({
       event: "moveend",
-      callback: () => {
+      callback: evt => {
         Util.log("APP", "center-lat", this._map.getCenter().lat);
         Util.log("APP", "center-lng", this._map.getCenter().lng);
         this.props.setMapPosition({
           center: this._map.getCenter(),
           zoom: this._map.getZoom(),
         });
-        this.props.onMoveend();
+        const isUserMove = evt.originalEvent !== undefined;
+        this.props.onMoveend(isUserMove);
       },
     });
 

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -403,10 +403,10 @@ export default Backbone.View.extend({
   onMapMoveStart: function(evt) {
     this.$centerpoint.addClass("dragging");
   },
-  onMapMoveEnd: function() {
+  onMapMoveEnd: function(isUserMove = true) {
     this.$centerpoint.removeClass("dragging");
 
-    if (this.hasBodyClass("content-visible") === false) {
+    if (this.hasBodyClass("content-visible") === false && isUserMove) {
       const { zoom, center } = mapPositionSelector(store.getState());
       this.setLocationRoute(zoom, center.lat, center.lng);
     }


### PR DESCRIPTION
Similar to how we handled https://github.com/jalMogo/mgmt/issues/142, we want to distinguish between map `moveend`s that are user-initiated and program-initiated.

Failure to distinguish between these two was manifesting itself as a bug that prevented routing to the default page.