### PR TITLE
Goldpbear/map drawing tools refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,136 @@
         }
       }
     },
+    "@emotion/cache": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.7.tgz",
+      "integrity": "sha512-wscXuawG+nQhSNbDpJdAqvv5d2g1O+fpwf/wD/CAmW/wsuN8hNzahWh2ldSVakqO9sINewyQNFl74IeDeTkRZg==",
+      "requires": {
+        "@emotion/sheet": "0.9.2",
+        "@emotion/stylis": "0.8.3",
+        "@emotion/utils": "0.11.1",
+        "@emotion/weak-memoize": "0.2.2"
+      },
+      "dependencies": {
+        "@emotion/stylis": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.3.tgz",
+          "integrity": "sha512-M3nMfJ6ndJMYloSIbYEBq6G3eqoYD41BpDOxreE8j0cb4fzz/5qvmqU9Mb2hzsXcCnIlGlWhS03PCzVGvTAe0Q=="
+        },
+        "@emotion/utils": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.1.tgz",
+          "integrity": "sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg=="
+        }
+      }
+    },
+    "@emotion/core": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.7.tgz",
+      "integrity": "sha512-f5ZeA8R5mTiD2VDFCy6kRTXrQXN/1s79WPvEZZSwROJIyy9mHBB0/Lxg9BSIXfFdXryVw76kHNehTcBkgDYS7A==",
+      "requires": {
+        "@emotion/cache": "^10.0.7",
+        "@emotion/css": "^10.0.7",
+        "@emotion/serialize": "^0.11.4",
+        "@emotion/sheet": "0.9.2",
+        "@emotion/utils": "0.11.1"
+      },
+      "dependencies": {
+        "@emotion/hash": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
+          "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
+        },
+        "@emotion/memoize": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
+          "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+        },
+        "@emotion/serialize": {
+          "version": "0.11.4",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.4.tgz",
+          "integrity": "sha512-JKmn+Qnc8f6OZKSHmNq1RpO27raIi6Kj0uqBaSOUVMW6NI0M3wLpV4pK5hZO4I+1WuCC39hOBPgQ/GcgoHbDeg==",
+          "requires": {
+            "@emotion/hash": "0.7.1",
+            "@emotion/memoize": "0.7.1",
+            "@emotion/unitless": "0.7.3",
+            "@emotion/utils": "0.11.1",
+            "csstype": "^2.5.7"
+          }
+        },
+        "@emotion/unitless": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
+          "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+        },
+        "@emotion/utils": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.1.tgz",
+          "integrity": "sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg=="
+        }
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.7.tgz",
+      "integrity": "sha512-r8JuPanNW0+ftBKFSna+6p5X7ewvU8d8NaNBlFjdPYl7xmtbDmoz8E7ceXqF4QgdRH4FBFIIRFzTA4Y05JwkIw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.4",
+        "@emotion/utils": "0.11.1",
+        "babel-plugin-emotion": "^10.0.7"
+      },
+      "dependencies": {
+        "@emotion/hash": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
+          "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
+        },
+        "@emotion/memoize": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
+          "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+        },
+        "@emotion/serialize": {
+          "version": "0.11.4",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.4.tgz",
+          "integrity": "sha512-JKmn+Qnc8f6OZKSHmNq1RpO27raIi6Kj0uqBaSOUVMW6NI0M3wLpV4pK5hZO4I+1WuCC39hOBPgQ/GcgoHbDeg==",
+          "requires": {
+            "@emotion/hash": "0.7.1",
+            "@emotion/memoize": "0.7.1",
+            "@emotion/unitless": "0.7.3",
+            "@emotion/utils": "0.11.1",
+            "csstype": "^2.5.7"
+          }
+        },
+        "@emotion/unitless": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
+          "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+        },
+        "@emotion/utils": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.1.tgz",
+          "integrity": "sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg=="
+        },
+        "babel-plugin-emotion": {
+          "version": "10.0.7",
+          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.7.tgz",
+          "integrity": "sha512-5PdLJYme3tFN97M3tBbEUS/rJVkS9EMbo7rs7/7BAUEUVMWehm1kb5DEbp16Rs+UsI3rTXRan1iqpL022T8XxA==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@emotion/hash": "0.7.1",
+            "@emotion/memoize": "0.7.1",
+            "@emotion/serialize": "^0.11.4",
+            "babel-plugin-macros": "^2.0.0",
+            "babel-plugin-syntax-jsx": "^6.18.0",
+            "convert-source-map": "^1.5.0",
+            "escape-string-regexp": "^1.0.5",
+            "find-root": "^1.1.0",
+            "source-map": "^0.5.7"
+          }
+        }
+      }
+    },
     "@emotion/hash": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
@@ -149,6 +279,11 @@
         "@emotion/utils": "^0.8.2"
       }
     },
+    "@emotion/sheet": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.2.tgz",
+      "integrity": "sha512-pVBLzIbC/QCHDKJF2E82V2H/W/B004mDFQZiyo/MSR+VC4pV5JLG0TF/zgQDFvP3fZL/5RTPGEmXlYJBMUuJ+A=="
+    },
     "@emotion/stylis": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
@@ -163,6 +298,11 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz",
+      "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
     },
     "@mapbox/extent": {
       "version": "0.4.0",
@@ -225,9 +365,8 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-draw": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.0.9.tgz",
-      "integrity": "sha512-33716RoG7BB5MhcQqymPb42TbWrOvTEKbaREby8UHKPerL/50W0z/mt3diX0QYrUsygYJNj5b2lALLWrRJNklw==",
+      "version": "github:mapseed/mapbox-gl-draw#a790a7804786dac196d1a2304dd56223c115aa26",
+      "from": "github:mapseed/mapbox-gl-draw#a790a7804786dac196d1a2304dd56223c115aa26",
       "requires": {
         "@mapbox/geojson-area": "^0.2.1",
         "@mapbox/geojson-extent": "^0.3.2",
@@ -6239,12 +6378,19 @@
       }
     },
     "geojson-flatten": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-0.2.2.tgz",
-      "integrity": "sha512-P9lzhr2NTsEjcVRmTBf/taXXSEw8Vwp6ITtY8oS54cvGuq1z0/d1BILv3E6IPRv83+XLLXGprOTvXxEq1yxJ/w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-0.2.4.tgz",
+      "integrity": "sha512-LiX6Jmot8adiIdZ/fthbcKKPOfWjTQchX/ggHnwMZ2e4b0I243N1ANUos0LvnzepTEsj0+D4fIJ5bKhBrWnAHA==",
       "requires": {
-        "concat-stream": "~1.6.0",
+        "get-stdin": "^6.0.0",
         "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+        }
       }
     },
     "geojson-rewind": {
@@ -17491,9 +17637,9 @@
       }
     },
     "vfile-message": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
-      "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
       }
@@ -17511,9 +17657,9 @@
       }
     },
     "vfile-statistics": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.1.tgz",
