### PR TITLE
Update pbdemo deployment configuration

### DIFF
--- a/src/flavors/pbdemo/config.json
+++ b/src/flavors/pbdemo/config.json
@@ -277,17 +277,17 @@
               "icon-image": [
                 "match",
                 ["get", "location_type"],
-                "culture-demo",
+                "culture",
                 "fountain.png",
-                "safety-demo",
+                "safety",
                 "safety.png",
-                "parks-demo",
+                "parks",
                 "tree.png",
-                "health-demo",
+                "health",
                 "health.png",
-                "streets-demo",
+                "streets",
                 "street-sidewalk.png",
-                "other-demo",
+                "other",
                 "idea.png",
                 "__no-icon-image__"
               ]
@@ -298,7 +298,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "culture-demo"],
+              ["==", ["get", "location_type"], "culture"],
               ["<", ["zoom"], 10]
             ],
             "symbol-layout": {
@@ -310,7 +310,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "culture-demo"],
+              ["==", ["get", "location_type"], "culture"],
               [">=", ["zoom"], 10],
               ["<", ["zoom"], 13]
             ],
@@ -323,7 +323,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "culture-demo"],
+              ["==", ["get", "location_type"], "culture"],
               [">=", ["zoom"], 13]
             ],
             "symbol-layout": {
@@ -335,7 +335,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "safety-demo"],
+              ["==", ["get", "location_type"], "safety"],
               ["<", ["zoom"], 10]
             ],
             "symbol-layout": {
@@ -347,7 +347,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "safety-demo"],
+              ["==", ["get", "location_type"], "safety"],
               [">=", ["zoom"], 10],
               ["<", ["zoom"], 13]
             ],
@@ -360,7 +360,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "safety-demo"],
+              ["==", ["get", "location_type"], "safety"],
               [">=", ["zoom"], 13]
             ],
             "symbol-layout": {
@@ -372,7 +372,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "parks-demo"],
+              ["==", ["get", "location_type"], "parks"],
               ["<", ["zoom"], 10]
             ],
             "symbol-layout": {
@@ -384,7 +384,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "parks-demo"],
+              ["==", ["get", "location_type"], "parks"],
               [">=", ["zoom"], 10],
               ["<", ["zoom"], 13]
             ],
@@ -397,7 +397,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "parks-demo"],
+              ["==", ["get", "location_type"], "parks"],
               [">=", ["zoom"], 13]
             ],
             "symbol-layout": {
@@ -409,7 +409,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "health-demo"],
+              ["==", ["get", "location_type"], "health"],
               ["<", ["zoom"], 10]
             ],
             "symbol-layout": {
@@ -421,7 +421,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "health-demo"],
+              ["==", ["get", "location_type"], "health"],
               [">=", ["zoom"], 10],
               ["<", ["zoom"], 13]
             ],
@@ -434,7 +434,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "health-demo"],
+              ["==", ["get", "location_type"], "health"],
               [">=", ["zoom"], 13]
             ],
             "symbol-layout": {
@@ -446,7 +446,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "streets-demo"],
+              ["==", ["get", "location_type"], "streets"],
               ["<", ["zoom"], 10]
             ],
             "symbol-layout": {
@@ -458,7 +458,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "streets-demo"],
+              ["==", ["get", "location_type"], "streets"],
               [">=", ["zoom"], 10],
               ["<", ["zoom"], 13]
             ],
@@ -471,7 +471,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "streets-demo"],
+              ["==", ["get", "location_type"], "streets"],
               [">=", ["zoom"], 13]
             ],
             "symbol-layout": {
@@ -483,7 +483,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "other-demo"],
+              ["==", ["get", "location_type"], "other"],
               ["<", ["zoom"], 10]
             ],
             "symbol-layout": {
@@ -495,7 +495,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "other-demo"],
+              ["==", ["get", "location_type"], "other"],
               [">=", ["zoom"], 10],
               ["<", ["zoom"], 13]
             ],
