### PR TITLE
refactor(MainMap): decouple isVisible from status

### DIFF
--- a/src/base/static/client/mapseed-api-client.js
+++ b/src/base/static/client/mapseed-api-client.js
@@ -2,8 +2,7 @@ const getPlaceCollections = async ({
   placeParams,
   placeCollections,
   layers,
-  showLayers,
-  setLayerLoaded,
+  setLayerFetched,
   setLayerError,
 }) => {
   const $progressContainer = $("#map-progress");
@@ -59,7 +58,7 @@ const getPlaceCollections = async ({
         },
 
         success: function(fetchedCollection, response, options) {
-          layer.is_visible_default && setLayerLoaded(collectionId);
+          layer.is_visible_default && setLayerFetched(collectionId);
           resolve(fetchedCollection, collectionId);
         },
 

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -37,13 +37,12 @@ import {
   mapPositionSelector,
   mapBasemapSelector,
   setMapPosition,
-  mapLayerStatusesSelector,
   initLayers,
   showLayers,
   hideLayers,
   setBasemap,
   setLayerError,
-  setLayerLoaded,
+  setLayerFetched,
 } from "../../state/ducks/map";
 import { setSupportConfig } from "../../state/ducks/support-config";
 import { setNavBarConfig } from "../../state/ducks/nav-bar-config";
@@ -323,8 +322,7 @@ export default Backbone.View.extend({
       placeParams,
       placeCollections: self.places,
       layers: mapLayersSelector(store.getState()),
-      showLayers: layerId => store.dispatch(showLayers([layerId])),
-      setLayerLoaded: layerId => store.dispatch(setLayerLoaded(layerId)),
+      setLayerFetched: layerId => store.dispatch(setLayerFetched(layerId)),
       setLayerError: layerId => store.dispatch(setLayerError(layerId)),
     });
 

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1135,7 +1135,7 @@ export default (container, options) => {
       }
 
       if (isBasemap && map.getStyle().name !== DEFAULT_STYLE_NAME) {
-        // If we're loading a basemap, check to see if the prior basemap was
+        // If we're updating the basemap, check to see if the prior basemap was
         // a Mapbox style. If so, reset the map's style and recover all
         // existing sources and layers that were not affiliated with the
         // Mapbox style.

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -61,17 +61,16 @@ export const initLayers = layers =>
     type: SET_LAYER_STATUS,
     payload: {
       id: layer.id,
-      isVisible: layer.type !== "place" ? !!layer.is_visible_default : false,
+      isVisible: !!layer.is_visible_default,
       isBasemap: !!layer.is_basemap,
       type: layer.type,
-      status: !!layer.is_visible_default ? "loading" : "",
+      status: layer.is_visible_default ? "loading" : "",
     },
   }));
 export const setLayerLoaded = layerId => ({
   type: SET_LAYER_STATUS,
   payload: {
     id: layerId,
-    isVisible: true,
     status: "loaded",
   },
 });

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -56,22 +56,36 @@ export const hideLayers = (layerIds = []) =>
       isVisible: false,
     },
   }));
-export const initLayers = layers =>
-  layers.map(layer => ({
-    type: SET_LAYER_STATUS,
-    payload: {
-      id: layer.id,
-      isVisible: !!layer.is_visible_default,
-      isBasemap: !!layer.is_basemap,
-      type: layer.type,
-      status: layer.is_visible_default ? "loading" : "",
-    },
-  }));
+export const initLayers = layers => {
+  return layers.map(layer => {
+    let status = "hidden";
+    if (layer.is_visible_default) {
+      status = layer.type === "place" ? "fetching" : "loading";
+    }
+    return {
+      type: SET_LAYER_STATUS,
+      payload: {
+        id: layer.id,
+        isVisible: !!layer.is_visible_default,
+        isBasemap: !!layer.is_basemap,
+        type: layer.type,
+        status: status,
+      },
+    };
+  });
+};
 export const setLayerLoaded = layerId => ({
   type: SET_LAYER_STATUS,
   payload: {
     id: layerId,
     status: "loaded",
+  },
+});
+export const setLayerFetched = layerId => ({
+  type: SET_LAYER_STATUS,
+  payload: {
+    id: layerId,
+    status: "loading",
   },
 });
 export const setLayerError = layerId => ({


### PR DESCRIPTION
This PR straightens out some of the logic between "loading" a layer, and marking it as "visible".

Note that some testing/cleanup may be required for the MapLayerGroup/Selector, so that it is consistent with the new logic.