### PR TITLE
Goldpbear/form group permissions

### DIFF
--- a/build-utils/config-template.hbs
+++ b/build-utils/config-template.hbs
@@ -23,7 +23,8 @@
     dashboard:        {{#serialize config.dashboard}}{{/serialize}},
     languageCode:    {{#serialize languageCode}}{{/serialize}},
     customHooks:     {{#serialize config.custom_hooks}}{{/serialize}},
-    customComponents:{{#serialize config.custom_components}}{{/serialize}}
+    customComponents:{{#serialize config.custom_components}}{{/serialize}},
+    datasets:        {{#serialize config.datasets}}{{/serialize}}
   };
 
   $(function() {
@@ -51,6 +52,7 @@
       languageCode: S.Config.languageCode,
       customHooks: S.Config.customHooks,
       customComponents: S.Config.customComponents,
+      datasetsConfig: S.Config.datasets,
       languageCode: "{{ languageCode }}"
     });
   });

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -106,6 +106,7 @@ Shareabouts.Util = Util;
         languageCode: options.languageCode,
         customHooks: options.customHooks,
         customComponents: options.customComponents,
+        datasetsConfig: options.datasetsConfig,
       });
 
       // Start tracking the history

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -58,6 +58,7 @@ import {
   geocodeAddressBarVisibilitySelector,
 } from "../../state/ducks/ui.js";
 import { loadUser, userSelector } from "../../state/ducks/user";
+import { loadDatasetsConfig } from "../../state/ducks/datasets-config";
 
 const Dashboard = lazy(() => import("../../components/templates/dashboard"));
 
@@ -106,6 +107,7 @@ export default Backbone.View.extend({
     // TODO(luke): move this into "componentDidMount" when App becomes a
     // component:
     store.dispatch(loadUser(Shareabouts.bootstrapped.currentUser));
+    store.dispatch(loadDatasetsConfig(this.options.datasetsConfig));
     store.dispatch(setMapConfig(this.options.mapConfig));
     store.dispatch(
       setPlaceConfig(this.options.placeConfig, userSelector(store.getState())),

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -57,6 +57,7 @@ import {
   setGeocodeAddressBarVisibility,
   geocodeAddressBarVisibilitySelector,
 } from "../../state/ducks/ui.js";
+import { loadUser, userSelector } from "../../state/ducks/user";
 
 const Dashboard = lazy(() => import("../../components/templates/dashboard"));
 
@@ -104,8 +105,11 @@ export default Backbone.View.extend({
   initialize: function() {
     // TODO(luke): move this into "componentDidMount" when App becomes a
     // component:
+    store.dispatch(loadUser(Shareabouts.bootstrapped.currentUser));
     store.dispatch(setMapConfig(this.options.mapConfig));
-    store.dispatch(setPlaceConfig(this.options.placeConfig));
+    store.dispatch(
+      setPlaceConfig(this.options.placeConfig, userSelector(store.getState())),
+    );
     store.dispatch(setLeftSidebarConfig(this.options.leftSidebarConfig));
     store.dispatch(setRightSidebarConfig(this.options.rightSidebarConfig));
     store.dispatch(setStoryConfig(this.options.storyConfig));

--- a/src/base/static/state/ducks/datasets-config.js
+++ b/src/base/static/state/ducks/datasets-config.js
@@ -1,0 +1,28 @@
+// Selectors:
+export const datasetSelector = (state, id) => {
+  return state.datasetConfigs.filter(datasetConfig => datasetConfig.id === id);
+};
+
+// Actions:
+const LOAD = "user/LOAD";
+
+// Action creators:
+export function loadDatasetsConfig(datasetsConfig) {
+  return { type: LOAD, payload: datasetsConfig };
+}
+
+// Reducers:
+// TODO(luke): refactor our current implementation in AppView to use
+const INITIAL_STATE = null;
+
+export default function reducer(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case LOAD:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/base/static/state/ducks/place-config.js
+++ b/src/base/static/state/ducks/place-config.js
@@ -1,5 +1,7 @@
 import PropTypes from "prop-types";
 
+import { userSelector } from "./user";
+
 // Selectors:
 export const placeConfigSelector = state => {
   return state.placeConfig;
@@ -26,11 +28,40 @@ export const placeConfigPropType = PropTypes.shape({
 });
 
 // Actions:
-const SET_CONFIG = "place-config/SET";
+const LOAD = "place-config/LOAD";
 
 // Action creators:
-export function setPlaceConfig(config) {
-  return { type: SET_CONFIG, payload: config };
+export function setPlaceConfig(config, user) {
+  config.place_detail = config.place_detail.map(category => {
+    category.fields = category.fields.map(field => {
+      if (!field.admin_groups) {
+        // If a form field declares no admin group, assume it should be visible
+        // to all users.
+        field.isVisible = true;
+      } else {
+        // Otherwise, determine if the field should be shown for the current
+        // user.
+        const groups = user.groups.filter(group => {
+          // Filter out groups that are not part of the dataset that this
+          // category belongs to.
+          const [datasetId] = group.dataset.split("/").slice(-1);
+          return datasetId === category.dataset;
+        });
+
+        // If the user groups array and the field admin_groups array share a
+        // common element, this field shoud be visible for the current user.
+        field.isVisible = user.groups.some(group =>
+          field.admin_groups.includes(group.name),
+        );
+      }
+
+      return field;
+    });
+
+    return category;
+  });
+
+  return { type: LOAD, payload: config };
 }
 
 // Reducers:
@@ -39,7 +70,7 @@ const INITIAL_STATE = null;
 
 export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
-    case SET_CONFIG:
+    case LOAD:
       return {
         ...state,
         ...action.payload,

--- a/src/base/static/state/ducks/user.js
+++ b/src/base/static/state/ducks/user.js
@@ -1,0 +1,30 @@
+// Selectors:
+export const userSelector = state => {
+  return state.user;
+};
+
+// Actions:
+const LOAD = "user/LOAD";
+
+// Action creators:
+export function loadUser(user) {
+  return { type: LOAD, payload: user };
+}
+
+// Reducers:
+// TODO(luke): refactor our current implementation in AppView to use
+const INITIAL_STATE = {
+  groups: [],
+};
+
+export default function reducer(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case LOAD:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/base/static/state/reducers.js
+++ b/src/base/static/state/reducers.js
@@ -16,6 +16,7 @@ import supportConfigReducer from "./ducks/support-config";
 import navBarConfigReducer from "./ducks/nav-bar-config";
 import pagesConfigReducer from "./ducks/pages-config";
 import dashboardConfigReducer from "./ducks/dashboard-config";
+import userReducer from "./ducks/user";
 
 const reducers = combineReducers({
   map: mapReducer,
@@ -24,7 +25,6 @@ const reducers = combineReducers({
   leftSidebar: leftSidebarReducer,
   mapDrawingToolbar: mapDrawingToolbarReducer,
   filters,
-
   appConfig: appConfigReducer,
   mapConfig: mapConfigReducer,
   placeConfig: placeConfigReducer,
@@ -35,6 +35,7 @@ const reducers = combineReducers({
   navBarConfig: navBarConfigReducer,
   pagesConfig: pagesConfigReducer,
   dashboardConfig: dashboardConfigReducer,
+  user: userReducer,
 });
 
 export default reducers;

--- a/src/base/static/state/reducers.js
+++ b/src/base/static/state/reducers.js
@@ -17,6 +17,7 @@ import navBarConfigReducer from "./ducks/nav-bar-config";
 import pagesConfigReducer from "./ducks/pages-config";
 import dashboardConfigReducer from "./ducks/dashboard-config";
 import userReducer from "./ducks/user";
+import datasetsConfigReducer from "./ducks/datasets-config";
 
 const reducers = combineReducers({
   map: mapReducer,
@@ -36,6 +37,7 @@ const reducers = combineReducers({
   pagesConfig: pagesConfigReducer,
   dashboardConfig: dashboardConfigReducer,
   user: userReducer,
+  datasetsConfig: datasetsConfigReducer,
 });
 
 export default reducers;

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -154,7 +154,8 @@
           filters:         {{#serialize config.filters}}{{/serialize}},
           datasets:        {{#serialize config.datasets}}{{/serialize}},
           customHooks:     {{#serialize config.custom_hooks}}{{/serialize}},
-          customComponents:{{#serialize config.custom_components}}{{/serialize}}
+          customComponents:{{#serialize config.custom_components}}{{/serialize}},
+          datasets:        {{#serialize config.datasets}}{{/serialize}}
         };
         $(function() {
           // Ready set go!
@@ -180,6 +181,7 @@
             dashboardConfig: S.Config.dashboard,
             customHooks: S.Config.customHooks,
             customComponents: S.Config.customComponents,
+            datasetsConfig: S.Config.datasets,
             languageCode: "{{ languageCode }}"
           });
         });

--- a/src/flavors/defaultflavor/config.json
+++ b/src/flavors/defaultflavor/config.json
@@ -1,4 +1,16 @@
 {
+  "datasets": [
+    {
+      "id": "demo",
+      "url": "https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/demo",
+      "anonymous_adding_supported": true
+    },
+    {
+      "id": "demo2",
+      "url": "https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/demo2",
+      "anonymous_adding_supported": false
+    }
+  ],
   "app": {
     "title": "Mapseed Demo",
     "name": "Mapseed Demo",
@@ -962,7 +974,6 @@
           {
             "name": "big_checkbox_field",
             "type": "big_checkbox",
-            "admin_groups": ["delegates", "reviewers"],
             "prompt": "_(Types of pollution seen:)",
             "display_prompt": "_( )",
             "content": [

--- a/src/flavors/defaultflavor/config.json
+++ b/src/flavors/defaultflavor/config.json
@@ -962,6 +962,7 @@
           {
             "name": "big_checkbox_field",
             "type": "big_checkbox",
+            "admin_groups": ["delegates", "reviewers"],
             "prompt": "_(Types of pollution seen:)",
             "display_prompt": "_( )",
             "content": [


### PR DESCRIPTION
**WIP**

Depends on: https://github.com/mapseed/api/pull/160

This PR refactors our UI such that certain components' visibility is determined by permissions sent from the API. Specifically:
* Place form categories will be rendered if the current user is a member of a group belonging to the category's dataset which grants `create` permissions on either the `places` or `*` (wildcard) `submission_set`
* The place detail editor will be available if the current user is a member of a group belonging to the place's dataset with grants `update` permissions
* The "add new place" button will be rendered if the current user is a member of at least one group in one dataset with grants `create` permissions

To support anonymous submissions, use the `anonymous_adding_supported` flag in the new `datasets` section of the config.

Additionally, we introduce the ability to render individual form fields based on group membership.

TODO:
 - [ ] refactor active flavors