### PR TITLE
fix(PlacesDuck): set places correctly when deeplinking to a place

### DIFF
--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -150,12 +150,13 @@ var self = (module.exports = {
     });
   },
 
-  getPlaceFromCollections: function(
+  getPlaceFromCollections: function({
     collectionsSet,
+    setPlaces,
     args,
     mapConfig,
     callbacks,
-  ) {
+  }) {
     const datasetId = _.find(mapConfig.layers, function(layer) {
       return layer.slug === args.datasetSlug;
     }).id;
@@ -169,6 +170,7 @@ var self = (module.exports = {
       collectionsSet.places[datasetId].fetchById(args.modelId, {
         validate: true,
         success: function(model) {
+          setPlaces([model.toJSON()]);
           callbacks.onFound(model, "place", datasetId);
         },
         error: function() {

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -570,17 +570,20 @@ export default Backbone.View.extend({
     this.renderRightSidebar();
 
     var self = this;
-    Util.getPlaceFromCollections(
-      {
+    Util.getPlaceFromCollections({
+      collectionsSet: {
         places: this.places,
       },
-      args,
-      this.options.mapConfig,
-      {
+      setPlaces: places => {
+        store.dispatch(setPlaces(places));
+      },
+      args: args,
+      mapConfig: this.options.mapConfig,
+      callbacks: {
         onFound: _.bind(onFound, this),
         onNotFound: _.bind(onNotFound, this),
       },
-    );
+    });
 
     function onFound(model, type, collectionId) {
       // REACT PORT SECTION //////////////////////////////////////////////////
@@ -682,7 +685,7 @@ export default Backbone.View.extend({
       }
 
       emitter.emit(constants.PLACE_COLLECTION_FOCUS_PLACE_EVENT, {
-        collectionId: collectionId,
+        datasetId: collectionId,
         modelId: model.get("id"),
       });
 

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -44,7 +44,13 @@ const INITIAL_STATE = [];
 export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
     case SET_PLACES:
-      return action.payload;
+      return action.payload.reduce((memo, newPlace) => {
+        return !memo.find(place => newPlace.id === place.id)
+          ? [...memo, newPlace]
+          : // If a place already exists in the map duck, make sure we don't
+            // add it again.
+            memo;
+      }, state);
     case CREATE_PLACE:
       return [...state, action.payload];
     default:


### PR DESCRIPTION
This PR fixes an issue where deeplinked places are not focused. The reason for the issue is that a deeplinked place is loaded with a separate call to the API to fetch that place's model independently of the dataset that it's in.