### PR TITLE
fix(PlaceDetailEditor): send credentials with attachments; fix privat…

### DIFF
--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -284,6 +284,11 @@ class InputForm extends Component {
       .map(state => state.get(constants.FIELD_VALUE_KEY))
       .toJS();
 
+    // A form field with name "private" should use the value "yes" to indicate
+    // that a place should be private.
+    // TODO: Make a special form field to encapsulate this.
+    attrs.private = attrs.private === "yes" ? true : false;
+
     if (this.state.fields.get(constants.GEOMETRY_PROPERTY_NAME)) {
       attrs[constants.GEOMETRY_STYLE_PROPERTY_NAME] =
         this.state.fields

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -94,6 +94,11 @@ class PlaceDetailEditor extends Component {
           .map(state => state.get(constants.FIELD_VALUE_KEY))
           .toJS();
 
+        // A form field with name "private" should use the value "yes" to indicate
+        // that a place should be private.
+        // TODO: Make a special form field to encapsulate this.
+        attrs.private = attrs.private === "yes" ? true : false;
+
         if (this.state.fields.get(constants.GEOMETRY_PROPERTY_NAME)) {
           attrs[constants.GEOMETRY_STYLE_PROPERTY_NAME] =
             this.state.fields

--- a/src/base/static/js/models/attachment-collection.js
+++ b/src/base/static/js/models/attachment-collection.js
@@ -9,7 +9,7 @@ module.exports = Backbone.Collection.extend({
 
   url: function() {
     var thingModel = this.options.thingModel,
-      thingUrl = thingModel.url();
+      thingUrl = thingModel.url().split("?")[0];
 
     return thingUrl + "/attachments";
   },

--- a/src/base/static/js/models/attachment-model.js
+++ b/src/base/static/js/models/attachment-model.js
@@ -73,6 +73,9 @@ module.exports = Backbone.Model.extend({
         }
         return myXhr;
       },
+      xhrFields: {
+        withCredentials: true,
+      },
       //Ajax events
       success: function(attachmentResponse) {
         var args = Array.prototype.slice.call(arguments);

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -1756,7 +1756,10 @@
             "optional": true,
             "trigger": {
               "trigger_value": "yes",
-              "targets": ["hedgerow_planting_quantity", "hedgerow_planting_datetime"]
+              "targets": [
+                "hedgerow_planting_quantity",
+                "hedgerow_planting_datetime"
+              ]
             },
             "content": [
               {
@@ -1940,15 +1943,15 @@
             "name": "private",
             "type": "big_radio",
             "prompt": "_(Would you be willing to share your stewardship story with the public? Checking \"yes\" below will place a pin on the map upon submission and your stewardship actions will be visible to the public.)",
-            "default_value": "true",
+            "default_value": "yes",
             "content": [
               {
                 "label": "_(Yes)",
-                "value": ""
+                "value": "no"
               },
               {
                 "label": "_(No)",
-                "value": "true"
+                "value": "yes"
               }
             ],
             "optional": true


### PR DESCRIPTION
This PR adds special handling for form fields with the name `private` to ensure only a boolean is sent. This is kind of a hacky quick fix, pending creation of a special form field to set the `private` flag.

This PR also ensures that credentials are sent when talking to the `attachments` endpoint.