-      "integrity": "sha512-dxUM6IYvGChHuwMT3dseyU5BHprNRXzAV0OHx1A769lVGsTiT50kU7BbpRFV+IE6oWmU+PwHdsTKfXhnDIRIgQ=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.2.tgz",
+      "integrity": "sha512-16wAC9eEGXdsD35LX9m/iXCRIZyX5LIrDgDtAF92rbATSqsBRbC4n05e0Rj5vt3XRpcKu0UJeWnTxWsSyvNZ+w=="
     },
     "viewport-mercator-project": {
       "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "prettier": "prettier --write \"{src,scripts}/**/*.{js,jsx}\""
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-draw": "^1.0.9",
+    "@emotion/core": "^10.0.7",
+    "@mapbox/mapbox-gl-draw": "github:mapseed/mapbox-gl-draw#a790a7804786dac196d1a2304dd56223c115aa26",
     "accessible-autocomplete": "github:mapseed/accessible-autocomplete#7e56b805ee7ce77bebae67f6454a5c3f5e4987a8",
     "babel-plugin-emotion": "^9.2.11",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -27,6 +27,7 @@ import {
   geometryStyleSelector,
   setActiveDrawingTool,
   geometryStyleProps,
+  setActiveDrawGeometryId,
 } from "../../state/ducks/map-drawing-toolbar";
 import {
   mapCenterpointSelector,
@@ -242,8 +243,9 @@ class InputForm extends Component {
     );
 
     if (!this.props.isMapDragged) {
-      newValidationErrors.add("mapNotDragged");
-      isValid = false;
+      //// TODO: ignore this validation check if the form is in drawing mode.
+      //newValidationErrors.add("mapNotDragged");
+      //isValid = false;
     }
 
     if (isValid) {
@@ -367,6 +369,8 @@ class InputForm extends Component {
           );
         }
       });
+
+      this.props.setActiveDrawGeometryId(null);
 
       // Fire post-save hook.
       // The post-save hook allows flavors to hijack the default
