### PR TITLE
refasctor(GeocodingField): improve geocoding workflow and feedback

### DIFF
--- a/src/base/static/components/form-fields/types/geocoding-field.js
+++ b/src/base/static/components/form-fields/types/geocoding-field.js
@@ -21,9 +21,6 @@ class GeocodingField extends Component {
       isWithGeocodingError: false,
     };
     this.geocodingEngine = this.props.mapConfig.geocoding_engine || "MapQuest";
-    this.hint =
-      this.props.mapConfig.geocode_bounding_box ||
-      this.props.mapConfig.geocode_hint;
   }
 
   componentDidUpdate(prevProps) {
@@ -37,31 +34,36 @@ class GeocodingField extends Component {
       isGeocoding: true,
       isWithGeocodingError: false,
     });
-    let address = this.props.value;
+    const address = this.props.value;
 
-    Util[this.geocodingEngine].geocode(address, this.hint, {
-      success: data => {
-        let locationsData = data.results[0].locations;
-        if (locationsData.length > 0) {
-          this.setState({
-            isGeocoding: false,
-            isWithGeocodingError: false,
-          });
-          emitter.emit("geocode", locationsData[0]);
-        } else {
+    Util[this.geocodingEngine].geocode({
+      location: address,
+      hint: this.props.mapConfig.geocode_hint,
+      bbox: this.props.mapConfig.geocode_bounding_box,
+      options: {
+        success: data => {
+          const locationsData = data.results[0] && data.results[0].locations;
+          if (locationsData && locationsData.length > 0) {
+            this.setState({
+              isGeocoding: false,
+              isWithGeocodingError: false,
+            });
+            emitter.emit("geocode", locationsData[0]);
+          } else {
+            this.setState({
+              isGeocoding: false,
+              isWithGeocodingError: true,
+            });
+          }
+        },
+        error: () => {
           this.setState({
             isGeocoding: false,
             isWithGeocodingError: true,
           });
-        }
-      },
-      error: () => {
-        this.setState({
-          isGeocoding: false,
-          isWithGeocodingError: true,
-        });
-        // eslint-disable-next-line no-console
-        console.error("There was an error while geocoding: ", arguments);
+          // eslint-disable-next-line no-console
+          console.error("There was an error while geocoding: ", arguments);
+        },
       },
     });
   }
@@ -81,11 +83,13 @@ class GeocodingField extends Component {
         <input
           className="geocoding-field__input"
           name={this.props.name}
+          tabIndex="-1"
           type="text"
           placeholder={this.props.placeholder}
           value={this.props.value}
           onBlur={this.doGeocode.bind(this)}
-          onChange={e => this.props.onChange(e.target.name, e.target.value)}
+          onKeyDown={e => this.props.onKeyDown(e)}
+          onChange={e => this.props.onChange(e.target.name, e.target.value, e)}
         />
         <div
           className={classNames("geocoding-field__geocoding-error", {
@@ -93,7 +97,7 @@ class GeocodingField extends Component {
               .isWithGeocodingError,
           })}
         >
-          {this.props.t("fields:geocodingField:locationNotFoundError")}
+          {this.props.t("locationNotFoundError")}
         </div>
       </div>
     );
@@ -104,6 +108,7 @@ GeocodingField.propTypes = {
   mapConfig: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  onKeyDown: PropTypes.func,
   placeholder: PropTypes.string,
   t: PropTypes.func.isRequired,
   isTriggeringGeocode: PropTypes.bool,

--- a/src/base/static/components/form-fields/types/geocoding-field.scss
+++ b/src/base/static/components/form-fields/types/geocoding-field.scss
@@ -18,6 +18,10 @@
   box-shadow: $geocoding-field-error-box-shadow;
 }
 
+.geocoding-field__geocoding-error--visible {
+  display: block;
+}
+
 .geocoding-field__input {
   width: $geocoding-field-width;
   border: $geocoding-field-border;

--- a/src/base/static/components/geocode-address-bar/index.js
+++ b/src/base/static/components/geocode-address-bar/index.js
@@ -17,11 +17,19 @@ class GeocodeAddressBar extends Component {
     };
   }
 
-  onChange(fieldName, fieldValue) {
+  onChange(fieldName, fieldValue, evt) {
     this.setState({
       value: fieldValue,
       isTriggeringGeocode: false,
     });
+  }
+
+  onKeyDown(evt) {
+    if (evt.key === "Tab") {
+      // Prevent the default field-switching behavior of a Tab press here
+      // because it screws up the UI.
+      evt.preventDefault();
+    }
   }
 
   onSubmit(evt) {
@@ -36,6 +44,7 @@ class GeocodeAddressBar extends Component {
       <form className="geocode-address-bar" onSubmit={this.onSubmit.bind(this)}>
         <GeocodingField
           mapConfig={this.props.mapConfig}
+          onKeyDown={this.onKeyDown}
           onChange={this.onChange.bind(this)}
           name="geocode-address-bar"
           placeholder={this.props.t("placeholderMsg")}

--- a/src/base/static/js/utils.js
+++ b/src/base/static/js/utils.js
@@ -758,7 +758,7 @@ var self = (module.exports = {
       return data;
     },
 
-    geocode: function(location, hint, options) {
+    geocode: function({ location, hint, bbox, options }) {
       var mapboxToken = Shareabouts.bootstrapped.mapboxToken,
         originalSuccess = options && options.success,
         transformedResultsSuccess = function(data) {
@@ -781,6 +781,9 @@ var self = (module.exports = {
         mapboxToken;
       if (hint) {
         options.url += "&proximity=" + hint.join(",");
+      }
+      if (bbox) {
+        options.url += "&bbox=" + bbox.join(",");
       }
       options.success = transformedResultsSuccess;
       $.ajax(options);

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -48,6 +48,7 @@
     "geocoding_engine": "Mapbox",
     "geocode_field_label": "_(Enter an address...)",
     "geocode_hint": [-78.906412, 35.9954801],
+    "geocode_bounding_box": [-79.09479, 35.865179, -78.78392, 36.119792],
     "options": {
       "map": {
         "center": {
@@ -286,7 +287,7 @@
             ],
             "symbol-layout": {
               "icon-image": "fountain-small.png",
-              "icon-size": 0.5,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           },
@@ -298,7 +299,7 @@
             ],
             "symbol-layout": {
               "icon-image": "fountain.png",
-              "icon-size": 0.6,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           },
@@ -323,7 +324,7 @@
             ],
             "symbol-layout": {
               "icon-image": "safety-small.png",
-              "icon-size": 0.5,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           },
@@ -335,7 +336,7 @@
             ],
             "symbol-layout": {
               "icon-image": "safety.png",
-              "icon-size": 0.6,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           },
@@ -359,7 +360,7 @@
               ["<", ["zoom"], 13]
             ],
             "symbol-layout": {
-              "icon-size": 0.5,
+              "icon-size": 0.4,
               "icon-image": "tree-small.png",
               "icon-anchor": "bottom"
             }
@@ -372,7 +373,7 @@
             ],
             "symbol-layout": {
               "icon-image": "tree.png",
-              "icon-size": 0.6,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           },
@@ -396,7 +397,7 @@
               ["<", ["zoom"], 13]
             ],
             "symbol-layout": {
-              "icon-size": 0.5,
+              "icon-size": 0.4,
               "icon-image": "health-small.png",
               "icon-anchor": "bottom"
             }
@@ -409,7 +410,7 @@
             ],
             "symbol-layout": {
               "icon-image": "health.png",
-              "icon-size": 0.6,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           },
@@ -433,7 +434,7 @@
               ["<", ["zoom"], 13]
             ],
             "symbol-layout": {
-              "icon-size": 0.5,
+              "icon-size": 0.4,
               "icon-image": "street-sidewalk-small.png",
               "icon-anchor": "bottom"
             }
@@ -446,7 +447,7 @@
             ],
             "symbol-layout": {
               "icon-image": "street-sidewalk.png",
-              "icon-size": 0.6,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           },
@@ -470,7 +471,7 @@
               ["<", ["zoom"], 13]
             ],
             "symbol-layout": {
-              "icon-size": 0.5,
+              "icon-size": 0.4,
               "icon-image": "idea-small.png",
               "icon-anchor": "bottom"
             }
@@ -483,7 +484,7 @@
             ],
             "symbol-layout": {
               "icon-image": "idea.png",
-              "icon-size": 0.6,
+              "icon-size": 0.4,
               "icon-anchor": "bottom"
             }
           }

--- a/src/locales/es/GeocodingField.json
+++ b/src/locales/es/GeocodingField.json
@@ -1,0 +1,3 @@
+{
+  "locationNotFoundError": "Lo sentimos, no pudimos encontrar esa ubicación."
+}


### PR DESCRIPTION
This PR does several things to improve the geocoding workflow:

* adds a geocode bounding box to the `pbdurham` flavor to improve geocoding accuracy
* fixes an apparent bug where using a geocode bounding box and hint together doesn't work
* fixes an issue with tab-switching out of the geocode address field
* restores the geocode address field error feedback, which apparently wasn't working before

This PR also tweaks `pbdurham` icon sizes.