### PR TITLE
Add support for private place submission

### DIFF
--- a/src/base/static/client/mapseed-api-client.js
+++ b/src/base/static/client/mapseed-api-client.js
@@ -24,7 +24,11 @@ const getPlaceCollections = async ({
         // Check for a valid location type before adding it to the collection
         validate: true,
         data: includePrivate
-          ? { ...placeParams, include_private: true }
+          ? {
+              ...placeParams,
+              include_private_places: true,
+              include_private_fields: true,
+            }
           : placeParams,
         // get the dataset slug and id from the array of map layers
         attributesToAdd: {

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -368,7 +368,7 @@ class InputForm extends Component {
   }
 
   defaultPostSave(model) {
-    if (model.get("is_private")) {
+    if (model.get("private")) {
       this.props.router.navigate("/", { trigger: true });
       emitter.emit("info-modal:open", {
         header: this.props.t("privateSubmissionModalHeader"),

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -368,7 +368,15 @@ class InputForm extends Component {
   }
 
   defaultPostSave(model) {
-    this.props.router.navigate(Util.getUrl(model), { trigger: true });
+    if (model.get("is_private")) {
+      this.props.router.navigate("/", { trigger: true });
+      emitter.emit("info-modal:open", {
+        header: this.props.t("privateSubmissionModalHeader"),
+        body: [this.props.t("privateSubmissionModalBody")],
+      });
+    } else {
+      this.props.router.navigate(Util.getUrl(model), { trigger: true });
+    }
   }
 
   getStageStartField() {

--- a/src/base/static/components/organisms/place-list.js
+++ b/src/base/static/components/organisms/place-list.js
@@ -254,6 +254,8 @@ PlaceList.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  // NOTE: the filter below should be removed when we refactor Backbone
+  // models into Redux.
   places: filteredPlacesSelector(state).filter(place => !place.private),
   placeConfig: placeConfigSelector(state),
 });

--- a/src/base/static/components/organisms/place-list.js
+++ b/src/base/static/components/organisms/place-list.js
@@ -254,7 +254,7 @@ PlaceList.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  places: filteredPlacesSelector(state),
+  places: filteredPlacesSelector(state).filter(place => !place.private),
   placeConfig: placeConfigSelector(state),
 });
 

--- a/src/base/static/components/templates/dashboard.js
+++ b/src/base/static/components/templates/dashboard.js
@@ -248,7 +248,7 @@ class Dashboard extends Component {
               this.props.dashboardConfig.datasetOwner
             }/datasets/${
               this.props.dashboardConfig.datasetId
-            }/mapseed-places.csv?format=csv&include_private=true&page_size=10000`}
+            }/mapseed-places.csv?format=csv&include_private_places&include_private_fields&page_size=10000`}
           >
             {`Download Survey Data`}
           </DownloadDataLink>

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -23,8 +23,8 @@ export const filteredPlacesSelector = state => {
     memo.push(filter.formId);
     return memo;
   }, []);
-  return state.places.filter(place =>
-    filteredFormIds.includes(place.location_type),
+  return state.places.filter(
+    place => filteredFormIds.includes(place.location_type) && !place.is_private,
   );
 };
 

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -23,8 +23,8 @@ export const filteredPlacesSelector = state => {
     memo.push(filter.formId);
     return memo;
   }, []);
-  return state.places.filter(
-    place => filteredFormIds.includes(place.location_type),
+  return state.places.filter(place =>
+    filteredFormIds.includes(place.location_type),
   );
 };
 

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -24,7 +24,7 @@ export const filteredPlacesSelector = state => {
     return memo;
   }, []);
   return state.places.filter(
-    place => filteredFormIds.includes(place.location_type) && !place.is_private,
+    place => filteredFormIds.includes(place.location_type),
   );
 };
 

