### PR TITLE
Allow for non-English default languages

### DIFF
--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -11,7 +11,7 @@ const {
 
 // This loader is used to listen to changes in the config file during development.
 // Any config changes will be detected and the config (but not the rest of the
-// static site) will be rebuilt. This loader only rebuilds the English version
+// static site) will be rebuilt. This loader only rebuilds the primary language version
 // of the config; to test other languages in development it will be necessary
 // to produce a full production build:
 //   npm run build
@@ -81,10 +81,10 @@ module.exports = function(source) {
   const template = Handlebars.compile(templateSource);
   const outputFile = template({
     config: config,
-    languageCode: "en_US",
+    languageCode: config.app.languages ? config.app.languages[0].code : "en_US",
   });
 
-  const outputPath = path.resolve(__dirname, "../www/config-en_US.js");
+  const outputPath = path.resolve(__dirname, "../www/config.js");
   try {
     fs.writeFileSync(outputPath, outputFile);
   } catch (e) {

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -131,7 +131,9 @@ if (isProd) {
     ? config.app.languages
     : [{ code: "en_US" }];
 } else {
-  activeLanguages = [{ code: "en_US" }];
+  activeLanguages = config.app.languages
+    ? [config.app.languages[0]]
+    : [{ code: "en_US" }];
 }
 
 // NOTE: We use [\s\S] here instead of . so we can match newlines.
@@ -143,7 +145,7 @@ let thisConfig, flavorPOPath, mergedPOFile, outputIndexFilename;
 
 // Loop over all languages defined in a given flavor's config file and
 // generate fully localized output.
-activeLanguages.forEach(language => {
+activeLanguages.forEach((language, langNum) => {
   // Quick and dirty config clone
   thisConfig = JSON.parse(JSON.stringify(config));
   flavorPOPath = path.resolve(
@@ -253,7 +255,7 @@ activeLanguages.forEach(language => {
   // Write out final xx.html file
   outputIndexFilename = path.resolve(
     outputPath,
-    (language.code == "en_US" ? "index" : language.code) + ".html",
+    (langNum === 0 ? "index" : language.code) + ".html",
   );
 
   if (isProd) {

--- a/scripts/static-build.js
+++ b/scripts/static-build.js
@@ -118,6 +118,13 @@ const indexTemplate = Handlebars.compile(source);
 
 // (5) Localize the config for each language for the current flavor, precompile
 //     and inject all localized content into the index-xx.html file
+//     We make the following assumptions about flavor languages:
+//       1. If a flavor declares no languages, we build a single index.html
+//          file in English.
+//       2. If a flavor declares languages, we assume the first language listed
+//          is the default language. This language will load with the main
+//          index.html file. Other languages will be built in index-xx.html
+//          format, where xx represents the language code.
 // -----------------------------------------------------------------------------
 
 // Constants and variables to use inside the localization loop below

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -258,6 +258,7 @@ class SiteHeader extends Component {
   };
 
   render() {
+    console.log("this.props.languageCode", this.props.languageCode);
     return (
       <SiteHeaderWrapper>
         <LogoTitleWrapper
@@ -306,41 +307,42 @@ class SiteHeader extends Component {
           })}
         </NavContainer>
         <RightAlignedContainer isHeaderExpanded={this.state.isHeaderExpanded}>
-          {this.props.appConfig.languages && (
-            <LanguagePicker
-              onMouseOver={() =>
-                this.setState({
-                  isLanguageMenuVisible: true,
-                })
-              }
-              onMouseOut={() =>
-                this.setState({
-                  isLanguageMenuVisible: false,
-                })
-              }
-            >
-              {
-                this.props.appConfig.languages.find(
-                  language => language.code === this.props.languageCode,
-                ).label
-              }{" "}
-              ⌄
-              <LanguagePickerMenu
-                isLanguageMenuVisible={this.state.isLanguageMenuVisible}
+          {this.props.appConfig.languages &&
+            this.props.appConfig.languages.length > 1 && (
+              <LanguagePicker
+                onMouseOver={() =>
+                  this.setState({
+                    isLanguageMenuVisible: true,
+                  })
+                }
+                onMouseOut={() =>
+                  this.setState({
+                    isLanguageMenuVisible: false,
+                  })
+                }
               >
-                {this.props.appConfig.languages.map(language => (
-                  <LanguageLink
-                    key={language.code}
-                    href={`/${language.code}.html`}
-                  >
-                    <LanguagePickerMenuItem>
-                      <RegularLabel>{language.label}</RegularLabel>
-                    </LanguagePickerMenuItem>
-                  </LanguageLink>
-                ))}
-              </LanguagePickerMenu>
-            </LanguagePicker>
-          )}
+                {
+                  this.props.appConfig.languages.find(
+                    language => language.code === this.props.languageCode,
+                  ).label
+                }{" "}
+                ⌄
+                <LanguagePickerMenu
+                  isLanguageMenuVisible={this.state.isLanguageMenuVisible}
+                >
+                  {this.props.appConfig.languages.map(language => (
+                    <LanguageLink
+                      key={language.code}
+                      href={`/${language.code}.html`}
+                    >
+                      <LanguagePickerMenuItem>
+                        <RegularLabel>{language.label}</RegularLabel>
+                      </LanguagePickerMenuItem>
+                    </LanguageLink>
+                  ))}
+                </LanguagePickerMenu>
+              </LanguagePicker>
+            )}
           <UserMenu
             router={this.props.router}
             apiRoot={this.props.appConfig.api_root}

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -258,7 +258,6 @@ class SiteHeader extends Component {
   };
 
   render() {
-    console.log("this.props.languageCode", this.props.languageCode);
     return (
       <SiteHeaderWrapper>
         <LogoTitleWrapper

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -186,7 +186,7 @@
       }(Shareabouts, jQuery));
     </script>
   {{else}}
-    <script src="/config-en_US.js" type="text/javascript"></script>
+    <script src="/config.js" type="text/javascript"></script>
   {{/if}}
 
   {{#if settings.googleAnalyticsId}}

--- a/src/flavors/argentina/config.json
+++ b/src/flavors/argentina/config.json
@@ -20,7 +20,13 @@
         "titleFontFamily": "Roboto, sans-serif",
         "titleColor": "#ffffff"
       }
-    }
+    },
+    "languages": [
+      {
+        "code": "es",
+        "label": "Hablo Español"
+      }
+    ]
   },
   "map": {
     "geolocation_enabled": true,
@@ -814,7 +820,7 @@
       "order": [
         {
           "url": "featured/5343",
-          "pan_to": [-60.50, -32.35],
+          "pan_to": [-60.5, -32.35],
           "zoom": 10
         },
         {
@@ -844,7 +850,7 @@
           "visible_layers": ["presencia-agua"],
           "spotlight": false,
           "basemap": "osm"
-}
+        }
       ]
     }
   }

--- a/src/flavors/bogtobay/config.json
+++ b/src/flavors/bogtobay/config.json
@@ -6,16 +6,6 @@
     "meta_author": "SmarterCleanup.org",
     "api_root": "https://dev-api.heyduwamish.org/api/v2/"
   },
-  "languages": [
-    {
-      "code": "es",
-      "label": "Hablo Español"
-    },
-    {
-      "code": "en_US",
-      "label": "I Speak English"
-    }
-  ],
   "map": {
     "geolocation_enabled": true,
     "geolocation_onload": false,

--- a/src/flavors/central-puget-sound/config.json
+++ b/src/flavors/central-puget-sound/config.json
@@ -22,16 +22,6 @@
       }
     }
   },
-  "languages": [
-    {
-      "code": "es",
-      "label": "Hablo Español"
-    },
-    {
-      "code": "en_US",
-      "label": "I Speak English"
-    }
-  ],
   "map": {
     "geolocation_enabled": true,
     "options": {

--- a/src/flavors/pboakland/config.json
+++ b/src/flavors/pboakland/config.json
@@ -18,16 +18,16 @@
   },
   "languages": [
     {
+      "code": "en_US",
+      "label": "I Speak English"
+    },
+    {
       "code": "es",
       "label": "Hablo Español"
     },
     {
       "code": "zh_Hant",
       "label": "我讲中文"
-    },
-    {
-      "code": "en_US",
-      "label": "I Speak English"
     }
   ],
   "map": {

--- a/src/flavors/raingardens/config.json
+++ b/src/flavors/raingardens/config.json
@@ -7,7 +7,6 @@
     "meta_author": "SmarterCleanup.org",
     "api_root": "https://dev-api.heyduwamish.org/api/v2/"
   },
-  "languages": null,
   "map": {
     "geolocation_enabled": true,
     "geolocation_onload": false,


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/200

We make the following assumptions about flavor languages in the config:
1. If a flavor declares no languages, we build a single `index.html` file in English.
2. If a flavor declares languages, we assume the first language listed is the default language. This language will load with the main `index.html` file. Other languages will be built in `index-xx.html` format, where `xx` represents the language code.