### PR TITLE
feat(Dashboard): render timeline using the flavor's timezone

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,6 @@
     "Handlebars": false,
     "Shareabouts": false,
     "MAP_PROVIDER_TOKEN": false,
-    "moment": false,
     "L": false,
     "ga": false
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5650,7 +5650,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6065,7 +6066,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6121,6 +6123,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6164,12 +6167,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10105,6 +10105,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
+    "moment-timezone": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
+      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "moo": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lodash.groupby": "^4.6.0",
     "mapbox-gl": "^0.51.0",
     "moment": "^2.20.1",
+    "moment-timezone": "^0.5.23",
     "node-env-file": "^0.1.7",
     "node-sass": "^4.0.0",
     "npm": "^6.4.1",

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -34,6 +34,17 @@ module.exports = function(source) {
     }
   });
 
+  // set the default values for our config:
+
+  // `show_timestamps`:
+  if (!config.app.hasOwnProperty("show_timestamps")) {
+    config.app.show_timestamps = true;
+  }
+  // `time_zone`:
+  if (!config.app.time_zone) {
+    config.app.time_zone = "America/Los_Angeles";
+  }
+
   // If we have dataset urls defined in the .env file, overwrite the default
   // urls found in the config here.
   config.map.layers.forEach((layer, i) => {

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -3,10 +3,11 @@ const Handlebars = require("handlebars");
 const fs = require("fs-extra");
 const path = require("path");
 
-const transformCommonFormElements = require("../src/base/static/utils/config-loader-utils")
-  .transformCommonFormElements;
-const transformStoryContent = require("../src/base/static/utils/config-loader-utils")
-  .transformStoryContent;
+const {
+  setConfigDefaults,
+  transformCommonFormElements,
+  transformStoryContent,
+} = require("../src/base/static/utils/config-loader-utils");
 
 // This loader is used to listen to changes in the config file during development.
 // Any config changes will be detected and the config (but not the rest of the
@@ -34,16 +35,7 @@ module.exports = function(source) {
     }
   });
 
-  // set the default values for our config:
-
-  // `show_timestamps`:
-  if (!config.app.hasOwnProperty("show_timestamps")) {
-    config.app.show_timestamps = true;
-  }
-  // `time_zone`:
-  if (!config.app.time_zone) {
-    config.app.time_zone = "America/Los_Angeles";
-  }
+  setConfigDefaults(config);
 
   // If we have dataset urls defined in the .env file, overwrite the default
   // urls found in the config here.

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -104,6 +104,17 @@ Handlebars.registerHelper("serialize", function(json) {
 const flavorConfigPath = path.resolve(flavorBasePath, "config.json");
 const config = JSON.parse(fs.readFileSync(flavorConfigPath, "utf8"));
 
+// set the default values for our config:
+
+// `show_timestamps`:
+if (!config.app.hasOwnProperty("show_timestamps")) {
+  config.app.show_timestamps = true;
+}
+// `time_zone`:
+if (!config.app.time_zone) {
+  config.app.time_zone = "America/Los_Angeles";
+}
+
 // (4) Compile base.hbs template
 // -----------------------------------------------------------------------------
 

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -12,10 +12,11 @@ const Spritesmith = require("spritesmith");
 const shell = require("shelljs");
 const zlib = require("zlib");
 
-const transformCommonFormElements = require("../src/base/static/utils/config-loader-utils")
-  .transformCommonFormElements;
-const transformStoryContent = require("../src/base/static/utils/config-loader-utils")
-  .transformStoryContent;
+const {
+  setConfigDefaults,
+  transformCommonFormElements,
+  transformStoryContent,
+} = require("../src/base/static/utils/config-loader-utils");
 
 // =============================================================================
 // BEGIN STATIC SITE BUILD
@@ -104,16 +105,7 @@ Handlebars.registerHelper("serialize", function(json) {
 const flavorConfigPath = path.resolve(flavorBasePath, "config.json");
 const config = JSON.parse(fs.readFileSync(flavorConfigPath, "utf8"));
 
-// set the default values for our config:
-
-// `show_timestamps`:
-if (!config.app.hasOwnProperty("show_timestamps")) {
-  config.app.show_timestamps = true;
-}
-// `time_zone`:
-if (!config.app.time_zone) {
-  config.app.time_zone = "America/Los_Angeles";
-}
+setConfigDefaults(config);
 
 // (4) Compile base.hbs template
 // -----------------------------------------------------------------------------

--- a/src/base/static/components/molecules/place-list-item.js
+++ b/src/base/static/components/molecules/place-list-item.js
@@ -12,7 +12,10 @@ import {
 } from "../../state/ducks/place-config";
 import { placePropType } from "../../state/ducks/places";
 import { supportConfigSelector } from "../../state/ducks/support-config";
-import { appConfigSelector } from "../../state/ducks/app-config";
+import {
+  appConfigSelector,
+  appConfigPropType,
+} from "../../state/ducks/app-config";
 import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import { HorizontalRule } from "../atoms/layout";
@@ -259,11 +262,7 @@ PlaceListItem.propTypes = {
     action_text: PropTypes.string.isRequired,
   }),
   placeConfig: placeConfigPropType.isRequired,
-  appConfig: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    meta_description: PropTypes.string.isRequired,
-    thumbnail: PropTypes.string,
-  }),
+  appConfig: appConfigPropType.isRequired,
   onLoad: PropTypes.func.isRequired,
   router: PropTypes.instanceOf(Backbone.Router).isRequired,
 };

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -16,7 +16,10 @@ import {
   navBarConfigSelector,
 } from "../../state/ducks/nav-bar-config";
 import FilterMenu from "./filter-menu";
