### PR TITLE
Add hybrid activity stream/legend component for the right sidebar

### DIFF
--- a/src/base/static/components/molecules/map-legend-group.js
+++ b/src/base/static/components/molecules/map-legend-group.js
@@ -1,25 +1,21 @@
-import React from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
-import classNames from "classnames";
+import styled from "react-emotion";
 
 import { HorizontalRule } from "../atoms/layout";
 import { Header6, Paragraph } from "../atoms/typography";
 
 import MapLegendItem from "./map-legend-item";
 
-import "./map-legend-group.scss";
-
 const MapLegendGroup = props => (
-  <div className={classNames(props.classes, "map-legend-group")}>
-    <HorizontalRule />
+  <Fragment>
     {props.title && (
-      <Header6 classes="map-legend-group__title">{props.title}</Header6>
+      <Fragment>
+        <HorizontalRule />
+        <Header6>{props.title}</Header6>
+      </Fragment>
     )}
-    {props.description && (
-      <Paragraph classes="map-legend-group__description">
-        {props.description}
-      </Paragraph>
-    )}
+    {props.description && <Paragraph>{props.description}</Paragraph>}
     {props.content.map((item, i) => (
       <MapLegendItem
         key={i}
@@ -28,7 +24,7 @@ const MapLegendGroup = props => (
         swatch={item.swatch}
       />
     ))}
-  </div>
+  </Fragment>
 );
 
 MapLegendGroup.propTypes = {

--- a/src/base/static/components/molecules/map-legend-group.js
+++ b/src/base/static/components/molecules/map-legend-group.js
@@ -1,6 +1,5 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
-import styled from "react-emotion";
 
 import { HorizontalRule } from "../atoms/layout";
 import { Header6, Paragraph } from "../atoms/typography";

--- a/src/base/static/components/molecules/map-legend-group.scss
+++ b/src/base/static/components/molecules/map-legend-group.scss
@@ -1,3 +1,0 @@
-.map-legend-group__title {
-  margin-bottom: 10px;
-}

--- a/src/base/static/components/organisms/map-legend-panel.js
+++ b/src/base/static/components/organisms/map-legend-panel.js
@@ -48,6 +48,7 @@ MapLegendPanel.propTypes = {
     ),
     title: PropTypes.string,
   }),
+  themed: PropTypes.bool,
 };
 
 export default MapLegendPanel;

--- a/src/base/static/components/organisms/map-legend-panel.js
+++ b/src/base/static/components/organisms/map-legend-panel.js
@@ -6,10 +6,11 @@ import { Image } from "../atoms/imagery";
 import { Paragraph, Header4 } from "../atoms/typography";
 import MapLegendGroup from "../molecules/map-legend-group";
 
-const MapLegendPanelContainer = styled("div")({
+const MapLegendPanelContainer = styled("div")(props => ({
   padding: 10,
+  backgroundColor: props.theme.brand.secondary,
   margin: 0,
-});
+}));
 
 const MapLegendPanel = props => {
   return (
@@ -21,7 +22,6 @@ const MapLegendPanel = props => {
       {props.config.groupings.map((grouping, i) => (
         <MapLegendGroup
           key={i}
-          classes={grouping.classes}
           content={grouping.content}
           description={grouping.description}
           title={grouping.title}

--- a/src/base/static/components/organisms/map-legend-panel.js
+++ b/src/base/static/components/organisms/map-legend-panel.js
@@ -8,13 +8,13 @@ import MapLegendGroup from "../molecules/map-legend-group";
 
 const MapLegendPanelContainer = styled("div")(props => ({
   padding: 10,
-  backgroundColor: props.theme.brand.secondary,
+  backgroundColor: props.themed ? props.theme.brand.secondary : "#fff",
   margin: 0,
 }));
 
 const MapLegendPanel = props => {
   return (
-    <MapLegendPanelContainer>
+    <MapLegendPanelContainer themed={props.themed}>
       {props.config.title && <Header4>{props.config.title}</Header4>}
       {props.config.description && (
         <Paragraph>{props.config.description}</Paragraph>

--- a/src/base/static/components/organisms/map-legend-panel.js
+++ b/src/base/static/components/organisms/map-legend-panel.js
@@ -8,13 +8,13 @@ import MapLegendGroup from "../molecules/map-legend-group";
 
 const MapLegendPanelContainer = styled("div")(props => ({
   padding: 10,
-  backgroundColor: props.themed ? props.theme.brand.secondary : "#fff",
+  backgroundColor: props.isThemed ? props.theme.brand.secondary : "#fff",
   margin: 0,
 }));
 
 const MapLegendPanel = props => {
   return (
-    <MapLegendPanelContainer themed={props.themed}>
+    <MapLegendPanelContainer isThemed={props.isThemed}>
       {props.config.title && <Header4>{props.config.title}</Header4>}
       {props.config.description && (
         <Paragraph>{props.config.description}</Paragraph>
@@ -48,7 +48,7 @@ MapLegendPanel.propTypes = {
     ),
     title: PropTypes.string,
   }),
-  themed: PropTypes.bool,
+  isThemed: PropTypes.bool,
 };
 
 export default MapLegendPanel;

--- a/src/base/static/components/templates/right-sidebar.js
+++ b/src/base/static/components/templates/right-sidebar.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -38,6 +38,15 @@ const RightSidebar = props => {
           config={props.rightSidebarConfig}
           places={props.places}
         />
+      )}
+      {props.rightSidebarConfig.component === "ActivityStreamWithLegend" && (
+        <Fragment>
+          <MapLegendPanel config={props.rightSidebarConfig} />
+          <ActivityStream
+            config={props.rightSidebarConfig}
+            places={props.places}
+          />
+        </Fragment>
       )}
     </div>
   );

--- a/src/base/static/components/templates/right-sidebar.js
+++ b/src/base/static/components/templates/right-sidebar.js
@@ -41,7 +41,7 @@ const RightSidebar = props => {
       )}
       {props.rightSidebarConfig.component === "ActivityStreamWithLegend" && (
         <Fragment>
-          <MapLegendPanel config={props.rightSidebarConfig} themed={true} />
+          <MapLegendPanel config={props.rightSidebarConfig} isThemed={true} />
           <ActivityStream
             config={props.rightSidebarConfig}
             places={props.places}

--- a/src/base/static/components/templates/right-sidebar.js
+++ b/src/base/static/components/templates/right-sidebar.js
@@ -41,7 +41,7 @@ const RightSidebar = props => {
       )}
       {props.rightSidebarConfig.component === "ActivityStreamWithLegend" && (
         <Fragment>
-          <MapLegendPanel config={props.rightSidebarConfig} />
+          <MapLegendPanel config={props.rightSidebarConfig} themed={true} />
           <ActivityStream
             config={props.rightSidebarConfig}
             places={props.places}


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/162

This PR gives us the ability to load two components into the right sidebar: the `MapLegendPanel` and the `ActivityStream`. This mimics the design of the original `pbgreensboro` flavor.

We also refactor the `MapLegendPanel` to be a styled component.