@@ -508,7 +508,7 @@
           {
             "filter": [
               "all",
-              ["==", ["get", "location_type"], "other-demo"],
+              ["==", ["get", "location_type"], "other"],
               [">=", ["zoom"], 13]
             ],
             "symbol-layout": {
@@ -887,10 +887,10 @@
       {
         "formId": "culture",
         "category": "culture",
-        "includeOnForm": false,
+        "includeOnForm": true,
         "includeOnList": true,
         "name": "location_type",
-        "datasetSlug": "pbdurham",
+        "datasetSlug": "pbdemo",
         "icon_url": "/static/css/images/markers/fountain.png",
         "value": "culture",
         "label": "_(Art & Culture)",
@@ -962,10 +962,10 @@
       {
         "formId": "parks",
         "category": "parks",
-        "includeOnForm": false,
+        "includeOnForm": true,
         "includeOnList": true,
         "name": "location_type",
-        "datasetSlug": "pbdurham",
+        "datasetSlug": "pbdemo",
         "icon_url": "/static/css/images/markers/tree.png",
         "value": "parks",
         "label": "_(Parks & Recreation)",
@@ -1037,10 +1037,10 @@
       {
         "formId": "streets",
         "category": "streets",
-        "includeOnForm": false,
+        "includeOnForm": true,
         "includeOnList": true,
         "name": "location_type",
-        "datasetSlug": "pbdurham",
+        "datasetSlug": "pbdemo",
         "icon_url": "/static/css/images/markers/street-sidewalk.png",
         "value": "streets",
         "label": "_(Streets & Sidewalks)",
@@ -1112,10 +1112,10 @@
       {
         "formId": "health",
         "category": "health",
-        "includeOnForm": false,
+        "includeOnForm": true,
         "includeOnList": true,
         "name": "location_type",
-        "datasetSlug": "pbdurham",
+        "datasetSlug": "pbdemo",
         "icon_url": "/static/css/images/markers/health.png",
         "value": "health",
         "label": "_(Health & Wellness)",
@@ -1187,10 +1187,10 @@
       {
         "formId": "safety",
         "category": "safety",
-        "includeOnForm": false,
+        "includeOnForm": true,
         "includeOnList": true,
         "name": "location_type",
-        "datasetSlug": "pbdurham",
+        "datasetSlug": "pbdemo",
         "icon_url": "/static/css/images/markers/safety.png",
         "value": "safety",
         "label": "_(Safety & Environment)",
@@ -1262,456 +1262,6 @@
       {
         "formId": "other",
         "category": "other",
-        "includeOnForm": false,
-        "includeOnList": true,
-        "name": "location_type",
-        "datasetSlug": "pbdurham",
-        "icon_url": "/static/css/images/markers/idea.png",
-        "value": "other",
-        "label": "_(Other)",
-        "fields": [
-          {
-            "name": "title",
-            "type": "text",
-            "prompt": "_(Title:)",
-            "display_prompt": "_(Title:)",
-            "placeholder": "_(Choose a descriptive title for your idea)",
-            "optional": false
-          },
-          {
-            "name": "idea-what",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(What is your idea for what should be built or repaired in our neighborhood?)",
-            "display_prompt": "_(My project idea is:)",
-            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
-            "optional": true
-          },
-          {
-            "name": "idea-why",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(Why is this important? What need in the community does this serve?)",
-            "display_prompt": "_( )",
-            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
-            "optional": true
-          },
-          {
-            "name": "my_image",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-age",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-ethnicity",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-home_address",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submitter_name",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-submitter_email",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-phone",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-volunteer",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submit",
-            "type": "common_form_element"
-          }
-        ]
-      },
-      {
-        "formId": "culture-demo",
-        "category": "culture-demo",
-        "includeOnForm": true,
-        "includeOnList": true,
-        "name": "location_type",
-        "datasetSlug": "pbdemo",
-        "icon_url": "/static/css/images/markers/fountain.png",
-        "value": "culture",
-        "label": "_(Art & Culture)",
-        "fields": [
-          {
-            "name": "title",
-            "type": "text",
-            "prompt": "_(Title:)",
-            "display_prompt": "_(Title:)",
-            "placeholder": "_(Choose a descriptive title for your idea)",
-            "optional": false
-          },
-          {
-            "name": "idea-what",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
-            "display_prompt": "_(My project idea is:)",
-            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
-            "optional": true
-          },
-          {
-            "name": "idea-why",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(Why is this important? What need in the community does this serve?)",
-            "display_prompt": "_( )",
-            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
-            "optional": true
-          },
-          {
-            "name": "my_image",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-age",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-ethnicity",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-home_address",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submitter_name",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-submitter_email",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-phone",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-volunteer",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submit",
-            "type": "common_form_element"
-          }
-        ]
-      },
-      {
-        "formId": "parks-demo",
-        "category": "parks-demo",
-        "includeOnForm": true,
-        "includeOnList": true,
-        "name": "location_type",
-        "datasetSlug": "pbdemo",
-        "icon_url": "/static/css/images/markers/tree.png",
-        "value": "parks",
-        "label": "_(Parks & Recreation)",
-        "fields": [
-          {
-            "name": "title",
-            "type": "text",
-            "prompt": "_(Title:)",
-            "display_prompt": "_(Title:)",
-            "placeholder": "_(Choose a descriptive title for your idea)",
-            "optional": false
-          },
-          {
-            "name": "idea-what",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
-            "display_prompt": "_(My project idea is:)",
-            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
-            "optional": true
-          },
-          {
-            "name": "idea-why",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(Why is this important? What need in the community does this serve?)",
-            "display_prompt": "_( )",
-            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
-            "optional": true
-          },
-          {
-            "name": "my_image",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-age",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-ethnicity",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-home_address",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submitter_name",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-submitter_email",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-phone",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-volunteer",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submit",
-            "type": "common_form_element"
-          }
-        ]
-      },
-      {
-        "formId": "streets-demo",
-        "category": "streets-demo",
-        "includeOnForm": true,
-        "includeOnList": true,
-        "name": "location_type",
-        "datasetSlug": "pbdemo",
-        "icon_url": "/static/css/images/markers/street-sidewalk.png",
-        "value": "streets",
-        "label": "_(Streets & Sidewalks)",
-        "fields": [
-          {
-            "name": "title",
-            "type": "text",
-            "prompt": "_(Title:)",
-            "display_prompt": "_(Title:)",
-            "placeholder": "_(Choose a descriptive title for your idea)",
-            "optional": false
-          },
-          {
-            "name": "idea-what",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
-            "display_prompt": "_(My project idea is:)",
-            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
-            "optional": true
-          },
-          {
-            "name": "idea-why",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(Why is this important? What need in the community does this serve?)",
-            "display_prompt": "_( )",
-            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
-            "optional": true
-          },
-          {
-            "name": "my_image",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-age",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-ethnicity",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-home_address",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submitter_name",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-submitter_email",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-phone",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-volunteer",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submit",
-            "type": "common_form_element"
-          }
-        ]
-      },
-      {
-        "formId": "health-demo",
-        "category": "health-demo",
-        "includeOnForm": true,
-        "includeOnList": true,
-        "name": "location_type",
-        "datasetSlug": "pbdemo",
-        "icon_url": "/static/css/images/markers/health.png",
-        "value": "health",
-        "label": "_(Health & Wellness)",
-        "fields": [
-          {
-            "name": "title",
-            "type": "text",
-            "prompt": "_(Title:)",
-            "display_prompt": "_(Title:)",
-            "placeholder": "_(Choose a descriptive title for your idea)",
-            "optional": false
-          },
-          {
-            "name": "idea-what",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
-            "display_prompt": "_(My project idea is:)",
-            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
-            "optional": true
-          },
-          {
-            "name": "idea-why",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(Why is this important? What need in the community does this serve?)",
-            "display_prompt": "_( )",
-            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
-            "optional": true
-          },
-          {
-            "name": "my_image",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-age",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-ethnicity",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-home_address",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submitter_name",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-submitter_email",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-phone",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-volunteer",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submit",
-            "type": "common_form_element"
-          }
-        ]
-      },
-      {
-        "formId": "safety-demo",
-        "category": "safety-demo",
-        "includeOnForm": true,
-        "includeOnList": true,
-        "name": "location_type",
-        "datasetSlug": "pbdemo",
-        "icon_url": "/static/css/images/markers/safety.png",
-        "value": "safety",
-        "label": "_(Safety & Environment)",
-        "fields": [
-          {
-            "name": "title",
-            "type": "text",
-            "prompt": "_(Title:)",
-            "display_prompt": "_(Title:)",
-            "placeholder": "_(Choose a descriptive title for your idea)",
-            "optional": false
-          },
-          {
-            "name": "idea-what",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
-            "display_prompt": "_(My project idea is:)",
-            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
-            "optional": true
-          },
-          {
-            "name": "idea-why",
-            "type": "textarea",
-            "includeOnListItem": true,
-            "prompt": "_(Why is this important? What need in the community does this serve?)",
-            "display_prompt": "_( )",
-            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
-            "optional": true
-          },
-          {
-            "name": "my_image",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-age",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-ethnicity",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-home_address",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submitter_name",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-submitter_email",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-phone",
-            "type": "common_form_element"
-          },
-          {
-            "name": "private-volunteer",
-            "type": "common_form_element"
-          },
-          {
-            "name": "submit",
-            "type": "common_form_element"
-          }
-        ]
-      },
-      {
-        "formId": "other-demo",
-        "category": "other-demo",
         "includeOnForm": true,
         "includeOnList": true,
         "name": "location_type",

--- a/src/flavors/pbdemo/config.json
+++ b/src/flavors/pbdemo/config.json
@@ -1,12 +1,23 @@
 {
   "datasets": [
     {
-      "slug": "pbdurham",
-      "url": "https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/pbdurham",
+      "slug": "pbdemo",
+      "url": "https://api.heyduwamish.org/api/v2/smartercleanup/datasets/pbdemo",
       "clientSlug": "idea",
       "anonymous_permissions": [
         {
           "abilities": ["retrieve", "create"],
+          "submission_set": "*"
+        }
+      ]
+    },
+    {
+      "slug": "pbdurham",
+      "url": "https://api.heyduwamish.org/api/v2/smartercleanup/datasets/pbdurham",
+      "clientSlug": "idea",
+      "anonymous_permissions": [
+        {
+          "abilities": ["retrieve"],
           "submission_set": "*"
         }
       ]
@@ -248,6 +259,262 @@
               "line-color": "#ffffff",
               "line-width": 2,
               "line-opacity": 0.7
+            }
+          }
+        ]
+      },
+      {
+        "id": "pbdemo",
+        "type": "place",
+        "datasetSlug": "pbdemo",
+        "feature_types": ["Point"],
+        "is_visible_default": true,
+        "focus_rules": [
+          {
+            "symbol-layout": {
+              "icon-size": 0.7,
+              "icon-anchor": "bottom",
+              "icon-image": [
+                "match",
+                ["get", "location_type"],
+                "culture-demo",
+                "fountain.png",
+                "safety-demo",
+                "safety.png",
+                "parks-demo",
+                "tree.png",
+                "health-demo",
+                "health.png",
+                "streets-demo",
+                "street-sidewalk.png",
+                "other-demo",
+                "idea.png",
+                "__no-icon-image__"
+              ]
+            }
+          }
+        ],
+        "rules": [
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "culture-demo"],
+              ["<", ["zoom"], 10]
+            ],
+            "symbol-layout": {
+              "icon-image": "dot-b75ab8.png",
+              "icon-size": 0.3,
+              "icon-anchor": "center"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "culture-demo"],
+              [">=", ["zoom"], 10],
+              ["<", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "fountain-small.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "culture-demo"],
+              [">=", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "fountain.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "safety-demo"],
+              ["<", ["zoom"], 10]
+            ],
+            "symbol-layout": {
+              "icon-image": "dot-fc9229.png",
+              "icon-size": 0.3,
+              "icon-anchor": "center"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "safety-demo"],
+              [">=", ["zoom"], 10],
+              ["<", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "safety-small.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "safety-demo"],
+              [">=", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "safety.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "parks-demo"],
+              ["<", ["zoom"], 10]
+            ],
+            "symbol-layout": {
+              "icon-image": "dot-55a504.png",
+              "icon-size": 0.3,
+              "icon-anchor": "center"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "parks-demo"],
+              [">=", ["zoom"], 10],
+              ["<", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-size": 0.4,
+              "icon-image": "tree-small.png",
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "parks-demo"],
+              [">=", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "tree.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "health-demo"],
+              ["<", ["zoom"], 10]
+            ],
+            "symbol-layout": {
+              "icon-image": "dot-ff78be.png",
+              "icon-size": 0.3,
+              "icon-anchor": "center"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "health-demo"],
+              [">=", ["zoom"], 10],
+              ["<", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-size": 0.4,
+              "icon-image": "health-small.png",
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "health-demo"],
+              [">=", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "health.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "streets-demo"],
+              ["<", ["zoom"], 10]
+            ],
+            "symbol-layout": {
+              "icon-image": "dot-8ea4b8.png",
+              "icon-size": 0.3,
+              "icon-anchor": "center"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "streets-demo"],
+              [">=", ["zoom"], 10],
+              ["<", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-size": 0.4,
+              "icon-image": "street-sidewalk-small.png",
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "streets-demo"],
+              [">=", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "street-sidewalk.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "other-demo"],
+              ["<", ["zoom"], 10]
+            ],
+            "symbol-layout": {
+              "icon-image": "dot-ffd614.png",
+              "icon-size": 0.3,
+              "icon-anchor": "center"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "other-demo"],
+              [">=", ["zoom"], 10],
+              ["<", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-size": 0.4,
+              "icon-image": "idea-small.png",
+              "icon-anchor": "bottom"
+            }
+          },
+          {
+            "filter": [
+              "all",
+              ["==", ["get", "location_type"], "other-demo"],
+              [">=", ["zoom"], 13]
+            ],
+            "symbol-layout": {
+              "icon-image": "idea.png",
+              "icon-size": 0.4,
+              "icon-anchor": "bottom"
             }
           }
         ]
@@ -545,7 +812,11 @@
             "layers": [
               {
                 "id": "pbdurham",
-                "title": "_(Your Ideas)"
+                "title": "_(Original PB Durham Ideas)"
+              },
+              {
+                "id": "pbdemo",
+                "title": "_(Demo ideas)"
               }
             ]
           },
@@ -616,7 +887,7 @@
       {
         "formId": "culture",
         "category": "culture",
-        "includeOnForm": true,
+        "includeOnForm": false,
         "includeOnList": true,
         "name": "location_type",
         "datasetSlug": "pbdurham",
@@ -691,7 +962,7 @@
       {
         "formId": "parks",
         "category": "parks",
-        "includeOnForm": true,
+        "includeOnForm": false,
         "includeOnList": true,
         "name": "location_type",
         "datasetSlug": "pbdurham",
@@ -766,7 +1037,7 @@
       {
         "formId": "streets",
         "category": "streets",
-        "includeOnForm": true,
+        "includeOnForm": false,
         "includeOnList": true,
         "name": "location_type",
         "datasetSlug": "pbdurham",
@@ -841,7 +1112,7 @@
       {
         "formId": "health",
         "category": "health",
-        "includeOnForm": true,
+        "includeOnForm": false,
         "includeOnList": true,
         "name": "location_type",
         "datasetSlug": "pbdurham",
@@ -916,7 +1187,7 @@
       {
         "formId": "safety",
         "category": "safety",
-        "includeOnForm": true,
+        "includeOnForm": false,
         "includeOnList": true,
         "name": "location_type",
         "datasetSlug": "pbdurham",
@@ -991,10 +1262,460 @@
       {
         "formId": "other",
         "category": "other",
-        "includeOnForm": true,
+        "includeOnForm": false,
         "includeOnList": true,
         "name": "location_type",
         "datasetSlug": "pbdurham",
+        "icon_url": "/static/css/images/markers/idea.png",
+        "value": "other",
+        "label": "_(Other)",
+        "fields": [
+          {
+            "name": "title",
+            "type": "text",
+            "prompt": "_(Title:)",
+            "display_prompt": "_(Title:)",
+            "placeholder": "_(Choose a descriptive title for your idea)",
+            "optional": false
+          },
+          {
+            "name": "idea-what",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(What is your idea for what should be built or repaired in our neighborhood?)",
+            "display_prompt": "_(My project idea is:)",
+            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
+            "optional": true
+          },
+          {
+            "name": "idea-why",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(Why is this important? What need in the community does this serve?)",
+            "display_prompt": "_( )",
+            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
+            "optional": true
+          },
+          {
+            "name": "my_image",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-age",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-ethnicity",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-home_address",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submitter_name",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-submitter_email",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-phone",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-volunteer",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submit",
+            "type": "common_form_element"
+          }
+        ]
+      },
+      {
+        "formId": "culture-demo",
+        "category": "culture-demo",
+        "includeOnForm": true,
+        "includeOnList": true,
+        "name": "location_type",
+        "datasetSlug": "pbdemo",
+        "icon_url": "/static/css/images/markers/fountain.png",
+        "value": "culture",
+        "label": "_(Art & Culture)",
+        "fields": [
+          {
+            "name": "title",
+            "type": "text",
+            "prompt": "_(Title:)",
+            "display_prompt": "_(Title:)",
+            "placeholder": "_(Choose a descriptive title for your idea)",
+            "optional": false
+          },
+          {
+            "name": "idea-what",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
+            "display_prompt": "_(My project idea is:)",
+            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
+            "optional": true
+          },
+          {
+            "name": "idea-why",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(Why is this important? What need in the community does this serve?)",
+            "display_prompt": "_( )",
+            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
+            "optional": true
+          },
+          {
+            "name": "my_image",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-age",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-ethnicity",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-home_address",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submitter_name",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-submitter_email",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-phone",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-volunteer",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submit",
+            "type": "common_form_element"
+          }
+        ]
+      },
+      {
+        "formId": "parks-demo",
+        "category": "parks-demo",
+        "includeOnForm": true,
+        "includeOnList": true,
+        "name": "location_type",
+        "datasetSlug": "pbdemo",
+        "icon_url": "/static/css/images/markers/tree.png",
+        "value": "parks",
+        "label": "_(Parks & Recreation)",
+        "fields": [
+          {
+            "name": "title",
+            "type": "text",
+            "prompt": "_(Title:)",
+            "display_prompt": "_(Title:)",
+            "placeholder": "_(Choose a descriptive title for your idea)",
+            "optional": false
+          },
+          {
+            "name": "idea-what",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
+            "display_prompt": "_(My project idea is:)",
+            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
+            "optional": true
+          },
+          {
+            "name": "idea-why",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(Why is this important? What need in the community does this serve?)",
+            "display_prompt": "_( )",
+            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
+            "optional": true
+          },
+          {
+            "name": "my_image",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-age",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-ethnicity",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-home_address",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submitter_name",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-submitter_email",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-phone",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-volunteer",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submit",
+            "type": "common_form_element"
+          }
+        ]
+      },
+      {
+        "formId": "streets-demo",
+        "category": "streets-demo",
+        "includeOnForm": true,
+        "includeOnList": true,
+        "name": "location_type",
+        "datasetSlug": "pbdemo",
+        "icon_url": "/static/css/images/markers/street-sidewalk.png",
+        "value": "streets",
+        "label": "_(Streets & Sidewalks)",
+        "fields": [
+          {
+            "name": "title",
+            "type": "text",
+            "prompt": "_(Title:)",
+            "display_prompt": "_(Title:)",
+            "placeholder": "_(Choose a descriptive title for your idea)",
+            "optional": false
+          },
+          {
+            "name": "idea-what",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
+            "display_prompt": "_(My project idea is:)",
+            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
+            "optional": true
+          },
+          {
+            "name": "idea-why",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(Why is this important? What need in the community does this serve?)",
+            "display_prompt": "_( )",
+            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
+            "optional": true
+          },
+          {
+            "name": "my_image",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-age",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-ethnicity",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-home_address",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submitter_name",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-submitter_email",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-phone",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-volunteer",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submit",
+            "type": "common_form_element"
+          }
+        ]
+      },
+      {
+        "formId": "health-demo",
+        "category": "health-demo",
+        "includeOnForm": true,
+        "includeOnList": true,
+        "name": "location_type",
+        "datasetSlug": "pbdemo",
+        "icon_url": "/static/css/images/markers/health.png",
+        "value": "health",
+        "label": "_(Health & Wellness)",
+        "fields": [
+          {
+            "name": "title",
+            "type": "text",
+            "prompt": "_(Title:)",
+            "display_prompt": "_(Title:)",
+            "placeholder": "_(Choose a descriptive title for your idea)",
+            "optional": false
+          },
+          {
+            "name": "idea-what",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
+            "display_prompt": "_(My project idea is:)",
+            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
+            "optional": true
+          },
+          {
+            "name": "idea-why",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(Why is this important? What need in the community does this serve?)",
+            "display_prompt": "_( )",
+            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
+            "optional": true
+          },
+          {
+            "name": "my_image",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-age",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-ethnicity",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-home_address",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submitter_name",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-submitter_email",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-phone",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-volunteer",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submit",
+            "type": "common_form_element"
+          }
+        ]
+      },
+      {
+        "formId": "safety-demo",
+        "category": "safety-demo",
+        "includeOnForm": true,
+        "includeOnList": true,
+        "name": "location_type",
+        "datasetSlug": "pbdemo",
+        "icon_url": "/static/css/images/markers/safety.png",
+        "value": "safety",
+        "label": "_(Safety & Environment)",
+        "fields": [
+          {
+            "name": "title",
+            "type": "text",
+            "prompt": "_(Title:)",
+            "display_prompt": "_(Title:)",
+            "placeholder": "_(Choose a descriptive title for your idea)",
+            "optional": false
+          },
+          {
+            "name": "idea-what",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(What is your idea for what should be improved in your neighborhood?)",
+            "display_prompt": "_(My project idea is:)",
+            "placeholder": "_(Ideas should be one-time project expenditures that address a community need)",
+            "optional": true
+          },
+          {
+            "name": "idea-why",
+            "type": "textarea",
+            "includeOnListItem": true,
+            "prompt": "_(Why is this important? What need in the community does this serve?)",
+            "display_prompt": "_( )",
+            "placeholder": "_(Let us know how your idea helps the City of Durham!)",
+            "optional": true
+          },
+          {
+            "name": "my_image",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-age",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-ethnicity",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-home_address",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submitter_name",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-submitter_email",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-phone",
+            "type": "common_form_element"
+          },
+          {
+            "name": "private-volunteer",
+            "type": "common_form_element"
+          },
+          {
+            "name": "submit",
+            "type": "common_form_element"
+          }
+        ]
+      },
+      {
+        "formId": "other-demo",
+        "category": "other-demo",
+        "includeOnForm": true,
+        "includeOnList": true,
+        "name": "location_type",
+        "datasetSlug": "pbdemo",
         "icon_url": "/static/css/images/markers/idea.png",
         "value": "other",
         "label": "_(Other)",


### PR DESCRIPTION
Update the `pbdemo` flavor such that we pull prod `pdurham` data in read-only format but let the form talk to a separate `pbdemo` dataset with mirrored categories.