-import { appConfigSelector } from "../../state/ducks/app-config";
+import {
+  appConfigSelector,
+  appConfigPropType,
+} from "../../state/ducks/app-config";
 import { mapConfigSelector } from "../../state/ducks/map-config";
 import {
   dashboardConfigSelector,
@@ -352,19 +355,7 @@ class SiteHeader extends Component {
 }
 
 SiteHeader.propTypes = {
-  appConfig: PropTypes.shape({
-    api_root: PropTypes.string.isRequired,
-    dataset_download: PropTypes.object,
-    name: PropTypes.string,
-    languages: PropTypes.arrayOf(
-      PropTypes.shape({
-        code: PropTypes.string.isRequired,
-        label: PropTypes.string.isRequired,
-      }),
-    ),
-    logo: PropTypes.string,
-    show_name_in_header: PropTypes.bool,
-  }).isRequired,
+  appConfig: appConfigPropType.isRequired,
   currentTemplate: PropTypes.string.isRequired,
   currentUser: PropTypes.object,
   isLeftSidebarExpanded: PropTypes.bool.isRequired,

--- a/src/base/static/components/place-detail/metadata-bar.js
+++ b/src/base/static/components/place-detail/metadata-bar.js
@@ -14,7 +14,10 @@ import {
   commentFormConfigPropType,
   commentFormConfigSelector,
 } from "../../state/ducks/forms-config";
-import { appConfigSelector } from "../../state/ducks/app-config";
+import {
+  appConfigSelector,
+  appConfigPropType,
+} from "../../state/ducks/app-config";
 
 const MetadataBarContainer = styled("div")(props => ({
   fontFamily: props.theme.text.bodyFontFamily,
@@ -59,7 +62,7 @@ const MetadataBar = props => {
             ? props.commentFormConfig.response_name
             : props.commentFormConfig.response_plural_name}
         </SmallText>
-        {props.appConfig.show_timestamps !== false && (
+        {props.appConfig.show_timestamps && (
           <SmallText display="block" textTransform="uppercase">
             <Time
               time={props.placeModel.get(
@@ -74,7 +77,7 @@ const MetadataBar = props => {
 };
 
 MetadataBar.propTypes = {
-  appConfig: PropTypes.object.isRequired,
+  appConfig: appConfigPropType.isRequired,
   avatarSrc: PropTypes.string,
   placeConfig: PropTypes.object.isRequired,
   placeModel: PropTypes.object.isRequired,

--- a/src/base/static/components/place-detail/survey-response-editor.js
+++ b/src/base/static/components/place-detail/survey-response-editor.js
@@ -18,7 +18,10 @@ import {
   commentFormConfigSelector,
 } from "../../state/ducks/forms-config";
 import { placeConfigSelector } from "../../state/ducks/place-config";
-import { appConfigSelector } from "../../state/ducks/app-config";
+import {
+  appConfigSelector,
+  appConfigPropType,
+} from "../../state/ducks/app-config";
 
 import "./survey-response-editor.scss";
 
@@ -137,7 +140,7 @@ class SurveyResponseEditor extends Component {
               submitter={this.props.submitter}
               anonymousName={this.props.placeConfig.anonymous_name}
             />
-            {this.props.appConfig.show_timestamps !== false && (
+            {this.props.appConfig.show_timestamps && (
               <SmallText display="block" textTransform="uppercase">
                 <Time
                   time={this.props.attributes.get(
@@ -154,7 +157,7 @@ class SurveyResponseEditor extends Component {
 }
 
 SurveyResponseEditor.propTypes = {
-  appConfig: PropTypes.object.isRequired,
+  appConfig: appConfigPropType.isRequired,
   attributes: PropTypes.object,
   isSubmitting: PropTypes.bool.isRequired,
   modelId: PropTypes.number.isRequired,

--- a/src/base/static/components/place-detail/survey-response.js
+++ b/src/base/static/components/place-detail/survey-response.js
@@ -12,7 +12,10 @@ import {
   commentFormConfigSelector,
 } from "../../state/ducks/forms-config";
 import { placeConfigSelector } from "../../state/ducks/place-config";
-import { appConfigSelector } from "../../state/ducks/app-config";
+import {
+  appConfigSelector,
+  appConfigPropType,
+} from "../../state/ducks/app-config";
 
 import "./survey-response.scss";
 
@@ -62,7 +65,7 @@ class SurveyResponse extends Component {
               }
               anonymousName={this.props.placeConfig.anonymous_name}
             />
-            {this.props.appConfig.show_timestamps !== false && (
+            {this.props.appConfig.show_timestamps && (
               <SmallText display="block" textTransform="uppercase">
                 <Time
                   time={this.props.attributes.get(
@@ -79,7 +82,7 @@ class SurveyResponse extends Component {
 }
 
 SurveyResponse.propTypes = {
-  appConfig: PropTypes.object.isRequired,
+  appConfig: appConfigPropType.isRequired,
   attributes: PropTypes.object.isRequired,
   modelId: PropTypes.number.isRequired,
   onMountTargetResponse: PropTypes.func.isRequired,

--- a/src/base/static/components/place-detail/survey.js
+++ b/src/base/static/components/place-detail/survey.js
@@ -5,7 +5,6 @@ import emitter from "../../utils/emitter";
 import { connect } from "react-redux";
 
 import FormField from "../form-fields/form-field";
-import SecondaryButton from "../ui-elements/secondary-button";
 import SurveyResponse from "./survey-response";
 import WarningMessagesContainer from "../ui-elements/warning-messages-container";
 import Avatar from "../ui-elements/avatar";
@@ -15,7 +14,10 @@ import {
   commentFormConfigPropType,
   commentFormConfigSelector,
 } from "../../state/ducks/forms-config";
-import { appConfigSelector } from "../../state/ducks/app-config";
+import {
+  appConfigSelector,
+  appConfigPropType,
+} from "../../state/ducks/app-config";
 
 import constants from "../../constants";
 import { translate } from "react-i18next";
@@ -213,9 +215,7 @@ class Survey extends Component {
 }
 
 Survey.propTypes = {
-  appConfig: PropTypes.shape({
-    api_root: PropTypes.string.isRequired,
-  }).isRequired,
+  appConfig: appConfigPropType.isRequired,
   getLoggingDetails: PropTypes.func.isRequired,
   isEditModeToggled: PropTypes.bool.isRequired,
   isSubmitting: PropTypes.bool.isRequired,

--- a/src/base/static/state/ducks/app-config.js
+++ b/src/base/static/state/ducks/app-config.js
@@ -1,7 +1,26 @@
+import PropTypes from "prop-types";
 // Selectors:
 export const appConfigSelector = state => {
   return state.appConfig;
 };
+
+export const appConfigPropType = PropTypes.shape({
+  title: PropTypes.string.isRequired,
+  meta_description: PropTypes.string.isRequired,
+  thumbnail: PropTypes.string,
+  api_root: PropTypes.string.isRequired,
+  dataset_download: PropTypes.object,
+  name: PropTypes.string,
+  time_zone: PropTypes.string.isRequired,
+  languages: PropTypes.arrayOf(
+    PropTypes.shape({
+      code: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ),
+  logo: PropTypes.string,
+  show_name_in_header: PropTypes.bool,
+});
 
 // Actions:
 const SET_CONFIG = "app/SET_CONFIG";

--- a/src/base/static/utils/config-loader-utils.js
+++ b/src/base/static/utils/config-loader-utils.js
@@ -52,7 +52,21 @@ const transformCommonFormElements = (placeDetail, commonFormElements) => {
   });
 };
 
+const setConfigDefaults = config => {
+  // set the default values for our config:
+
+  // `show_timestamps`:
+  if (!config.app.hasOwnProperty("show_timestamps")) {
+    config.app.show_timestamps = true;
+  }
+  // `time_zone`:
+  if (!config.app.time_zone) {
+    config.app.time_zone = "America/Los_Angeles";
+  }
+};
+
 module.exports = {
   transformStoryContent,
   transformCommonFormElements,
+  setConfigDefaults,
 };

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -5,6 +5,7 @@
     "logo": "/static/css/images/pbdurham-logo-large.png",
     "meta_description": "_(Participatory Budgeting for City of Durham)",
     "api_root": "https://dev-api.heyduwamish.org/api/v2/",
+    "time_zone": "America/New_York",
     "theme": {
       "bg": {
         "default": "#d6d5d9",


### PR DESCRIPTION
This PR renders the dashboard's timeline using the app's timezone. Previously, we've been rendering the dashboard's timeline according to the user's timezone. This isn't ideal because the chart should look the same regardless of the timezone that you are viewing the website from.

Changes are staged on snohomish and durham master.

This PR also includes some refactoring:
 - Moved the AppConfig prop type into the AppConfig duck. (previously, we've been spreading the prop types across all of the components)
 - Refactor config loader to set default config values if they aren't declared.