### PR TITLE
Jalmogo/implement filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,21 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/types": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.2.tgz",
@@ -3329,6 +3344,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz",
+      "integrity": "sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4357,6 +4377,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
+    "downshift": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.1.5.tgz",
+      "integrity": "sha512-2PpR4+A0WiF0R+Q6sq79sSG+sAy4KBlH5FwnU8FtD5zkeZH/UQZm/QS7kq/CglSH8vl1qpPoaap4Z2Oe9Swcrg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.6.0",
+        "react-is": "^16.5.2"
+      }
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -14436,8 +14467,7 @@
     "react-is": {
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
-      "dev": true
+      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "classnames": "^2.2.5",
     "compass-importer": "^0.4.1",
     "dotenv": "^4.0.0",
+    "downshift": "^3.1.5",
     "emotion": "^9.2.6",
     "emotion-theming": "^9.2.6",
     "esprima": "^3.1.3",

--- a/src/base/static/components/atoms/imagery.js
+++ b/src/base/static/components/atoms/imagery.js
@@ -1,30 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import classNames from "classnames";
 import styled from "react-emotion";
 import mq from "../../../../media-queries";
-
-import "./imagery.scss";
-
-const LegacyImage = ({ ...props }) => {
-  return (
-    <img
-      className={classNames("mapseed__image", props.classes)}
-      src={props.src}
-      alt={props.alt}
-    />
-  );
-};
-
-LegacyImage.propTypes = {
-  alt: PropTypes.string.isRequired,
-  classes: PropTypes.string,
-  src: PropTypes.string.isRequired,
-};
-
-LegacyImage.defaultProps = {
-  alt: "Untitled image",
-};
 
 const Image = props => <img src={props.src} alt={props.alt} {...props} />;
 
@@ -113,4 +90,4 @@ UserAvatar.defaultProps = {
 
 export default UserAvatar;
 
-export { LegacyImage, Image, UserAvatar, SiteLogo, FontAwesomeIcon };
+export { Image, UserAvatar, SiteLogo, FontAwesomeIcon };

--- a/src/base/static/components/atoms/imagery.scss
+++ b/src/base/static/components/atoms/imagery.scss
@@ -1,4 +1,0 @@
-.mapseed__image {
-  height: auto;
-  width: auto;
-}

--- a/src/base/static/components/atoms/typography.js
+++ b/src/base/static/components/atoms/typography.js
@@ -129,14 +129,21 @@ const SmallTitle = styled("h3")(props => ({
 }));
 
 // TODO: Other label types.
-const RegularLabel = styled("label")(
-  props => (
-    {
-      color: "#444",
-    },
-    props.styles
-  ),
-);
+const LargeLabel = styled("label")(props => ({
+  fontSize: "1.5rem",
+  fontFamily: props.theme.text.headerFontFamily,
+}));
+
+const RegularLabel = styled("label")(props => ({
+  fontSize: "1rem",
+  lineHeight: "1.2rem",
+  fontFamily: props.theme.text.headerFontFamily,
+}));
+
+const SmallLabel = styled("label")(props => ({
+  fontSize: "0.7rem",
+  fontFamily: props.theme.text.headerFontFamily,
+}));
 
 RegularLabel.propTypes = {
   styles: PropTypes.object,
@@ -232,7 +239,9 @@ export {
   Header4,
   Header5,
   Header6,
+  LargeLabel,
   RegularLabel,
+  SmallLabel,
   LargeTitle,
   RegularTitle,
   SmallTitle,

--- a/src/base/static/components/molecules/buttons.js
+++ b/src/base/static/components/molecules/buttons.js
@@ -1,0 +1,28 @@
+import React from "react";
+import styled from "react-emotion";
+import { Button } from "../atoms/buttons";
+import mq from "../../../../media-queries";
+
+const NavButton = styled(props => {
+  return (
+    <Button
+      className={props.className}
+      color={props.color}
+      variant={props.variant}
+      onClick={props.onClick}
+    >
+      {props.children}
+    </Button>
+  );
+})(props => ({
+  fontFamily: props.theme.text.navBarFontFamily,
+  fontWeight: 600,
+  marginLeft: "4px",
+  marginRight: "4px",
+
+  [mq[0]]: {
+    width: "100%",
+  },
+}));
+
+export { NavButton };

--- a/src/base/static/components/molecules/buttons.js
+++ b/src/base/static/components/molecules/buttons.js
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "react-emotion";
 import { Button } from "../atoms/buttons";
+import { Link } from "../atoms/typography";
 import mq from "../../../../media-queries";
 
 const NavButton = styled(props => {
@@ -25,4 +26,13 @@ const NavButton = styled(props => {
   },
 }));
 
-export { NavButton };
+const CloseButton = styled(props => (
+  <Link className={props.className} onClick={props.onClick}>
+    {"✕"}
+  </Link>
+))({
+  color: "red",
+  fontSize: "1.5em",
+});
+
+export { NavButton, CloseButton };

--- a/src/base/static/components/molecules/map-legend-item.js
+++ b/src/base/static/components/molecules/map-legend-item.js
@@ -2,18 +2,15 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "react-emotion";
 
-import { LegacyIcon } from "../atoms/feedback";
+import { Image } from "../atoms/imagery";
 import { RegularLabel } from "../atoms/typography";
 
-// TODO: Abstract these components out when we refactor other panel types.
-const LegendIcon = styled(props => (
-  <LegacyIcon icon={props.icon} classes={props.className} />
-))(() => ({
+const LegendIcon = styled(Image)({
   flex: "0 0 30px",
   width: "30px",
   height: "auto",
   marginRight: "10px",
-}));
+});
 
 const MapLegendItemContainer = styled("div")({
   display: "flex",
@@ -25,7 +22,7 @@ const MapLegendItemContainer = styled("div")({
 const MapLegendItem = props => {
   return (
     <MapLegendItemContainer>
-      <LegendIcon icon={props.icon} />
+      <LegendIcon src={props.icon} />
       <RegularLabel>{props.label}</RegularLabel>
     </MapLegendItemContainer>
   );

--- a/src/base/static/components/molecules/typography.js
+++ b/src/base/static/components/molecules/typography.js
@@ -1,0 +1,22 @@
+import React from "react";
+import styled from "react-emotion";
+import { Link } from "../atoms/typography";
+import mq from "../../../../media-queries";
+
+const NavLink = styled(props => (
+  <Link href={props.href} rel="internal" className={props.className}>
+    {props.children}
+  </Link>
+))(props => ({
+  display: "flex",
+  alignItems: "center",
+  textDecoration: "none",
+
+  [mq[1]]: {
+    height: props.height,
+    borderLeft:
+      props.position > 0 ? `solid 1px ${props.theme.text.tertiary}` : "none",
+  },
+}));
+
+export { NavLink };

--- a/src/base/static/components/molecules/user-menu.js
+++ b/src/base/static/components/molecules/user-menu.js
@@ -42,7 +42,8 @@ const MenuButton = styled(props => {
       {props.children}
     </Button>
   );
-})(() => ({
+})(props => ({
+  fontFamily: props.theme.text.navBarFontFamily,
   fontSize: "0.75em",
   textAlign: "center",
   textDecoration: "none",

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -20,7 +20,7 @@ import Modal from "react-modal";
 Modal.setAppElement("#main");
 
 const FilterNavButton = styled(linkProps => (
-  <NavButton variant="raised" color="primary" onClick={linkProps.onClick}>
+  <NavButton color={"tertiary"} onClick={linkProps.onClick}>
     {linkProps.children}
   </NavButton>
 ))(() => ({
@@ -124,7 +124,9 @@ class FilterMenu extends Component {
         {({ getItemProps, getToggleButtonProps, getMenuProps, isOpen }) => (
           <div>
             <FilterNavButton {...getToggleButtonProps()}>
-              {`${this.props.navBarItem.title}${isFiltering ? " (on)" : ""}`}
+              {`${this.props.navBarItem.title}${
+                isFiltering ? " (on) ⌄" : " ⌄"
+              }`}
             </FilterNavButton>
             {isOpen && (
               <CategoryFilterDropdown {...getMenuProps()}>

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -1,0 +1,196 @@
+import React, { Component, Fragment } from "react";
+import PropTypes from "prop-types";
+import { NavButton } from "../molecules/buttons";
+import { Image } from "../atoms/imagery";
+import { RegularTitle, LargeLabel } from "../atoms/typography";
+import styled from "react-emotion";
+import mq from "../../../../media-queries";
+import { connect } from "react-redux";
+import {
+  updateFilters,
+  filtersPropType,
+  filtersSelector,
+} from "../../state/ducks/filters";
+import {
+  placeFormsConfigPropType,
+  placeFormsConfigSelector,
+} from "../../state/ducks/forms-config";
+
+import Modal from "react-modal";
+Modal.setAppElement("#main");
+
+const FilterNavButton = styled(linkProps => (
+  <NavButton variant="raised" color="primary" onClick={linkProps.onClick}>
+    {linkProps.children}
+  </NavButton>
+))(() => ({
+  [mq[0]]: {
+    display: "none",
+  },
+  [mq[1]]: {
+    display: "block",
+  },
+}));
+
+const FilterMenuWrapper = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  height: "100%",
+});
+
+const FilterMenuTitle = styled(RegularTitle)({
+  marginLeft: "auto",
+  marginRight: "auto",
+  textAlign: "center",
+});
+const FilterOptions = styled("div")({
+  marginLeft: "auto",
+  marginRight: "auto",
+});
+const CategoryFilterOption = styled("div")(props => ({
+  display: "flex",
+  flexDirection: "row",
+  marginBottom: "8px",
+  alignItems: "center",
+
+  background: props.isSelected ? props.theme.bg.highlighted : "clear",
+}));
+const CategoryImage = styled(Image)({
+  width: "30px",
+  height: "auto",
+});
+const CategoryLabel = styled(LargeLabel)(props => ({
+  marginLeft: "8px",
+
+  color: props.isSelected
+    ? props.theme.text.highlighted
+    : props.theme.text.primary,
+}));
+
+const modalStyles = {
+  content: {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    backgroundColor: "#fff",
+    borderRadius: "8px",
+    outline: "none",
+    boxShadow: "0 1px 5px rgba(0, 0, 0, 0.65)",
+    wordWrap: "break-word",
+    maxWidth: "95%",
+    maxHeight: "95%",
+    width: "360px",
+  },
+
+  overlay: {
+    position: "fixed",
+    top: "0px",
+    left: "0px",
+    right: "0px",
+    bottom: "0px",
+    backgroundColor: "rgba(255, 255, 255, 0.7)",
+    zIndex: 99,
+  },
+};
+
+class FilterMenu extends Component {
+  state = {
+    isModalOpen: false,
+  };
+  openModal = () => {
+    this.setState({ isModalOpen: true });
+  };
+  closeModal = () => {
+    this.setState({ isModalOpen: false });
+  };
+  render() {
+    return (
+      <Fragment>
+        <FilterNavButton
+          onClick={() => {
+            this.props.onClick();
+            this.openModal();
+          }}
+        >
+          {this.props.navBarItem.title}
+        </FilterNavButton>
+        <Modal
+          style={modalStyles}
+          isOpen={this.state.isModalOpen}
+          onRequestClose={this.closeModal}
+          contentLabel="set your filters"
+        >
+          <FilterMenuWrapper>
+            <FilterMenuTitle>{"Filter Menu"}</FilterMenuTitle>
+            <FilterOptions>
+              <CategoryFilterOption
+                isSelected={this.props.filters.length === 0}
+                onClick={() => {
+                  this.props.updateFilters([]);
+                }}
+              >
+                <CategoryLabel isSelected={this.props.filters.length === 0}>
+                  {"All"}
+                </CategoryLabel>
+              </CategoryFilterOption>
+              {this.props.placeFormsConfig.map(placeForm => {
+                const isFilterSelected = !!this.props.filters.find(
+                  filter => filter.formId === placeForm.id,
+                );
+                return (
+                  <CategoryFilterOption
+                    key={placeForm.id}
+                    isSelected={isFilterSelected}
+                    onClick={() => {
+                      isFilterSelected
+                        ? this.props.updateFilters(
+                            this.props.filters.filter(
+                              filter => filter.formId !== placeForm.id,
+                            ),
+                          )
+                        : this.props.updateFilters([
+                            ...this.props.filters,
+                            {
+                              formId: placeForm.id,
+                              datasetId: placeForm.datasetId,
+                            },
+                          ]);
+                    }}
+                  >
+                    <CategoryImage src={placeForm.icon} />
+                    <CategoryLabel isSelected={isFilterSelected}>
+                      {placeForm.label}
+                    </CategoryLabel>
+                  </CategoryFilterOption>
+                );
+              })}
+            </FilterOptions>
+          </FilterMenuWrapper>
+        </Modal>
+      </Fragment>
+    );
+  }
+}
+
+FilterMenu.propTypes = {
+  navBarItem: PropTypes.object.isRequired,
+  onClick: PropTypes.func.isRequired,
+  filters: filtersPropType.isRequired,
+  placeFormsConfig: placeFormsConfigPropType.isRequired,
+  updateFilters: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => ({
+  filters: filtersSelector(state),
+  placeFormsConfig: placeFormsConfigSelector(state),
+});
+const mapDispatchToProps = dispatch => ({
+  updateFilters: filters => dispatch(updateFilters(filters)),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(FilterMenu);

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -48,6 +48,7 @@ const CategoryFilterOption = styled("li")(props => ({
   alignItems: "center",
 
   background: props.isSelected ? props.theme.bg.highlighted : "clear",
+  cursor: "pointer",
   color: props.isSelected
     ? props.theme.text.highlighted
     : props.theme.text.primary,
@@ -61,10 +62,10 @@ const CategoryFilterOption = styled("li")(props => ({
 const CategoryLabel = styled(RegularLabel)(props => ({
   color: "unset",
   margin: "4px 16px 4px 16px",
+  cursor: "pointer",
 
   "&:hover": {
     color: props.theme.text.highlighted,
-    cursor: "pointer",
   },
 }));
 

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -146,6 +146,7 @@ class FilterMenu extends Component {
                     filter => filter.formId === placeForm.id,
                   );
                   return (
+                    // eslint-disable-next-line react/jsx-key
                     <CategoryFilterOption
                       {...getItemProps({
                         key: placeForm.id,

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -55,6 +55,14 @@ const CategoryFilterOption = styled("div")(props => ({
   alignItems: "center",
 
   background: props.isSelected ? props.theme.bg.highlighted : "clear",
+  color: props.isSelected
+    ? props.theme.text.highlighted
+    : props.theme.text.primary,
+
+  "&:hover": {
+    background: props.theme.bg.highlighted,
+    color: props.theme.text.highlighted,
+  },
 }));
 const CategoryImage = styled(Image)({
   width: "30px",
@@ -62,10 +70,11 @@ const CategoryImage = styled(Image)({
 });
 const CategoryLabel = styled(LargeLabel)(props => ({
   marginLeft: "8px",
+  color: "unset",
 
-  color: props.isSelected
-    ? props.theme.text.highlighted
-    : props.theme.text.primary,
+  "&:hover": {
+    color: props.theme.text.highlighted,
+  },
 }));
 
 const modalStyles = {

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -1,8 +1,8 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
-import { NavButton } from "../molecules/buttons";
+import { NavButton, CloseButton } from "../molecules/buttons";
 import { Image } from "../atoms/imagery";
-import { RegularTitle, LargeLabel } from "../atoms/typography";
+import { Link, RegularTitle, LargeLabel } from "../atoms/typography";
 import styled from "react-emotion";
 import mq from "../../../../media-queries";
 import { connect } from "react-redux";
@@ -39,10 +39,13 @@ const FilterMenuWrapper = styled("div")({
   height: "100%",
 });
 
+const FilterMenuHeading = styled("div")({
+  display: "flex",
+});
 const FilterMenuTitle = styled(RegularTitle)({
+  textAlign: "center",
   marginLeft: "auto",
   marginRight: "auto",
-  textAlign: "center",
 });
 const FilterOptions = styled("div")({
   marginLeft: "auto",
@@ -133,7 +136,10 @@ class FilterMenu extends Component {
           contentLabel="set your filters"
         >
           <FilterMenuWrapper>
-            <FilterMenuTitle>{"Filter Menu"}</FilterMenuTitle>
+            <FilterMenuHeading>
+              <FilterMenuTitle>{"Filter Menu"}</FilterMenuTitle>
+              <CloseButton onClick={this.closeModal} />
+            </FilterMenuHeading>
             <FilterOptions>
               <CategoryFilterOption
                 isSelected={!isFiltering}

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -64,6 +64,7 @@ const CategoryLabel = styled(RegularLabel)(props => ({
 
   "&:hover": {
     color: props.theme.text.highlighted,
+    cursor: "pointer",
   },
 }));
 

--- a/src/base/static/components/organisms/filter-menu.js
+++ b/src/base/static/components/organisms/filter-menu.js
@@ -106,6 +106,7 @@ class FilterMenu extends Component {
     this.setState({ isModalOpen: false });
   };
   render() {
+    const isFiltering = this.props.filters.length > 0;
     return (
       <Fragment>
         <FilterNavButton
@@ -114,7 +115,7 @@ class FilterMenu extends Component {
             this.openModal();
           }}
         >
-          {this.props.navBarItem.title}
+          {`${this.props.navBarItem.title}${isFiltering ? " (on)" : ""}`}
         </FilterNavButton>
         <Modal
           style={modalStyles}
@@ -126,14 +127,12 @@ class FilterMenu extends Component {
             <FilterMenuTitle>{"Filter Menu"}</FilterMenuTitle>
             <FilterOptions>
               <CategoryFilterOption
-                isSelected={this.props.filters.length === 0}
+                isSelected={!isFiltering}
                 onClick={() => {
                   this.props.updateFilters([]);
                 }}
               >
-                <CategoryLabel isSelected={this.props.filters.length === 0}>
-                  {"All"}
-                </CategoryLabel>
+                <CategoryLabel isSelected={!isFiltering}>{"All"}</CategoryLabel>
               </CategoryFilterOption>
               {this.props.placeFormsConfig.map(placeForm => {
                 const isFilterSelected = !!this.props.filters.find(

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -458,12 +458,17 @@ class MainMap extends Component {
         .filter(layerConfig => layerConfig.type === "place")
         .map(layerConfig => layerConfig.id);
       datasetIds.forEach(datasetId => {
-        const layerStatus = this.props.layerStatuses[datasetId];
         const layerConfig = this.props.layers.find(
           layer => layer.id === datasetId,
         );
-        this._map.removeLayer(layerConfig, { clearCache: true });
-        this.addLayer(layerConfig, layerStatus.isBasemap);
+        this._map.updateLayerData(
+          layerConfig.id,
+          createGeoJSONFromPlaces(
+            this.props.places.filter(
+              place => place.datasetId === layerConfig.id,
+            ),
+          ),
+        );
       });
     }
   }

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -11,7 +11,12 @@ import {
   mapConfigSelector,
   mapLayersSelector,
 } from "../../state/ducks/map-config";
-import { placesSelector, placesPropType } from "../../state/ducks/places";
+import {
+  filteredPlacesSelector,
+  placesSelector,
+  placesPropType,
+} from "../../state/ducks/places";
+import { filtersSelector, filtersPropType } from "../../state/ducks/filters";
 import {
   mapBasemapSelector,
   mapLayerStatusesSelector,
@@ -416,6 +421,7 @@ class MainMap extends Component {
       });
     }
 
+    // Check if a layer's visibibility or load status has changed:
     for (let layerId in this.props.layerStatuses) {
       const layerStatus = this.props.layerStatuses[layerId];
       const prevLayerStatus = prevProps.layerStatuses[layerId];
@@ -444,6 +450,20 @@ class MainMap extends Component {
           layerStatus.isBasemap,
         );
       }
+    }
+    if (prevProps.filters.length !== this.props.filters.length) {
+      const datasetIds = this.props.filters.reduce((memo, filter) => {
+        memo.push(filter.datasetId);
+        return memo;
+      }, []);
+      datasetIds.forEach(datasetId => {
+        const layerStatus = this.props.layerStatuses[datasetId];
+        const layerConfig = this.props.layers.find(
+          layer => layer.id === datasetId,
+        );
+        this._map.removeLayer(layerConfig, { clearCache: true });
+        this.addLayer(layerConfig, layerStatus.isBasemap);
+      });
     }
   }
 
@@ -589,6 +609,7 @@ MainMap.propTypes = {
   store: PropTypes.object.isRequired,
   updatingFilterGroupId: PropTypes.string,
   updatingFilterTargetLayer: PropTypes.string,
+  filters: filtersPropType.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -605,7 +626,8 @@ const mapStateToProps = state => ({
   mapboxStyleId: mapboxStyleIdSelector(state),
   updatingFilterGroupId: mapUpdatingFilterGroupIdSelector(state),
   updatingFilterTargetLayer: mapUpdatingFilterTargetLayerSelector(state),
-  places: placesSelector(state),
+  places: filteredPlacesSelector(state),
+  filters: filtersSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -451,11 +451,12 @@ class MainMap extends Component {
         );
       }
     }
+
+    // Update place datasets when filters have been updated:
     if (prevProps.filters.length !== this.props.filters.length) {
-      const datasetIds = this.props.filters.reduce((memo, filter) => {
-        memo.push(filter.datasetId);
-        return memo;
-      }, []);
+      const datasetIds = this.props.layers
+        .filter(layerConfig => layerConfig.type === "place")
+        .map(layerConfig => layerConfig.id);
       datasetIds.forEach(datasetId => {
         const layerStatus = this.props.layerStatuses[datasetId];
         const layerConfig = this.props.layers.find(

--- a/src/base/static/components/organisms/place-list.js
+++ b/src/base/static/components/organisms/place-list.js
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 import styled from "react-emotion";
 import { translate } from "react-i18next";
 import { connect } from "react-redux";
-import { placesSelector, placesPropType } from "../../state/ducks/places";
+import {
+  filteredPlacesSelector,
+  placesSelector,
+  placesPropType,
+} from "../../state/ducks/places";
 import {
   placeConfigSelector,
   placeConfigPropType,
@@ -251,7 +255,7 @@ PlaceList.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  places: placesSelector(state),
+  places: filteredPlacesSelector(state),
   placeConfig: placeConfigSelector(state),
 });
 

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -9,7 +9,7 @@ import { Link } from "../atoms/navigation";
 import { NavButton } from "../molecules/buttons";
 import { NavLink } from "../molecules/typography";
 import UserMenu from "../molecules/user-menu";
-import { RegularTitle } from "../atoms/typography";
+import { RegularTitle, RegularLabel } from "../atoms/typography";
 
 import {
   navBarConfigPropType,
@@ -94,17 +94,18 @@ const LanguagePickerMenu = styled("ul")(props => ({
   [mq[1]]: {
     display: props.isLanguageMenuVisible ? "block" : "none",
     position: "fixed",
-    border: "3px solid rgba(0, 0, 0, 0.05)",
+    border: `4px solid ${props.theme.brand.accent}`,
   },
 }));
 
 const LanguagePickerMenuItem = styled("li")(props => ({
+  fontFamily: props.theme.text.navBarFontFamily,
   textTransform: "uppercase",
   fontSize: "0.75rem",
   padding: "8px",
   "&:hover": {
-    color: props.theme.text.secondary,
-    backgroundColor: props.theme.brand.accent,
+    color: props.theme.text.highlighted,
+    backgroundColor: props.theme.bg.highlighted,
     cursor: "pointer",
   },
 
@@ -115,6 +116,7 @@ const LanguagePickerMenuItem = styled("li")(props => ({
 
 const LanguagePicker = styled("nav")(props => ({
   textTransform: "uppercase",
+  fontFamily: props.theme.text.navBarFontFamily,
   "&:hover": {
     cursor: "pointer",
   },
@@ -310,7 +312,7 @@ class SiteHeader extends Component {
                     href={`/${language.code}.html`}
                   >
                     <LanguagePickerMenuItem>
-                      {language.label}
+                      <RegularLabel>{language.label}</RegularLabel>
                     </LanguagePickerMenuItem>
                   </LanguageLink>
                 ))}

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -189,11 +189,7 @@ const navItemMappings = {
       position={linkProps.position}
       href={linkProps.navBarItem.url}
     >
-      <NavButton
-        variant={linkProps.navBarItem.variant}
-        color={linkProps.navBarItem.color || "tertiary"}
-        onClick={linkProps.onClick}
-      >
+      <NavButton color={"tertiary"} onClick={linkProps.onClick}>
         {linkProps.children}
       </NavButton>
     </NavLink>
@@ -201,8 +197,7 @@ const navItemMappings = {
   left_sidebar_toggle: linkProps => (
     <NavButtonWrapper position={linkProps.position}>
       <NavButton
-        variant={linkProps.navBarItem.variant}
-        color={linkProps.navBarItem.color || "tertiary"}
+        color={"tertiary"}
         onClick={() => {
           linkProps.onClick();
           linkProps.setLeftSidebarComponent(linkProps.navBarItem.component);

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -1,17 +1,21 @@
 /* eslint react/display-name: 0 */
-
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "react-emotion";
 import { connect } from "react-redux";
 
 import { SiteLogo } from "../atoms/imagery";
-import { Button } from "../atoms/buttons";
 import { Link } from "../atoms/navigation";
+import { NavButton } from "../molecules/buttons";
+import { NavLink } from "../molecules/typography";
 import UserMenu from "../molecules/user-menu";
 import { RegularTitle } from "../atoms/typography";
 
-import { navBarConfigSelector } from "../../state/ducks/nav-bar-config";
+import {
+  navBarConfigPropType,
+  navBarConfigSelector,
+} from "../../state/ducks/nav-bar-config";
+import FilterMenu from "./filter-menu";
 import { appConfigSelector } from "../../state/ducks/app-config";
 import { currentTemplateSelector } from "../../state/ducks/ui";
 import {
@@ -54,28 +58,6 @@ const NavContainer = styled("nav")(props => ({
   },
 }));
 
-const NavButton = styled(props => {
-  return (
-    <Button
-      className={props.className}
-      color={props.color}
-      variant={props.variant}
-      onClick={props.onClick}
-    >
-      {props.children}
-    </Button>
-  );
-})(props => ({
-  fontFamily: props.theme.text.navBarFontFamily,
-  fontWeight: 600,
-  marginLeft: "4px",
-  marginRight: "4px",
-
-  [mq[0]]: {
-    width: "100%",
-  },
-}));
-
 const SiteTitle = styled(RegularTitle)(props => ({
   color: props.theme.text.titleColor,
   fontFamily: props.theme.text.titleFontFamily,
@@ -86,22 +68,6 @@ const SiteTitle = styled(RegularTitle)(props => ({
   [mq[0]]: {
     // NOTE: This is an override of our RegularTitle font size.
     fontSize: "1rem",
-  },
-}));
-
-const NavLink = styled(props => (
-  <Link href={props.href} rel="internal" className={props.className}>
-    {props.children}
-  </Link>
-))(props => ({
-  display: "flex",
-  alignItems: "center",
-  textDecoration: "none",
-
-  [mq[1]]: {
-    height: props.height,
-    borderLeft:
-      props.position > 0 ? `solid 1px ${props.theme.text.tertiary}` : "none",
   },
 }));
 
@@ -267,6 +233,7 @@ const navItemMappings = {
       display: "block",
     },
   })),
+  filter: FilterMenu,
 };
 
 class SiteHeader extends Component {
@@ -297,29 +264,27 @@ class SiteHeader extends Component {
           )}
         </LogoTitleWrapper>
         <NavContainer isHeaderExpanded={this.state.isHeaderExpanded}>
-          {this.props.navBarConfig
-            .filter(navBarItem => !navBarItem.hide_from_top_bar)
-            .map((navBarItem, i) => {
-              const NavItemComponent = navItemMappings[navBarItem.type];
-              return (
-                <NavItemComponent
-                  key={i}
-                  position={i}
-                  navBarItem={navBarItem}
-                  currentTemplate={this.props.currentTemplate}
-                  setLeftSidebarComponent={this.props.setLeftSidebarComponent}
-                  setLeftSidebarExpanded={this.props.setLeftSidebarExpanded}
-                  isLeftSidebarExpanded={this.props.isLeftSidebarExpanded}
-                  onClick={() => {
-                    this.setState({
-                      isHeaderExpanded: false,
-                    });
-                  }}
-                >
-                  {navBarItem.title}
-                </NavItemComponent>
-              );
-            })}
+          {this.props.navBarConfig.map((navBarItem, i) => {
+            const NavItemComponent = navItemMappings[navBarItem.type];
+            return (
+              <NavItemComponent
+                key={i}
+                position={i}
+                navBarItem={navBarItem}
+                currentTemplate={this.props.currentTemplate}
+                setLeftSidebarComponent={this.props.setLeftSidebarComponent}
+                setLeftSidebarExpanded={this.props.setLeftSidebarExpanded}
+                isLeftSidebarExpanded={this.props.isLeftSidebarExpanded}
+                onClick={() => {
+                  this.setState({
+                    isHeaderExpanded: false,
+                  });
+                }}
+              >
+                {navBarItem.title}
+              </NavItemComponent>
+            );
+          })}
         </NavContainer>
         <RightAlignedContainer isHeaderExpanded={this.state.isHeaderExpanded}>
           {this.props.appConfig.languages && (
@@ -387,16 +352,7 @@ SiteHeader.propTypes = {
   currentUser: PropTypes.object,
   isLeftSidebarExpanded: PropTypes.bool.isRequired,
   languageCode: PropTypes.string.isRequired,
-  navBarConfig: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string,
-      type: PropTypes.string.isRequired,
-      url: PropTypes.string,
-      start_page: PropTypes.bool,
-      name: PropTypes.string,
-      component: PropTypes.string,
-    }),
-  ),
+  navBarConfig: navBarConfigPropType,
   router: PropTypes.instanceOf(Backbone.Router),
   setLeftSidebarComponent: PropTypes.func.isRequired,
   setLeftSidebarExpanded: PropTypes.func.isRequired,

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1185,12 +1185,19 @@ export default (container, options) => {
       map.remove();
     },
 
-    removeLayer: layer => {
-      layer &&
-        layersCache[layer.id] &&
+    removeLayer: (layer, { clearCache = false }) => {
+      if (layer && layersCache[layer.id]) {
         layersCache[layer.id].forEach(mapboxLayer => {
           !!map.getLayer(mapboxLayer.id) && map.removeLayer(mapboxLayer.id);
         });
+        if (clearCache) {
+          delete layersCache[layer.id];
+          delete sourcesCache[layer.id];
+          if (map.getSource(layer.id)) {
+            map.removeSource(layer.id);
+          }
+        }
+      }
     },
 
     isLayerCached: layerId => {

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1185,18 +1185,11 @@ export default (container, options) => {
       map.remove();
     },
 
-    removeLayer: (layer, { clearCache = false } = {}) => {
+    removeLayer: layer => {
       if (layer && layersCache[layer.id]) {
         layersCache[layer.id].forEach(mapboxLayer => {
           !!map.getLayer(mapboxLayer.id) && map.removeLayer(mapboxLayer.id);
         });
-        if (clearCache) {
-          delete layersCache[layer.id];
-          delete sourcesCache[layer.id];
-          if (map.getSource(layer.id)) {
-            map.removeSource(layer.id);
-          }
-        }
       }
     },
 

--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -1185,7 +1185,7 @@ export default (container, options) => {
       map.remove();
     },
 
-    removeLayer: (layer, { clearCache = false }) => {
+    removeLayer: (layer, { clearCache = false } = {}) => {
       if (layer && layersCache[layer.id]) {
         layersCache[layer.id].forEach(mapboxLayer => {
           !!map.getLayer(mapboxLayer.id) && map.removeLayer(mapboxLayer.id);

--- a/src/base/static/state/ducks/filters.js
+++ b/src/base/static/state/ducks/filters.js
@@ -4,7 +4,6 @@ export const filtersSelector = state => {
   return state.filters;
 };
 
-// export const filtersPropType = PropTypes.arrayOf(PropTypes.string);
 export const filtersPropType = PropTypes.arrayOf(
   PropTypes.shape({
     formId: PropTypes.string,

--- a/src/base/static/state/ducks/filters.js
+++ b/src/base/static/state/ducks/filters.js
@@ -1,0 +1,32 @@
+import PropTypes from "prop-types";
+// Selectors:
+export const filtersSelector = state => {
+  return state.filters;
+};
+
+// export const filtersPropType = PropTypes.arrayOf(PropTypes.string);
+export const filtersPropType = PropTypes.arrayOf(
+  PropTypes.shape({
+    formId: PropTypes.string,
+    datasetId: PropTypes.string,
+  }),
+);
+
+// Actions:
+const UPDATE = "filters/UPDATE";
+
+// Action creators:
+export function updateFilters(filters) {
+  return { type: UPDATE, payload: filters };
+}
+
+const INITIAL_STATE = [];
+
+export default function reducer(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case UPDATE:
+      return action.payload;
+    default:
+      return state;
+  }
+}

--- a/src/base/static/state/ducks/nav-bar-config.js
+++ b/src/base/static/state/ducks/nav-bar-config.js
@@ -1,7 +1,19 @@
+import PropTypes from "prop-types";
 // Selectors:
 export const navBarConfigSelector = state => {
   return state.navBarConfig;
 };
+
+export const navBarConfigPropType = PropTypes.arrayOf(
+  PropTypes.shape({
+    title: PropTypes.string,
+    type: PropTypes.string.isRequired,
+    url: PropTypes.string,
+    start_page: PropTypes.bool,
+    name: PropTypes.string,
+    component: PropTypes.string,
+  }),
+);
 
 // Actions:
 const SET_CONFIG = "navBar/SET_CONFIG";

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -4,6 +4,20 @@ import PropTypes from "prop-types";
 export const placesSelector = state => {
   return state.places;
 };
+export const filteredPlacesSelector = state => {
+  const filters = state.filters;
+  if (!state.places || filters.length === 0) {
+    return state.places;
+  }
+  // a formId and a location_type are currenty equivalent
+  const filteredFormIds = filters.reduce((memo, filter) => {
+    memo.push(filter.formId);
+    return memo;
+  }, []);
+  return state.places.filter(place =>
+    filteredFormIds.includes(place.location_type),
+  );
+};
 
 export const placePropType = PropTypes.shape({
   attachments: PropTypes.array.isRequired,

--- a/src/base/static/state/reducers.js
+++ b/src/base/static/state/reducers.js
@@ -2,6 +2,7 @@ import { combineReducers } from "redux";
 import mapReducer from "./ducks/map";
 import placesReducer from "./ducks/places";
 import uiReducer from "./ducks/ui";
+import filters from "./ducks/filters";
 import leftSidebarReducer from "./ducks/left-sidebar";
 import mapDrawingToolbarReducer from "./ducks/map-drawing-toolbar";
 
@@ -21,6 +22,7 @@ const reducers = combineReducers({
   ui: uiReducer,
   leftSidebar: leftSidebarReducer,
   mapDrawingToolbar: mapDrawingToolbarReducer,
+  filters,
 
   appConfig: appConfigReducer,
   mapConfig: mapConfigReducer,

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -1252,7 +1252,7 @@
       "show_map_button_label": "_(Show on a map)"
     },
     {
-      "title": "_(Filters)",
+      "title": "_(Filter Ideas)",
       "enabled_label": "_(Filters Enabled)",
       "type": "filter"
     }

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -1250,6 +1250,11 @@
       "type": "list_toggle",
       "show_list_button_label": "_(Show as a list)",
       "show_map_button_label": "_(Show on a map)"
+    },
+    {
+      "title": "_(Filters)",
+      "enabled_label": "_(Filters Enabled)",
+      "type": "filter"
     }
   ],
   "pages": [

--- a/src/theme.js
+++ b/src/theme.js
@@ -91,6 +91,7 @@ const theme = {
   bg: {
     default: "#fff",
     light: "#a3c7d9",
+    highlighted: "#007fbf",
   },
   input: {
     border: "0.25em solid #a3c7d9",
@@ -101,6 +102,7 @@ const theme = {
   text: {
     primary: "#36454f",
     secondary: "#fff",
+    highlighted: "#fff",
     headerFontFamily: "Roboto,sans-serif",
     bodyFontFamily: "Roboto,sans-serif",
     textTransform: "uppercase",


### PR DESCRIPTION
This PR:
 * adds the ability to filter places by their place type category
 * adds a filter duck
 * removes unused LegacyImage atom
 * adds a `theme.text.highlighted` and a `theme.bg.highlighted` (best I could come up with - open to suggestions!)

I am also open to design suggestions on the new filter menu! 
The PR is up on the durham staging site

TODO: 
 - [x] add a hover state for a better UX
 - [x] add a "close" button in the top right of the modal (this should be default for all modals)