@@ -567,6 +571,7 @@ InputForm.propTypes = {
   router: PropTypes.object.isRequired,
   selectedCategory: PropTypes.string.isRequired,
   setActiveDrawingTool: PropTypes.func.isRequired,
+  setActiveDrawGeometryId: PropTypes.func.isRequired,
   showNewPin: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   createFeaturesInGeoJSONSource: PropTypes.func.isRequired,
@@ -587,6 +592,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   createFeaturesInGeoJSONSource: (sourceId, sourceData) =>
     dispatch(createFeaturesInGeoJSONSource(sourceId, sourceData)),
+  setActiveDrawGeometryId: id => dispatch(setActiveDrawGeometryId(id)),
   setActiveDrawingTool: activeDrawingTool =>
     dispatch(setActiveDrawingTool(activeDrawingTool)),
   createPlace: place => dispatch(createPlace(place)),

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -243,9 +243,8 @@ class InputForm extends Component {
     );
 
     if (!this.props.isMapDragged) {
-      //// TODO: ignore this validation check if the form is in drawing mode.
-      //newValidationErrors.add("mapNotDragged");
-      //isValid = false;
+      newValidationErrors.add("mapNotDragged");
+      isValid = false;
     }
 
     if (isValid) {

--- a/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
+++ b/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
@@ -25,10 +25,11 @@ import {
 } from "../../../state/ducks/map-drawing-toolbar";
 import {
   updateDrawModeActive,
-  updateGeoJSONSourceRemoveFeature,
-  updateGeoJSONSourceAddFeature,
+  removeFeatureInGeoJSONSource,
+  createFeaturesInGeoJSONSource,
 } from "../../../state/ducks/map";
 import { placeSelector } from "../../../state/ducks/places";
+import { toClientGeoJSONFeature } from "../../../utils/place-utils";
 
 import { ToolbarButton } from "../../atoms/buttons";
 import { Paragraph } from "../../atoms/typography";
@@ -117,7 +118,7 @@ class MapDrawingToolbar extends Component {
       // If we are editing existing geometry on the map, remove the underlying
       // feature from its source and relocate it to mapbox-gl-draw so it can
       // be manipulated.
-      this.props.updateGeoJSONSourceRemoveFeature(
+      this.props.removeFeatureInGeoJSONSource(
         this.props.datasetSlug,
         this.props.existingPlaceId,
       );
@@ -154,9 +155,11 @@ class MapDrawingToolbar extends Component {
     // In edit mode, restore the original geometry removed on mount to make way
     // for the editable geometry.
     this.props.existingPlaceId &&
-      this.props.updateGeoJSONSourceAddFeature(
+      this.props.createFeaturesInGeoJSONSource(
         this.props.datasetSlug,
-        this.props.placeSelector(this.props.existingPlaceId),
+        toClientGeoJSONFeature(
+          this.props.placeSelector(this.props.existingPlaceId),
+        ),
       );
   }
 
@@ -439,8 +442,8 @@ MapDrawingToolbar.propTypes = {
   setMarkers: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   updateDrawModeActive: PropTypes.func.isRequired,
-  updateGeoJSONSourceAddFeature: PropTypes.func.isRequired,
-  updateGeoJSONSourceRemoveFeature: PropTypes.func.isRequired,
+  createFeaturesInGeoJSONSource: PropTypes.func.isRequired,
+  removeFeatureInGeoJSONSource: PropTypes.func.isRequired,
   visibleDrawingTools: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
@@ -467,10 +470,10 @@ const mapDispatchToProps = dispatch => ({
   setGeometryStyle: geometryStyle => dispatch(setGeometryStyle(geometryStyle)),
   setMarkers: markers => dispatch(setMarkers(markers)),
   updateDrawModeActive: isActive => dispatch(updateDrawModeActive(isActive)),
-  updateGeoJSONSourceAddFeature: (sourceId, place) =>
-    dispatch(updateGeoJSONSourceAddFeature(sourceId, place)),
-  updateGeoJSONSourceRemoveFeature: (sourceId, featureId) =>
-    dispatch(updateGeoJSONSourceRemoveFeature(sourceId, featureId)),
+  createFeaturesInGeoJSONSource: (sourceId, newFeatures) =>
+    dispatch(createFeaturesInGeoJSONSource(sourceId, newFeatures)),
+  removeFeatureInGeoJSONSource: (sourceId, featureId) =>
+    dispatch(removeFeatureInGeoJSONSource(sourceId, featureId)),
 });
 
 export default connect(

--- a/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
+++ b/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
@@ -288,9 +288,9 @@ class MapDrawingToolbar extends Component {
                 }}
                 onChange={colorInfo => {
                   this.props.setGeometryStyle({
-                    [constants.LINE_COLOR_PROPERTY_NAME]: colorInfo.color,
-                    [constants.LINE_OPACITY_PROPERTY_NAME]:
-                      colorInfo.alpha / 100,
+                    ...this.props.geometryStyle,
+                    stroke: colorInfo.color,
+                    "stroke-opacity": colorInfo.alpha / 100,
                   });
                 }}
                 placement="topRight"
@@ -334,9 +334,9 @@ class MapDrawingToolbar extends Component {
                 }}
                 onChange={colorInfo => {
                   this.props.setGeometryStyle({
-                    [constants.FILL_COLOR_PROPERTY_NAME]: colorInfo.color,
-                    [constants.FILL_OPACITY_PROPERTY_NAME]:
-                      colorInfo.alpha / 100,
+                    ...this.props.geometryStyle,
+                    fill: colorInfo.color,
+                    "fill-opacity": colorInfo.alpha / 100,
                   });
                 }}
                 placement="topRight"

--- a/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
+++ b/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
@@ -19,7 +19,9 @@ import {
   geometryStyleSelector,
   setGeometryStyle,
   resetDrawingToolbarState,
+  setActiveDrawGeometryId,
 } from "../../../state/ducks/map-drawing-toolbar";
+import { updateDrawModeActive } from "../../../state/ducks/map";
 
 import { ToolbarButton } from "../../atoms/buttons";
 import { Paragraph } from "../../atoms/typography";
@@ -37,10 +39,11 @@ const deleteToolLabels = {
 
 class MapDrawingToolbar extends Component {
   componentDidMount() {
+    this.props.updateDrawModeActive(true);
     this.props.resetDrawingToolbarState();
     this.props.setMarkers(this.props.markers);
     this.drawUpdateListener = emitter.addListener(
-      constants.DRAW_UPDATE_GEOMETRY_EVENT,
+      "draw:update-geometry",
       geometry => {
         this.props.onChange(this.props.name, geometry);
       },
@@ -72,8 +75,8 @@ class MapDrawingToolbar extends Component {
           this.props.setGeometryStyle(this.props.existingGeometryStyle);
           break;
       }
-
       emitter.emit(constants.PLACE_COLLECTION_UNFOCUS_ALL_PLACES_EVENT);
+
       emitter.emit(constants.PLACE_COLLECTION_HIDE_PLACE_EVENT, {
         datasetSlug: this.props.datasetSlug,
         placeId: this.props.existingPlaceId,
@@ -83,6 +86,8 @@ class MapDrawingToolbar extends Component {
 
   componentWillUnmount() {
     this.drawUpdateListener.remove();
+    this.props.updateDrawModeActive(false);
+    this.props.setActiveDrawGeometryId(null);
   }
 
   render() {
@@ -126,7 +131,6 @@ class MapDrawingToolbar extends Component {
                 this.props.setActiveDrawingTool(
                   constants.DRAW_CREATE_MARKER_TOOL,
                 );
-                emitter.emit(constants.DRAW_START_MARKER_EVENT);
               }}
             />
             <ToolbarButton
@@ -152,7 +156,6 @@ class MapDrawingToolbar extends Component {
                 this.props.setActiveDrawingTool(
                   constants.DRAW_CREATE_POLYLINE_TOOL,
                 );
-                emitter.emit(constants.DRAW_START_POLYLINE_EVENT);
               }}
             />
             <ToolbarButton
@@ -178,7 +181,6 @@ class MapDrawingToolbar extends Component {
                 this.props.setActiveDrawingTool(
                   constants.DRAW_CREATE_POLYGON_TOOL,
                 );
-                emitter.emit(constants.DRAW_START_POLYGON_EVENT);
               }}
             />
           </div>
@@ -325,7 +327,6 @@ class MapDrawingToolbar extends Component {
                     constants.DRAW_DEFAULT_LINE_OPACITY,
                 });
                 this.props.setActiveDrawingTool(null);
-                emitter.emit(constants.DRAW_DELETE_GEOMETRY_EVENT);
               }}
             />
           </div>
@@ -378,11 +379,13 @@ MapDrawingToolbar.propTypes = {
   onChange: PropTypes.func.isRequired,
   resetDrawingToolbarState: PropTypes.func.isRequired,
   setActiveColorpicker: PropTypes.func.isRequired,
+  setActiveDrawGeometryId: PropTypes.func.isRequired,
   setActiveDrawingTool: PropTypes.func.isRequired,
   setActiveMarkerIndex: PropTypes.func.isRequired,
   setGeometryStyle: PropTypes.func.isRequired,
   setMarkers: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
+  updateDrawModeActive: PropTypes.func.isRequired,
   visibleDrawingTools: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
@@ -399,12 +402,14 @@ const mapDispatchToProps = dispatch => ({
   resetDrawingToolbarState: () => dispatch(resetDrawingToolbarState()),
   setActiveColorpicker: activeColorpicker =>
     dispatch(setActiveColorpicker(activeColorpicker)),
+  setActiveDrawGeometryId: id => dispatch(setActiveDrawGeometryId(id)),
   setActiveMarkerIndex: activeMarkerIndex =>
     dispatch(setActiveMarkerIndex(activeMarkerIndex)),
   setActiveDrawingTool: activeDrawingTool =>
     dispatch(setActiveDrawingTool(activeDrawingTool)),
   setGeometryStyle: geometryStyle => dispatch(setGeometryStyle(geometryStyle)),
   setMarkers: markers => dispatch(setMarkers(markers)),
+  updateDrawModeActive: isActive => dispatch(updateDrawModeActive(isActive)),
 });
 
 export default connect(

--- a/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
+++ b/src/base/static/components/molecules/form-field-types/map-drawing-toolbar.js
@@ -379,6 +379,7 @@ class MapDrawingToolbar extends Component {
                     constants.DRAW_DEFAULT_LINE_OPACITY,
                 });
                 this.props.setActiveDrawingTool(null);
+                this.props.setActiveDrawGeometryId(null);
               }}
             />
           </div>

--- a/src/base/static/components/organisms/map-drawing-overlay.js
+++ b/src/base/static/components/organisms/map-drawing-overlay.js
@@ -1,4 +1,0 @@
-import React from "react"
-import PropTypes from "prop-types"
-
-

--- a/src/base/static/components/organisms/map-drawing-overlay.js
+++ b/src/base/static/components/organisms/map-drawing-overlay.js
@@ -1,0 +1,4 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -180,6 +180,7 @@ class PlaceDetailEditor extends Component {
         this.props.onRequestEnd();
       }
     } else {
+      this.props.onRequestEnd();
       this.setState({
         formValidationErrors: newValidationErrors,
         showValidityStatus: true,

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -28,7 +28,7 @@ import {
   removePlace,
   removePlaceAttachment,
   placePropType,
-  updateActivePlaceId,
+  updateActiveEditPlaceId,
 } from "../../state/ducks/places";
 import { removeGeoJSONFeature } from "../../state/ducks/map";
 import { updateEditModeToggled } from "../../state/ducks/ui";
@@ -84,11 +84,11 @@ class PlaceDetailEditor extends Component {
   }
 
   componentDidMount() {
-    this.props.updateActivePlaceId(this.props.place.id);
+    this.props.updateActiveEditPlaceId(this.props.place.id);
   }
 
   componentWillUnmount() {
-    this.props.updateActivePlaceId(null);
+    this.props.updateActiveEditPlaceId(null);
   }
 
   async updatePlace() {
@@ -380,6 +380,7 @@ PlaceDetailEditor.propTypes = {
   router: PropTypes.object,
   setPlaceRequestType: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
+  updateActiveEditPlaceId: PropTypes.func.isRequired,
   updateEditModeToggled: PropTypes.func.isRequired,
   updatePlace: PropTypes.func.isRequired,
 };
@@ -399,7 +400,8 @@ const mapDispatchToProps = dispatch => ({
   removePlace: placeId => dispatch(removePlace(placeId)),
   removePlaceAttachment: (placeId, attachmentId) =>
     dispatch(removePlaceAttachment(placeId, attachmentId)),
-  updateActivePlaceId: placeId => dispatch(updateActivePlaceId(placeId)),
+  updateActiveEditPlaceId: placeId =>
+    dispatch(updateActiveEditPlaceId(placeId)),
 });
 
 export default connect(

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -28,6 +28,7 @@ import {
   removePlace,
   removePlaceAttachment,
   placePropType,
+  updateActivePlaceId,
 } from "../../state/ducks/places";
 import { removeGeoJSONFeature } from "../../state/ducks/map";
 import { updateEditModeToggled } from "../../state/ducks/ui";
@@ -80,6 +81,14 @@ class PlaceDetailEditor extends Component {
       showValidityStatus: false,
       isNetworkRequestInFlight: false,
     };
+  }
+
+  componentDidMount() {
+    this.props.updateActivePlaceId(this.props.place.id);
+  }
+
+  componentWillUnmount() {
+    this.props.updateActivePlaceId(null);
   }
 
   async updatePlace() {
@@ -389,6 +398,7 @@ const mapDispatchToProps = dispatch => ({
   removePlace: placeId => dispatch(removePlace(placeId)),
   removePlaceAttachment: (placeId, attachmentId) =>
     dispatch(removePlaceAttachment(placeId, attachmentId)),
+  updateActivePlaceId: placeId => dispatch(updateActivePlaceId(placeId)),
 });
 
 export default connect(

--- a/src/base/static/components/templates/main-map.js
+++ b/src/base/static/components/templates/main-map.js
@@ -423,8 +423,8 @@ class MainMap extends Component {
           mapboxApiAccessToken={MAP_PROVIDER_TOKEN}
           minZoom={this.props.mapViewport.minZoom}
           maxZoom={this.props.mapViewport.maxZoom}
-          onMouseUp={this.onMouseUp}
-          onMouseDown={this.onMouseDown}
+          onMouseUp={this.endFeatureQuery}
+          onMouseDown={this.beginFeatureQuery}
           onTouchEnd={this.onMouseUp}
           onTouchStart={this.onMouseDown}
           onViewportChange={viewport => {

--- a/src/base/static/components/templates/main-map.js
+++ b/src/base/static/components/templates/main-map.js
@@ -20,7 +20,7 @@ import {
   sourcesMetadataSelector,
   updateMapDragged,
   updateMapDragging,
-  updateGeoJSONFeatures,
+  updateFeaturesInGeoJSONSource,
   sourcesMetadataPropType,
   updateSources,
   updateLayers,
@@ -218,11 +218,7 @@ class MainMap extends Component {
         return true;
       };
       this.map.setSourceData = (sourceId, newFeatures) => {
-        this.props.updateGeoJSONFeatures({
-          sourceId,
-          newFeatures,
-          mode: "replace",
-        });
+        this.props.updateFeaturesInGeoJSONSource(sourceId, newFeatures);
       };
 
       this.map.on("draw.update", evt => {
@@ -262,11 +258,7 @@ class MainMap extends Component {
     // Remove any drawn geometry.
     this.props.setActiveDrawGeometryId(null);
     ["mapbox-gl-draw-cold", "mapbox-gl-draw-hot"].forEach(sourceId =>
-      this.props.updateGeoJSONFeatures({
-        sourceId,
-        newFeatures: [],
-        mode: "replace",
-      }),
+      this.props.updateFeaturesInGeoJSONSource(sourceId, []),
     );
     this.draw.deleteAll();
   }
@@ -300,12 +292,10 @@ class MainMap extends Component {
       const sourceId = this.props.placeFilters.length
         ? this.props.placeFilters[0].datasetSlug
         : prevProps.placeFilters[0].datasetSlug;
-      this.props.updateGeoJSONFeatures({
+      this.props.updateFeaturesInGeoJSONSource(
         sourceId,
-        newFeatures: createGeoJSONFromPlaces(this.props.filteredPlaces)
-          .features,
-        mode: "replace",
-      });
+        createGeoJSONFromPlaces(this.props.filteredPlaces).features,
+      );
     }
 
     if (
@@ -530,7 +520,7 @@ MainMap.propTypes = {
   sourcesMetadata: sourcesMetadataPropType.isRequired,
   updateMapDragged: PropTypes.func.isRequired,
   updateMapDragging: PropTypes.func.isRequired,
-  updateGeoJSONFeatures: PropTypes.func.isRequired,
+  updateFeaturesInGeoJSONSource: PropTypes.func.isRequired,
   updateLayers: PropTypes.func.isRequired,
   updateMapViewport: PropTypes.func.isRequired,
   updateSources: PropTypes.func.isRequired,
@@ -564,8 +554,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setLeftSidebarComponent(component)),
   updateMapDragged: isDragged => dispatch(updateMapDragged(isDragged)),
   updateMapDragging: isDragging => dispatch(updateMapDragging(isDragging)),
-  updateGeoJSONFeatures: ({ sourceId, newFeatures, mode }) =>
-    dispatch(updateGeoJSONFeatures({ sourceId, newFeatures, mode })),
+  updateFeaturesInGeoJSONSource: (sourceId, newFeatures) =>
+    dispatch(updateFeaturesInGeoJSONSource(sourceId, newFeatures)),
   updateMapViewport: viewport => dispatch(updateMapViewport(viewport)),
   updateSourceLoadStatus: (sourceId, loadStatus) =>
     dispatch(updateSourceLoadStatus(sourceId, loadStatus)),

--- a/src/base/static/components/templates/main-map.js
+++ b/src/base/static/components/templates/main-map.js
@@ -335,6 +335,7 @@ class MainMap extends Component {
         }
       }
 
+      // TODO: activePlaceId is a poor name
       if (!prevProps.activePlaceId && this.props.activePlaceId) {
         // The user has entered Edit mode with pre-existing drawn geometry.
         const activeDrawGeometryId = this.draw.add(
@@ -343,18 +344,6 @@ class MainMap extends Component {
         this.props.setActiveDrawGeometryId(activeDrawGeometryId);
         this.draw.changeMode(this.draw.modes.SIMPLE_SELECT);
         this.updateDrawGeometryStyle(activeDrawGeometryId);
-      }
-
-      if (
-        this.props.activeMarker !== prevProps.activeMarker &&
-        this.draw.get(this.props.activeDrawGeometryId)
-      ) {
-        this.draw.setFeatureProperty(
-          this.props.activeDrawGeometryId,
-          "marker-symbol",
-          this.props.activeMarker,
-        );
-        this.draw.set(this.draw.getAll());
       }
 
       if (

--- a/src/base/static/components/templates/main-map.js
+++ b/src/base/static/components/templates/main-map.js
@@ -43,7 +43,7 @@ import {
   setLeftSidebarComponent,
 } from "../../state/ducks/left-sidebar";
 import {
-  activePlaceIdSelector,
+  activeEditPlaceIdSelector,
   filteredPlacesSelector,
   placePropType,
   placeSelector,
@@ -335,11 +335,10 @@ class MainMap extends Component {
         }
       }
 
-      // TODO: activePlaceId is a poor name
-      if (!prevProps.activePlaceId && this.props.activePlaceId) {
+      if (!prevProps.activeEditPlaceId && this.props.activeEditPlaceId) {
         // The user has entered Edit mode with pre-existing drawn geometry.
         const activeDrawGeometryId = this.draw.add(
-          this.props.placeSelector(this.props.activePlaceId).geometry,
+          this.props.placeSelector(this.props.activeEditPlaceId).geometry,
         )[0];
         this.props.setActiveDrawGeometryId(activeDrawGeometryId);
         this.draw.changeMode(this.draw.modes.SIMPLE_SELECT);
@@ -500,7 +499,7 @@ MainMap.propTypes = {
   activeDrawGeometryId: PropTypes.string,
   activeDrawingTool: PropTypes.string,
   activeMarker: PropTypes.string,
-  activePlaceId: PropTypes.number,
+  activeEditPlaceId: PropTypes.number,
   container: PropTypes.instanceOf(Element).isRequired,
   filteredPlaces: PropTypes.arrayOf(placePropType).isRequired,
   geometryStyle: geometryStyleProps,
@@ -542,7 +541,7 @@ const mapStateToProps = state => ({
   activeDrawGeometryId: activeDrawGeometryIdSelector(state),
   activeDrawingTool: activeDrawingToolSelector(state),
   activeMarker: activeMarkerSelector(state),
-  activePlaceId: activePlaceIdSelector(state),
+  activeEditPlaceId: activeEditPlaceIdSelector(state),
   filteredPlaces: filteredPlacesSelector(state),
   geometryStyle: geometryStyleSelector(state),
   isDrawModeActive: drawModeActiveSelector(state),

--- a/src/base/static/components/templates/main-map.js
+++ b/src/base/static/components/templates/main-map.js
@@ -357,6 +357,7 @@ class MainMap extends Component {
 
       if (prevProps.activeDrawGeometryId && !this.props.activeDrawGeometryId) {
         this.draw.deleteAll();
+        emitter.emit("draw:update-geometry", null);
       }
     }
   }

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -45,8 +45,6 @@ import { setRightSidebarConfig } from "../../state/ducks/right-sidebar-config";
 import { setAppConfig } from "../../state/ducks/app-config";
 import { loadDashboardConfig } from "../../state/ducks/dashboard-config";
 import {
-  mapPositionSelector,
-  setMapDragging,
   updateMapViewport,
   loadMapViewport,
   updateFocusedGeoJSONFeatures,
@@ -893,7 +891,6 @@ export default Backbone.View.extend({
     store.dispatch(setContentPanel(true));
 
     const dimensions = this.getMapDimensions();
-    console.log("!!!", dimensions);
     store.dispatch(
       updateMapViewport({
         width: dimensions.width,
@@ -919,7 +916,6 @@ export default Backbone.View.extend({
     store.dispatch(setContentPanel(false));
 
     const dimensions = this.getMapDimensions();
-    console.log("!!!", dimensions);
     store.dispatch(
       updateMapViewport({
         width: dimensions.width,

--- a/src/base/static/state/ducks/map-drawing-toolbar.js
+++ b/src/base/static/state/ducks/map-drawing-toolbar.js
@@ -139,10 +139,6 @@ export default function reducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         geometryStyle: action.payload,
-        //  geometryStyle: {
-        //    ...state.geometryStyle,
-        //    ...action.payload,
-        //  },
       };
     case RESET_DRAWING_TOOLBAR_STATE:
       return INITIAL_STATE;

--- a/src/base/static/state/ducks/map-drawing-toolbar.js
+++ b/src/base/static/state/ducks/map-drawing-toolbar.js
@@ -17,6 +17,9 @@ export const activeMarkerSelector = state => {
     state.mapDrawingToolbar.activeMarkerIndex
   ];
 };
+export const markerSelector = (state, markerIndex) => {
+  return state.mapDrawingToolbar.markers[markerIndex];
+};
 export const activeDrawGeometryIdSelector = state => {
   return state.mapDrawingToolbar.activeDrawGeometryId;
 };
@@ -27,10 +30,11 @@ export const geometryStyleSelector = state => {
   return state.mapDrawingToolbar.geometryStyle;
 };
 export const geometryStyleProps = PropTypes.shape({
-  [constants.LINE_COLOR_PROPERTY_NAME]: PropTypes.string.isRequired,
-  [constants.LINE_OPACITY_PROPERTY_NAME]: PropTypes.number.isRequired,
-  [constants.FILL_COLOR_PROPERTY_NAME]: PropTypes.string.isRequired,
-  [constants.FILL_OPACITY_PROPERTY_NAME]: PropTypes.number.isRequired,
+  stroke: PropTypes.string,
+  "stroke-opacity": PropTypes.number,
+  fill: PropTypes.string,
+  "fill-opacity": PropTypes.number,
+  "marker-symbol": PropTypes.string,
 });
 
 // Actions:
@@ -134,10 +138,11 @@ export default function reducer(state = INITIAL_STATE, action) {
     case SET_GEOMETRY_STYLE:
       return {
         ...state,
-        geometryStyle: {
-          ...state.geometryStyle,
-          ...action.payload,
-        },
+        geometryStyle: action.payload,
+        //  geometryStyle: {
+        //    ...state.geometryStyle,
+        //    ...action.payload,
+        //  },
       };
     case RESET_DRAWING_TOOLBAR_STATE:
       return INITIAL_STATE;

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -417,14 +417,13 @@ export default function reducer(state = INITIAL_STATE, action) {
                 features: state.style.sources[
                   action.payload.sourceId
                 ].data.features.filter(
-                  feature => feature.id !== action.payload.featureId,
+                  feature => feature.properties.id !== action.payload.featureId,
                 ),
               },
             },
           },
         },
       };
-
     case REMOVE_FOCUSED_GEOJSON_FEATURES:
       return {
         ...state,

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -25,9 +25,11 @@ const LOAD_VIEWPORT = "map/LOAD_VIEWPORT";
 const UPDATE_VIEWPORT = "map/UPDATE_VIEWPORT";
 const UPDATE_STYLE = "map/UPDATE_STYLE";
 const UPDATE_LAYER_GROUP_LOAD_STATUS = "map/UPDATE_LAYER_GROUP_LOAD_STATUS";
-const UPDATE_GEOJSON_SOURCE = "map/UPDATE_GEOJSON_SOURCE";
+const UPDATE_FEATURES_IN_GEOJSON_SOURCE =
+  "map/UPDATE_FEATURES_IN_GEOJSON_SOURCE";
 const CREATE_FEATURES_IN_GEOJSON_SOURCE =
   "map/CREATE_FEATURES_IN_GEOJSON_SOURCE";
+const REMOVE_FEATURE_IN_GEOJSON_SOURCE = "map/REMOVE_FEATURE_IN_GEOJSON_SOURCE";
 const LOAD_STYLE_AND_METADATA = "map/LOAD_STYLE_AND_METADATA";
 const UPDATE_SOURCE_LOAD_STATUS = "map/UPDATE_SOURCE_LOAD_STATUS";
 const UPDATE_LAYER_GROUP_VISIBILITY = "map/UPDATE_LAYER_GROUP_VISIBILITY";
@@ -35,14 +37,9 @@ const UPDATE_FOCUSED_GEOJSON_FEATURES = "map/UPDATE_FOCUSED_GEOJSON_FEATURES";
 const REMOVE_FOCUSED_GEOJSON_FEATURES = "map/REMOVE_FOCUSED_GEOJSON_FEATURES";
 const UPDATE_MAP_DRAGGED = "map/UPDATE_MAP_DRAGGED";
 const UPDATE_MAP_DRAGGING = "map/UPDATE_MAP_DRAGGING";
-const REMOVE_GEOJSON_FEATURE = "map/REMOVE_GEOJSON_FEATURE";
 const UPDATE_SOURCES = "map/UPDATE_SOURCES";
 const UPDATE_LAYERS = "map/UPDATE_LAYERS";
 const UPDATE_DRAW_MODE_ACTIVE = "map/UPDATE_DRAW_MODE_ACTIVE";
-const UPDATE_GEOJSON_SOURCE_REMOVE_FEATURE =
-  "map/UPDATE_GEOJSON_SOURCE_REMOVE_FEATURE";
-const UPDATE_GEOJSON_SOURCE_ADD_FEATURE =
-  "map/UPDATE_GEOJSON_SOURCE_ADD_FEATURE";
 
 // Layer group load status terminology:
 // ------------------------------------
@@ -61,30 +58,6 @@ export function updateLayerGroupLoadStatus(groupId, loadStatus) {
   return {
     type: UPDATE_LAYER_GROUP_LOAD_STATUS,
     payload: { groupId, loadStatus },
-  };
-}
-
-export function updateGeoJSONSourceAddFeature(sourceId, place) {
-  const { geometry, ...rest } = place;
-
-  return {
-    // sourceId is equivalent to a datasetSlug.
-    type: UPDATE_GEOJSON_SOURCE_ADD_FEATURE,
-    payload: {
-      sourceId,
-      feature: {
-        type: "Feature",
-        geometry,
-        properties: rest,
-      },
-    },
-  };
-}
-
-export function updateGeoJSONSourceRemoveFeature(sourceId, featureId) {
-  return {
-    type: UPDATE_GEOJSON_SOURCE_REMOVE_FEATURE,
-    payload: { sourceId, featureId },
   };
 }
 
@@ -163,9 +136,9 @@ export function updateMapDragging(isDragging) {
   return { type: UPDATE_MAP_DRAGGING, payload: isDragging };
 }
 
-export function updateGeoJSONSource(sourceId, newFeatures) {
+export function updateFeaturesInGeoJSONSource(sourceId, newFeatures) {
   return {
-    type: UPDATE_GEOJSON_SOURCE,
+    type: UPDATE_FEATURES_IN_GEOJSON_SOURCE,
     payload: {
       sourceId,
       newFeatures,
@@ -180,9 +153,9 @@ export function createFeaturesInGeoJSONSource(sourceId, newFeatures) {
   };
 }
 
-export function removeGeoJSONFeature(sourceId, featureId) {
+export function removeFeatureInGeoJSONSource(sourceId, featureId) {
   return {
-    type: REMOVE_GEOJSON_FEATURE,
+    type: REMOVE_FEATURE_IN_GEOJSON_SOURCE,
     payload: { sourceId, featureId },
   };
 }
@@ -394,7 +367,7 @@ const INITIAL_STATE = {
 
 export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
-    case UPDATE_GEOJSON_SOURCE:
+    case UPDATE_FEATURES_IN_GEOJSON_SOURCE:
       return {
         ...state,
         style: {
@@ -430,7 +403,7 @@ export default function reducer(state = INITIAL_STATE, action) {
           },
         },
       };
-    case REMOVE_GEOJSON_FEATURE:
+    case REMOVE_FEATURE_IN_GEOJSON_SOURCE:
       return {
         ...state,
         style: {
@@ -684,46 +657,6 @@ export default function reducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         isDrawModeActive: action.payload,
-      };
-    case UPDATE_GEOJSON_SOURCE_REMOVE_FEATURE:
-      return {
-        ...state,
-        style: {
-          ...state.style,
-          sources: {
-            ...state.style.sources,
-            [action.payload.sourceId]: {
-              ...state.style.sources[action.payload.sourceId],
-              data: {
-                ...state.style.sources[action.payload.sourceId].data,
-                features: state.style.sources[
-                  action.payload.sourceId
-                ].data.features.filter(
-                  feature => feature.properties.id !== action.payload.featureId,
-                ),
-              },
-            },
-          },
-        },
-      };
-    case UPDATE_GEOJSON_SOURCE_ADD_FEATURE:
-      return {
-        ...state,
-        style: {
-          ...state.style,
-          sources: {
-            ...state.style.sources,
-            [action.payload.sourceId]: {
-              ...state.style.sources[action.payload.sourceId],
-              data: {
-                ...state.style.sources[action.payload.sourceId].data,
-                features: state.style.sources[
-                  action.payload.sourceId
-                ].data.features.concat(action.payload.feature),
-              },
-            },
-          },
-        },
       };
     default:
       return state;

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -18,6 +18,7 @@ export const mapCenterpointSelector = state => ({
   latitude: state.map.viewport.latitude,
   longitude: state.map.viewport.longitude,
 });
+export const drawModeActiveSelector = state => state.map.isDrawModeActive;
 
 // Actions:
 const LOAD_VIEWPORT = "map/LOAD_VIEWPORT";
@@ -35,12 +36,15 @@ const REMOVE_FOCUSED_GEOJSON_FEATURES = "map/REMOVE_FOCUSED_GEOJSON_FEATURES";
 const UPDATE_MAP_DRAGGED = "map/UPDATE_MAP_DRAGGED";
 const UPDATE_MAP_DRAGGING = "map/UPDATE_MAP_DRAGGING";
 const REMOVE_GEOJSON_FEATURE = "map/REMOVE_GEOJSON_FEATURE";
+const UPDATE_SOURCES = "map/UPDATE_SOURCES";
+const UPDATE_LAYERS = "map/UPDATE_LAYERS";
+const UPDATE_DRAW_MODE_ACTIVE = "map/UPDATE_DRAW_MODE_ACTIVE"
 
 // Layer group load status terminology:
 // ------------------------------------
 // "unloaded": The map has not yet begun to fetch data for any source consumed
-// "loading": The map has begun fetching data for one or more sources consumed
 //     by this layer group.
+// "loading": The map has begun fetching data for one or more sources consumed
 //     by this layer group, but has not finished.
 // "loaded": All data for all sources consumed by this layer group have been
 //     fetched. Rendering may or may not be in progress.
@@ -60,6 +64,27 @@ export function removeFocusedGeoJSONFeatures() {
   return {
     type: REMOVE_FOCUSED_GEOJSON_FEATURES,
     payload: null,
+  };
+}
+
+export function updateDrawModeActive(isActive) {
+  return {
+    type: UPDATE_DRAW_MODE_ACTIVE,
+    payload: isActive
+  }
+}
+
+export function updateSources(newSourceId, newSource) {
+  return {
+    type: UPDATE_SOURCES,
+    payload: { newSourceId, newSource },
+  };
+}
+
+export function updateLayers(newLayer) {
+  return {
+    type: UPDATE_LAYERS,
+    payload: newLayer,
   };
 }
 
@@ -336,6 +361,7 @@ const INITIAL_STATE = {
   isMapSizeValid: false,
   isMapDragged: false,
   isMapDragging: false,
+  isDrawModeActive: false,
 };
 
 export default function reducer(state = INITIAL_STATE, action) {
@@ -607,6 +633,30 @@ export default function reducer(state = INITIAL_STATE, action) {
         ...state,
         isMapDragging: action.payload,
       };
+    case UPDATE_SOURCES:
+      return {
+        ...state,
+        style: {
+          ...state.style,
+          sources: {
+            ...state.style.sources,
+            [action.payload.newSourceId]: action.payload.newSource,
+          },
+        },
+      };
+    case UPDATE_LAYERS:
+      return {
+        ...state,
+        style: {
+          ...state.style,
+          layers: state.style.layers.concat(action.payload),
+        },
+      };
+    case UPDATE_DRAW_MODE_ACTIVE:
+      return {
+        ...state,
+        isDrawModeActive: action.payload
+      }
     default:
       return state;
   }

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -43,6 +43,10 @@ export const placeExists = (state, placeId) => {
   return !!state.places.placeModels.find(place => place.id === placeId);
 };
 
+export const activePlaceIdSelector = state => {
+  return state.places.activePlaceId;
+};
+
 export const placePropType = PropTypes.shape({
   attachments: PropTypes.array.isRequired,
   updated_datetime: PropTypes.string.isRequired,
@@ -77,6 +81,7 @@ const UPDATE_PLACE_TAG = "places/UPDATE_PLACE_TAG";
 const REMOVE_PLACE_ATTACHMENT = "places/REMOVE_PLACE_ATTACHMENT";
 const CREATE_PLACE_ATTACHMENT = "places/CREATE_PLACE_ATTACHMENT";
 const UPDATE_LOAD_STATUS = "places/UPDATE_LOAD_STATUS";
+const UPDATE_ACTIVE_PLACE_ID = "places/UPDATE_ACTIVE_PLACE_ID";
 
 // Action creators:
 export function loadPlaces(places, storyConfig = {}) {
@@ -94,6 +99,10 @@ export function loadPlaces(places, storyConfig = {}) {
   });
 
   return { type: LOAD_PLACES, payload: places };
+}
+
+export function updateActivePlaceId(placeId) {
+  return { type: UPDATE_ACTIVE_PLACE_ID, payload: placeId };
 }
 
 export function updatePlace(place) {
@@ -185,6 +194,7 @@ const normalizeSubmissionSets = place => {
 const INITIAL_STATE = {
   placeModels: [],
   loadStatus: "unloaded",
+  activePlaceId: null,
 };
 
 export default function reducer(state = INITIAL_STATE, action) {
@@ -368,6 +378,11 @@ export default function reducer(state = INITIAL_STATE, action) {
 
           return place;
         }),
+      };
+    case UPDATE_ACTIVE_PLACE_ID:
+      return {
+        ...state,
+        activePlaceId: action.payload,
       };
     default:
       return state;

--- a/src/base/static/state/ducks/places.js
+++ b/src/base/static/state/ducks/places.js
@@ -43,8 +43,8 @@ export const placeExists = (state, placeId) => {
   return !!state.places.placeModels.find(place => place.id === placeId);
 };
 
-export const activePlaceIdSelector = state => {
-  return state.places.activePlaceId;
+export const activeEditPlaceIdSelector = state => {
+  return state.places.activeEditPlaceId;
 };
 
 export const placePropType = PropTypes.shape({
@@ -81,7 +81,7 @@ const UPDATE_PLACE_TAG = "places/UPDATE_PLACE_TAG";
 const REMOVE_PLACE_ATTACHMENT = "places/REMOVE_PLACE_ATTACHMENT";
 const CREATE_PLACE_ATTACHMENT = "places/CREATE_PLACE_ATTACHMENT";
 const UPDATE_LOAD_STATUS = "places/UPDATE_LOAD_STATUS";
-const UPDATE_ACTIVE_PLACE_ID = "places/UPDATE_ACTIVE_PLACE_ID";
+const UPDATE_ACTIVE_EDIT_PLACE_ID = "places/UPDATE_ACTIVE_EDIT_PLACE_ID";
 
 // Action creators:
 export function loadPlaces(places, storyConfig = {}) {
@@ -101,8 +101,8 @@ export function loadPlaces(places, storyConfig = {}) {
   return { type: LOAD_PLACES, payload: places };
 }
 
-export function updateActivePlaceId(placeId) {
-  return { type: UPDATE_ACTIVE_PLACE_ID, payload: placeId };
+export function updateActiveEditPlaceId(placeId) {
+  return { type: UPDATE_ACTIVE_EDIT_PLACE_ID, payload: placeId };
 }
 
 export function updatePlace(place) {
@@ -194,7 +194,7 @@ const normalizeSubmissionSets = place => {
 const INITIAL_STATE = {
   placeModels: [],
   loadStatus: "unloaded",
-  activePlaceId: null,
+  activeEditPlaceId: null,
 };
 
 export default function reducer(state = INITIAL_STATE, action) {
@@ -379,10 +379,10 @@ export default function reducer(state = INITIAL_STATE, action) {
           return place;
         }),
       };
-    case UPDATE_ACTIVE_PLACE_ID:
+    case UPDATE_ACTIVE_EDIT_PLACE_ID:
       return {
         ...state,
-        activePlaceId: action.payload,
+        activeEditPlaceId: action.payload,
       };
     default:
       return state;

--- a/src/base/static/state/misc/drawing-layers.js
+++ b/src/base/static/state/misc/drawing-layers.js
@@ -1,0 +1,266 @@
+// These layers support drawing via mapbox-gl-draw.
+export default [
+  // Polygon fill: selected.
+  {
+    id: "gl-draw-polygon-fill-active",
+    type: "fill",
+    filter: [
+      "all",
+      ["==", "$type", "Polygon"],
+      ["!=", "mode", "static"],
+      ["==", "active", "true"],
+    ],
+    paint: {
+      "fill-color": [
+        "case",
+        // The user_ prefix is set automatically by the draw plugin.
+        ["has", "user_fill"],
+        ["get", "user_fill"],
+        "#f1f075",
+      ],
+      "fill-opacity": [
+        "case",
+        ["has", "user_fill-opacity"],
+        ["get", "user_fill-opacity"],
+        0.3,
+      ],
+    },
+    layout: {
+      visibility: "visible",
+    },
+  },
+  // Polygon outline: selected.
+  {
+    id: "gl-draw-polygon-stroke-active",
+    type: "line",
+    filter: [
+      "all",
+      ["==", "$type", "Polygon"],
+      ["!=", "mode", "static"],
+      ["==", "active", "true"],
+    ],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+      visibility: "visible",
+    },
+    paint: {
+      "line-color": [
+        "case",
+        ["has", "user_stroke"],
+        ["get", "user_stroke"],
+        "#f86767",
+      ],
+      "line-opacity": [
+        "case",
+        ["has", "user_stroke-opacity"],
+        ["get", "user_stroke-opacity"],
+        0.7,
+      ],
+      "line-width": 3,
+    },
+  },
+  // Linestring: selected.
+  {
+    id: "gl-draw-line-active",
+    type: "line",
+    filter: [
+      "all",
+      ["==", "$type", "LineString"],
+      ["!=", "mode", "static"],
+      ["==", "active", "true"],
+    ],
+    paint: {
+      "line-color": [
+        "case",
+        ["has", "user_stroke"],
+        ["get", "user_stroke"],
+        "#f86767",
+      ],
+      "line-opacity": [
+        "case",
+        ["has", "user_stroke-opacity"],
+        ["get", "user_stroke-opacity"],
+        0.7,
+      ],
+      "line-width": 3,
+    },
+    layout: {
+      visibility: "visible",
+    },
+  },
+  // Vertex point halos.
+  {
+    id: "gl-draw-polygon-and-line-vertex-halo-active",
+    type: "circle",
+    filter: [
+      "all",
+      ["==", "meta", "vertex"],
+      ["==", "$type", "Point"],
+      ["!=", "mode", "static"],
+    ],
+    paint: {
+      "circle-radius": 7,
+      "circle-color": "#FFF",
+    },
+    layout: {
+      visibility: "visible",
+    },
+  },
+  // Vertex points.
+  {
+    id: "gl-draw-polygon-and-line-vertex-active",
+    type: "circle",
+    filter: [
+      "all",
+      ["==", "meta", "vertex"],
+      ["==", "$type", "Point"],
+      ["!=", "mode", "static"],
+    ],
+    paint: {
+      "circle-radius": 5,
+      "circle-color": "#D20C0C",
+    },
+    layout: {
+      visibility: "visible",
+    },
+  },
+  // Line segment midpoints.
+  {
+    id: "gl-draw-polygon-midpoint",
+    type: "circle",
+    filter: ["all", ["==", "$type", "Point"], ["==", "meta", "midpoint"]],
+    paint: {
+      "circle-color": "#D20C0C",
+      "circle-radius": 3,
+    },
+    layout: {
+      visibility: "visible",
+    },
+  },
+  // Points: selected.
+  {
+    id: "gl-draw-marker-active",
+    type: "symbol",
+    filter: [
+      "all",
+      ["==", "$type", "Point"],
+      ["!=", "mode", "static"],
+      ["==", "active", "true"],
+    ],
+    layout: {
+      "icon-image": ["get", "user_marker-symbol"],
+      "icon-allow-overlap": true,
+      "icon-anchor": "bottom",
+      visibility: "visible",
+    },
+  },
+  // Points: unselected.
+  {
+    id: "gl-draw-marker-inactive",
+    type: "symbol",
+    filter: [
+      "all",
+      ["==", "$type", "Point"],
+      ["!=", "mode", "static"],
+      ["==", "active", "false"],
+    ],
+    layout: {
+      "icon-image": ["get", "user_marker-symbol"],
+      "icon-allow-overlap": true,
+      "icon-anchor": "bottom",
+      visibility: "visible",
+    },
+  },
+
+  // Linestring: unselected.
+  {
+    id: "gl-draw-line-inactive",
+    type: "line",
+    filter: [
+      "all",
+      ["==", "$type", "LineString"],
+      ["!=", "mode", "static"],
+      ["==", "active", "false"],
+    ],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+      visibility: "visible",
+    },
+    paint: {
+      "line-color": [
+        "case",
+        ["has", "user_stroke"],
+        ["get", "user_stroke"],
+        "#f86767",
+      ],
+      "line-opacity": [
+        "case",
+        ["has", "user_stroke-opacity"],
+        ["get", "user_stroke-opacity"],
+        0.7,
+      ],
+      "line-width": 3,
+    },
+  },
+  // Polygon fill: unselected.
+  {
+    id: "gl-draw-polygon-fill-inactive",
+    type: "fill",
+    filter: [
+      "all",
+      ["==", "$type", "Polygon"],
+      ["!=", "mode", "static"],
+      ["==", "active", "false"],
+    ],
+    paint: {
+      "fill-color": [
+        "case",
+        ["has", "user_fill"],
+        ["get", "user_fill"],
+        "#f1f075",
+      ],
+      "fill-opacity": [
+        "case",
+        ["has", "user_fill-opacity"],
+        ["get", "user_fill-opacity"],
+        0.3,
+      ],
+    },
+    layout: {
+      visibility: "visible",
+    },
+  },
+  // Polygon outline: unselected.
+  {
+    id: "gl-draw-polygon-stroke-inactive",
+    type: "line",
+    filter: [
+      "all",
+      ["==", "$type", "Polygon"],
+      ["!=", "mode", "static"],
+      ["==", "active", "false"],
+    ],
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+      visibility: "visible",
+    },
+    paint: {
+      "line-color": [
+        "case",
+        ["has", "user_stroke"],
+        ["get", "user_stroke"],
+        "#f86767",
+      ],
+      "line-opacity": [
+        "case",
+        ["has", "user_stroke-opacity"],
+        ["get", "user_stroke-opacity"],
+        0.7,
+      ],
+      "line-width": 3,
+    },
+  },
+];

--- a/src/base/static/utils/place-utils.js
+++ b/src/base/static/utils/place-utils.js
@@ -58,7 +58,6 @@ const toClientGeoJSONFeature = placeData => {
 const toServerGeoJSONFeature = placeData => {
   // We intentionally strip out some keys from the placeData object which
   // should not be sent to the server in the request payload.
-  /* eslint-disable no-unused-vars */
   const {
     geometry,
     submitter,
@@ -69,7 +68,6 @@ const toServerGeoJSONFeature = placeData => {
     _clientSlug,
     ...rest
   } = placeData;
-  /* eslint-enable no-unused-vars */
 
   return {
     type: "Feature",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,6 +107,9 @@ module.exports = {
       { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" },
     ],
   },
+  node: {
+    fs: "empty",
+  },
   plugins: [
     new webpack.DefinePlugin({
       "process.env.NODE_ENV": isProd


### PR DESCRIPTION
This PR refactors our `mapbox-gl-draw`-based drawing tools to work with `react-map-gl`. Note that the approach used here is a little hacky and is designed to be a stopgap until `react-map-gl` builds out native drawing tools.

See: https://github.com/uber/react-map-gl/issues/734

TODO
 - [x] clean up duck create/update/remove terminology