### PR TITLE
fix(mapboxgl-provider): disable draw plugin on touch devices

### DIFF
--- a/src/base/static/libs/maps/mapboxgl-provider.js
+++ b/src/base/static/libs/maps/mapboxgl-provider.js
@@ -6,6 +6,8 @@ import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
 
 import VectorTileClient from "../../client/vector-tile-client";
 
+import { isTouchDevice } from "../../utils/misc-utils";
+
 import constants from "../../constants";
 
 mapboxgl.accessToken = MAP_PROVIDER_TOKEN;
@@ -657,7 +659,7 @@ export default (container, options) => {
   let draw;
   // Unless drawing_enabled is explicitly set to false, we assume we should
   // instantiate the draw plugin.
-  if (options.drawing_enabled !== false) {
+  if (options.drawing_enabled !== false && !isTouchDevice) {
     draw = new MapboxDraw({
       displayControlsDefault: false,
       userProperties: true,


### PR DESCRIPTION
Owing to a bug in `mapbox-gl-draw` (documented here: https://github.com/mapbox/mapbox-gl-draw/issues/617), this PR disables the draw plugin entirely on touch devices.

This PR fixes an issue where flavors with the drawing plugin enabled prevented touch events from registering, making it impossible to click on places on the map when on a touch device.