--- a/src/base/static/utils/place-utils.js
+++ b/src/base/static/utils/place-utils.js
@@ -1,7 +1,7 @@
 import constants from "../constants";
 
 const createGeoJSONFromPlaces = places => {
-  const features = places.map(place => {
+  const features = places.filter(place => !place.is_private).map(place => {
     const properties = Object.keys(place).reduce(
       (geoJSONProperties, property) => {
         geoJSONProperties[property] = place[property];

--- a/src/base/static/utils/place-utils.js
+++ b/src/base/static/utils/place-utils.js
@@ -1,7 +1,7 @@
 import constants from "../constants";
 
 const createGeoJSONFromPlaces = places => {
-  const features = places.filter(place => !place.is_private).map(place => {
+  const features = places.filter(place => !place.private).map(place => {
     const properties = Object.keys(place).reduce(
       (geoJSONProperties, property) => {
         geoJSONProperties[property] = place[property];

--- a/src/base/static/utils/place-utils.js
+++ b/src/base/static/utils/place-utils.js
@@ -1,6 +1,8 @@
 import constants from "../constants";
 
 const createGeoJSONFromPlaces = places => {
+  // NOTE: the filter below should be removed when we refactor Backbone
+  // models into Redux.
   const features = places.filter(place => !place.private).map(place => {
     const properties = Object.keys(place).reduce(
       (geoJSONProperties, property) => {

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -494,6 +494,7 @@
         "category": "reports",
         "submitter_editing_supported": true,
         "includeOnForm": true,
+        "includeOnList": true,
         "submitter_editing_supported": true,
         "name": "location_type",
         "datasetSlug": "palouse-input",
@@ -1881,6 +1882,7 @@
           },
           {
             "name": "my_image",
+            "includeOnList": true,
             "type": "file",
             "prompt": "_(Show your stewardship practices! Upload photos:)",
             "label": "_(Upload photos)",
@@ -1888,6 +1890,7 @@
           },
           {
             "name": "practices_description",
+            "includeOnList": true,
             "type": "textarea",
             "prompt": "_(Add a description of your stewardship practices!)",
             "display_prompt": "_(Description:)",
@@ -1917,18 +1920,18 @@
             ]
           },
           {
-            "name": "private-share_story",
+            "name": "is_private",
             "type": "big_radio",
             "prompt": "_(Would you be willing to share your stewardship story with the public?)",
-            "default_value": "no",
+            "default_value": true,
             "content": [
               {
                 "label": "_(Yes)",
-                "value": "yes"
+                "value": false
               },
               {
                 "label": "_(No)",
-                "value": "no"
+                "value": true
               }
             ]
           },

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -1920,9 +1920,9 @@
             ]
           },
           {
-            "name": "is_private",
+            "name": "private",
             "type": "big_radio",
-            "prompt": "_(Would you be willing to share your stewardship story with the public?)",
+            "prompt": "_(Would you be willing to share your stewardship story with the public? Checking \"yes\" below will place a pin on the map upon submission and your stewardship actions will be visible to the public.)",
             "default_value": true,
             "content": [
               {

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -494,7 +494,6 @@
         "category": "reports",
         "submitter_editing_supported": true,
         "includeOnForm": true,
-        "includeOnList": true,
         "submitter_editing_supported": true,
         "name": "location_type",
         "datasetSlug": "palouse-input",
@@ -1882,7 +1881,6 @@
           },
           {
             "name": "my_image",
-            "includeOnList": true,
             "type": "file",
             "prompt": "_(Show your stewardship practices! Upload photos:)",
             "label": "_(Upload photos)",
@@ -1890,7 +1888,6 @@
           },
           {
             "name": "practices_description",
-            "includeOnList": true,
             "type": "textarea",
             "prompt": "_(Add a description of your stewardship practices!)",
             "display_prompt": "_(Description:)",

--- a/src/locales/en_US/InputForm.json
+++ b/src/locales/en_US/InputForm.json
@@ -1,4 +1,6 @@
 {
   "validationHeader":
-    "Your post is looking good, but we need some more information before we can proceed."
+    "Your post is looking good, but we need some more information before we can proceed.",
+  "privateSubmissionModalHeader": "Thank you!",
+  "privateSubmissionModalBody": "Your information was submitted successfully, and will remain private."
 }

--- a/src/locales/es/InputForm.json
+++ b/src/locales/es/InputForm.json
@@ -1,3 +1,5 @@
 {
-  "validationHeader": "Su publicación se ve bien, pero necesitamos más información antes de poder continuar."
+  "validationHeader": "Su publicación se ve bien, pero necesitamos más información antes de poder continuar.",
+  "privateSubmissionModalHeader": "Gracias!",
+  "privateSubmissionModalBody": "Su información fue enviada exitosamente y permanecerá privada."
 }


### PR DESCRIPTION
Depends on https://github.com/mapseed/api/pull/162.

This PR adds support for private places. Private places are hidden from view on the public-facing parts of the site, but are viewable by users with the proper credentials.

Upon submission of a private place, we route to the `/` route and display a modal box confirming the successful private submission of data.

This PR also adds a private form field for the `palouse` flavor.

Tested on the staging API with the `palouse` flavor.