### PR TITLE
Goldpbear/default editor values

### DIFF
--- a/src/base/static/components/form-fields/form-field.js
+++ b/src/base/static/components/form-fields/form-field.js
@@ -2,11 +2,14 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { List, Map } from "immutable";
 import classNames from "classnames";
+import { connect } from "react-redux";
 
 import { InfoModalTrigger } from "../atoms/feedback";
 import fieldDefinitions from "./field-definitions";
 import { translate } from "react-i18next";
 import constants from "../../constants";
+
+import { isEditModeToggled } from "../../state/ducks/ui";
 
 import "./form-field.scss";
 
@@ -31,11 +34,16 @@ class FormField extends Component {
     // We have to coordinate between the FormField component and its parent--
     // which manages the state--in order to initialize properly. We should
     // search for a better pattern to support field state management.
+
+    // In edit mode, don't fill in default values.
+    const defaultValue = this.props.isEditModeToggled
+      ? null
+      : this.props.fieldConfig.default_value;
     const initialFieldValue = this.fieldDefinition.getInitialValue({
       value:
         this.props.fieldState.get(constants.FIELD_VALUE_KEY) ||
         autofillValue ||
-        this.props.fieldConfig.default_value ||
+        defaultValue ||
         "",
       fieldConfig: this.props.fieldConfig,
       attachmentModels: this.props.attachmentModels,
@@ -148,6 +156,7 @@ FormField.propTypes = {
   disabled: PropTypes.bool,
   fieldConfig: PropTypes.object.isRequired,
   fieldState: PropTypes.object,
+  isEditModeToggled: PropTypes.bool.isRequired,
   isInitializing: PropTypes.bool,
   updatingField: PropTypes.string,
   map: PropTypes.object,
@@ -169,4 +178,8 @@ FormField.defaultProps = {
   attachmentModels: new List(),
 };
 
-export default translate("FormField")(FormField);
+const mapStateToProps = state => ({
+  isEditModeToggled: isEditModeToggled(state),
+});
+
+export default connect(mapStateToProps)(translate("FormField")(FormField));

--- a/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
+++ b/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
@@ -9,8 +9,7 @@ exports[`InputForm renders input form 1`] = `
     id="mapseed-input-form"
     onSubmit={[Function]}
   >
-    <FormField
-      attachmentModels={Immutable.List []}
+    <Connect(FormField)
       disabled={false}
       fieldConfig={
         Object {
@@ -41,11 +40,9 @@ exports[`InputForm renders input form 1`] = `
         }
       }
       showValidityStatus={false}
-      t={[Function]}
       updatingField={null}
     />
-    <FormField
-      attachmentModels={Immutable.List []}
+    <Connect(FormField)
       disabled={false}
       fieldConfig={
         Object {
@@ -76,11 +73,9 @@ exports[`InputForm renders input form 1`] = `
         }
       }
       showValidityStatus={false}
-      t={[Function]}
       updatingField={null}
     />
-    <FormField
-      attachmentModels={Immutable.List []}
+    <Connect(FormField)
       disabled={false}
       fieldConfig={
         Object {
@@ -111,7 +106,6 @@ exports[`InputForm renders input form 1`] = `
         }
       }
       showValidityStatus={false}
-      t={[Function]}
       updatingField={null}
     />
   </form>

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -1920,17 +1920,18 @@
             "name": "private",
             "type": "big_radio",
             "prompt": "_(Would you be willing to share your stewardship story with the public? Checking \"yes\" below will place a pin on the map upon submission and your stewardship actions will be visible to the public.)",
-            "default_value": true,
+            "default_value": "true",
             "content": [
               {
                 "label": "_(Yes)",
-                "value": false
+                "value": ""
               },
               {
                 "label": "_(No)",
-                "value": true
+                "value": "true"
               }
-            ]
+            ],
+            "optional": true
           },
           {
             "name": "private-landowner_email",


### PR DESCRIPTION
This PR prevents default form fields values from populating fields in the place detail editor. This behavior is unintuitive, and also can create problems with our new private places feature.