### PR TITLE
Goldpbear/remove backbone models

### DIFF
--- a/src/base/static/components/form-fields/response-field.js
+++ b/src/base/static/components/form-fields/response-field.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { List } from "immutable";
 
 import fieldDefinitions from "./field-definitions";
 
@@ -12,9 +11,7 @@ import "./response-field.scss";
 const getCheckboxLabels = (fieldValue, fieldConfig) => {
   if (!fieldConfig.content) return null;
 
-  if (List.isList(fieldValue)) {
-    fieldValue = fieldValue.toArray();
-  } else {
+  if (!Array.isArray(fieldValue)) {
     fieldValue = [fieldValue];
   }
 

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -390,7 +390,9 @@ class InputForm extends Component {
       });
     } else {
       this.props.router.navigate(
-        `${this.selectedCategoryConfig.placeSlug}/${place.id}`,
+        `${this.props.datasetClientSlugSelector(this.props.datasetSlug)}/${
+          place.id
+        }`,
         {
           trigger: true,
         },

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -26,7 +26,10 @@ import {
   updatePlacesLoadStatus,
 } from "../../state/ducks/places";
 import { loadPlaceConfig } from "../../state/ducks/place-config";
-import { setStoryConfig } from "../../state/ducks/story-config";
+import {
+  setStoryConfig,
+  storyConfigSelector,
+} from "../../state/ducks/story-config";
 import { loadFormsConfig } from "../../state/ducks/forms-config";
 import { setPagesConfig, pageSelector } from "../../state/ducks/pages-config";
 import {
@@ -419,6 +422,7 @@ export default Backbone.View.extend({
           store.dispatch(
             loadPlaces(
               placeData.reduce((flat, toFlatten) => flat.concat(toFlatten), []),
+              storyConfigSelector(store.getState()),
             ),
           );
         } else {
@@ -721,8 +725,12 @@ export default Backbone.View.extend({
     this.showSpotlightMask();
     const story = place.story;
 
+    console.log("place", place);
+
     if (story) {
       this.isStoryActive = true;
+
+      console.log("!!!!", story);
 
       mapBasemapSelector(store.getState()) !== story.basemap &&
         store.dispatch(setBasemap(story.basemap));

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -84,6 +84,9 @@ export function loadPlaces(places, storyConfig = {}) {
     return flat.concat(toFlatten.chapters);
   }, []);
 
+  console.log("storyConfig", storyConfig)
+  console.log("storyChapters", storyChapters)
+
   places = places.map(place => {
     place.submission_sets.support = place.submission_sets.support || [];
     place.submission_sets.comments = place.submission_sets.comments || [];

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -84,9 +84,6 @@ export function loadPlaces(places, storyConfig = {}) {
     return flat.concat(toFlatten.chapters);
   }, []);
 
-  console.log("storyConfig", storyConfig)
-  console.log("storyChapters", storyChapters)
-
   places = places.map(place => {
     place.submission_sets.support = place.submission_sets.support || [];
     place.submission_sets.comments = place.submission_sets.comments || [];

--- a/src/base/static/utils/field-response-filter.js
+++ b/src/base/static/utils/field-response-filter.js
@@ -1,7 +1,11 @@
 import constants from "../constants";
 
-export default (fieldList, place) =>
-  fieldList
+export default (fieldConfigs, place) => {
+  if (!fieldConfigs) {
+    return [];
+  }
+
+  return fieldConfigs
     .filter(
       fieldConfig =>
         ![
@@ -21,3 +25,4 @@ export default (fieldList, place) =>
     )
     .filter(fieldConfig => fieldConfig.name.indexOf("private-") !== 0)
     .filter(fieldConfig => !!place[fieldConfig.name]);
+};

--- a/src/flavors/pugetsound/config.json
+++ b/src/flavors/pugetsound/config.json
@@ -97,9 +97,10 @@
       },
       {
         "id": "satellite",
-        "is_basemap": true,
         "type": "raster-tile",
-        "url": "https://1.aerial.maps.cit.api.here.com/maptile/2.1/maptile/newest/hybrid.day/{z}/{x}/{y}/256/png8?app_id=tFZyfnyJAmhfh5gdoGcR&app_code=vJ8o9OCQ1o0Y2wwbRspzSA&lg=eng"
+        "is_basemap": true,
+        "url": "https://api.tiles.mapbox.com/v4/smartercleanup.pe3o4gdn/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw",
+        "attribution": "&copy; OpenStreetMap contributors, CC-BY-SA. <a href=\"//mapbox.com/about/maps\" target=\"_blank\">Terms &amp; Feedback</a>. Geocoding Courtesy of <a href=\"//www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"//developer.mapquest.com/content/osm/mq_logo.png\">."
       },
       {
         "id": "light-nolabels",


### PR DESCRIPTION
This PR cleans up a few issues after the Backbone model refactor:
* correct `clientSlug` on new place creation
* guard against place data with outdated `location_types`
* remove a lingering use of `immutable` data structures in a child of the detail view
* fix a bug where stories are not initialized correctly

We also fix the satellite layer on the `pugetsound` flavor.