### PR TITLE
refactor(RichTextareaField): restore fluid video dimensions

### DIFF
--- a/src/base/static/components/form-fields/types/rich-textarea-field.js
+++ b/src/base/static/components/form-fields/types/rich-textarea-field.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactQuill, { Quill } from "react-quill";
 import classNames from "classnames";
+const BlockEmbed = Quill.import("blots/block/embed");
 const Embed = Quill.import("blots/embed");
 const SnowTheme = Quill.import("themes/snow");
 const Link = Quill.import("formats/link");
@@ -40,6 +41,30 @@ const getRandomName = () => {
     .toString(36)
     .substring(7);
 };
+
+class WrappedVideo extends BlockEmbed {
+  static create(url) {
+    let node = super.create();
+    node.style =
+      "position: relative; padding-bottom: 56.25%; padding-top: 0; height: 0; overflow: hidden;";
+
+    const iframe = document.createElement("iframe");
+
+    url = Link.sanitize(extractVideoUrl(url));
+    iframe.setAttribute("src", url);
+    iframe.setAttribute("frameborder", 0);
+    iframe.setAttribute("allowfullscreen", true);
+    iframe.style =
+      "position: absolute; top: 0; left: 0; width: 100%; height: 100%;";
+    iframe.className = "ql-video";
+    node.appendChild(iframe);
+
+    return node;
+  }
+}
+WrappedVideo.blotName = "wrappedVideo";
+WrappedVideo.tagName = "DIV";
+Quill.register(WrappedVideo);
 
 let onAddAttachment;
 class ImageWithName extends Embed {


### PR DESCRIPTION
In recent testing video embeds are not adopting the proper dimensions and are rendering letterboxed. We used to have some code that worked around this, but we took it out for a reason that I can't remember. 

This PR restores the feature that wraps video embeds in some CSS so they maximize their size and don't appear letterboxed.

See here for an explanation of how this feature works: https://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php