### PR TITLE
Goldpbear/fix featured sites form

### DIFF
--- a/src/base/static/components/form-fields/types/geocoding-field.js
+++ b/src/base/static/components/form-fields/types/geocoding-field.js
@@ -87,7 +87,7 @@ class GeocodingField extends Component {
           placeholder={this.props.placeholder}
           value={this.props.value}
           onBlur={this.doGeocode.bind(this)}
-          onKeyDown={e => this.props.onKeyDown(e)}
+          onKeyDown={e => this.props.onKeyDown && this.props.onKeyDown(e)}
           onChange={e => this.props.onChange(e.target.name, e.target.value)}
         />
         <div

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -154,6 +154,12 @@ class InputForm extends Component {
         field => field.type === constants.MAP_DRAWING_TOOLBAR_TYPENAME,
       ) >= 0;
     this.attachments = [];
+    if (this.isWithCustomGeometry) {
+      this.props.hideSpotlightMask();
+      this.props.hideNewPin();
+    } else {
+      this.props.showNewPin();
+    }
   }
 
   onFieldChange({ fieldName, fieldStatus, isInitializing }) {
@@ -398,13 +404,6 @@ class InputForm extends Component {
   }
 
   render() {
-    if (this.isWithCustomGeometry) {
-      this.props.hideSpotlightMask();
-      this.props.hideNewPin();
-    } else if (!this.props.selectedCategory) {
-      this.props.showNewPin();
-    }
-
     const cn = {
       form: classNames("input-form__form", this.props.className, {
         "input-form__form--inactive": this.state.isFormSubmitting,

--- a/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
+++ b/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
@@ -40,9 +40,12 @@ class MapDrawingToolbar extends Component {
   componentDidMount() {
     this.props.resetDrawingToolbarState();
     this.props.setMarkers(this.props.markers);
-    emitter.addListener(constants.DRAW_UPDATE_GEOMETRY_EVENT, geometry => {
-      this.props.onChange(this.props.name, geometry);
-    });
+    this.drawUpdateListener = emitter.addListener(
+      constants.DRAW_UPDATE_GEOMETRY_EVENT,
+      geometry => {
+        this.props.onChange(this.props.name, geometry);
+      },
+    );
 
     if (this.props.existingGeometry) {
       emitter.emit(
@@ -78,6 +81,10 @@ class MapDrawingToolbar extends Component {
         modelId: this.props.existingModelId,
       });
     }
+  }
+
+  componentWillUnmount() {
+    this.drawUpdateListener.remove();
   }
 
   render() {


### PR DESCRIPTION
This PR fixes a couple of latent issues with complex forms, which caused some featured site forms to crash:
* we unbind an event listener in the `MapDrawingToolbar` on component unmount
* we move the show/hide new pin logic out of the form's `render()` method

