### PR TITLE
feat: group-restricted fields

### DIFF
--- a/src/base/static/components/form-fields/form-field.js
+++ b/src/base/static/components/form-fields/form-field.js
@@ -105,7 +105,8 @@ class FormField extends Component {
         .set(
           constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY,
           this.props.fieldState.get(constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY),
-        ),
+        )
+        .set("config", this.props.fieldState.get("config")),
       isInitializing: isInitializing,
     });
   }

--- a/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
+++ b/src/base/static/components/input-form/__tests__/__snapshots__/input-form.test.js.snap
@@ -21,6 +21,11 @@ exports[`InputForm renders input form 1`] = `
       fieldState={
         Immutable.Map {
           "value": "",
+          "config": Immutable.Map {
+            "name": "test1",
+            "type": "text",
+            "isVisible": true,
+          },
           "trigger": undefined,
           "triggerTargets": undefined,
           "isVisible": true,
@@ -53,6 +58,11 @@ exports[`InputForm renders input form 1`] = `
       fieldState={
         Immutable.Map {
           "value": "",
+          "config": Immutable.Map {
+            "name": "test2",
+            "type": "text",
+            "isVisible": true,
+          },
           "trigger": undefined,
           "triggerTargets": undefined,
           "isVisible": true,
@@ -85,6 +95,11 @@ exports[`InputForm renders input form 1`] = `
       fieldState={
         Immutable.Map {
           "value": "",
+          "config": Immutable.Map {
+            "name": "test3",
+            "type": "text",
+            "isVisible": true,
+          },
           "trigger": undefined,
           "triggerTargets": undefined,
           "isVisible": true,

--- a/src/base/static/components/input-form/__tests__/input-form.test.js
+++ b/src/base/static/components/input-form/__tests__/input-form.test.js
@@ -2,7 +2,6 @@ import React from "react";
 import { shallow } from "enzyme";
 import { InputForm } from "../index.js";
 import FormField from "../../form-fields/form-field";
-import constants from "../../../constants";
 import WarningMessagesContainer from "../../ui-elements/warning-messages-container";
 import { OrderedMap, Map } from "immutable";
 
@@ -66,19 +65,22 @@ describe("InputForm", () => {
     wrapper.setState({
       fields: OrderedMap({
         [fieldName1]: Map({
-          [constants.FIELD_VISIBILITY_KEY]: true,
-          [constants.FIELD_VALIDITY_KEY]: true,
-          [constants.FIELD_VALIDITY_MESSAGE_KEY]: errorMessage1,
+          isVisible: true,
+          isValid: true,
+          message: errorMessage1,
+          config: Map(),
         }),
         [fieldName2]: Map({
-          [constants.FIELD_VISIBILITY_KEY]: true,
-          [constants.FIELD_VALIDITY_KEY]: true,
-          [constants.FIELD_VALIDITY_MESSAGE_KEY]: errorMessage2,
+          isVisible: true,
+          isValid: true,
+          message: errorMessage2,
+          config: Map(),
         }),
         [fieldName3]: Map({
-          [constants.FIELD_VISIBILITY_KEY]: true,
-          [constants.FIELD_VALIDITY_KEY]: false,
-          [constants.FIELD_VALIDITY_MESSAGE_KEY]: errorMessage3,
+          isVisible: true,
+          isValid: false,
+          message: errorMessage3,
+          config: Map(),
         }),
       }),
     });
@@ -104,24 +106,28 @@ describe("InputForm", () => {
     wrapper.setState({
       fields: OrderedMap({
         [fieldName1]: Map({
-          [constants.FIELD_VISIBILITY_KEY]: true,
-          [constants.FIELD_VALUE_KEY]: "",
-          [constants.FIELD_VALIDITY_KEY]: true,
+          isVisible: true,
+          value: "",
+          isValid: true,
+          config: Map(),
         }),
         [fieldName2]: Map({
-          [constants.FIELD_VISIBILITY_KEY]: true,
-          [constants.FIELD_VALUE_KEY]: "",
-          [constants.FIELD_VALIDITY_KEY]: true,
+          isVisible: true,
+          value: "",
+          isValid: true,
+          config: Map(),
         }),
         [fieldName3]: Map({
-          [constants.FIELD_VISIBILITY_KEY]: true,
-          [constants.FIELD_VALUE_KEY]: "",
-          [constants.FIELD_VALIDITY_KEY]: true,
+          isVisible: true,
+          value: "",
+          isValid: true,
+          config: Map(),
         }),
         [fieldName4]: Map({
-          [constants.FIELD_VISIBILITY_KEY]: true,
-          [constants.FIELD_VALUE_KEY]: "",
-          [constants.FIELD_VALIDITY_KEY]: true,
+          isVisible: true,
+          value: "",
+          isValid: true,
+          config: Map(),
         }),
       }),
     });

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -133,6 +133,10 @@ class InputForm extends Component {
             config: fieldConfig,
             trigger: field.trigger && field.trigger.trigger_value,
             triggerTargets: field.trigger && fromJS(field.trigger.targets),
+            // A field will be hidden if it is explicitly declared as
+            // hidden_default in the config, or if it is restricted to a
+            // group and the current user is not in that group or is not in
+            // the administrators group.
             isVisible: field.hidden_default
               ? false
               : fieldConfig.has("restrictToGroup")
@@ -355,7 +359,7 @@ class InputForm extends Component {
         if (fieldConfig.autocomplete) {
           Util.saveAutocompleteValue(
             fieldConfig.name,
-            this.state.fields.get(fieldConfig.name).get("value"),
+            this.state.fields.getIn([fieldConfig.name, "value"]),
             30, // 30 days
           );
         }

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -11,7 +11,6 @@ import FormStageHeaderBar from "../molecules/form-stage-header-bar";
 import FormStageControlBar from "../molecules/form-stage-control-bar";
 
 import { translate } from "react-i18next";
-import constants from "../../constants";
 import { extractEmbeddedImages } from "../../utils/embedded-images";
 import { scrollTo } from "../../utils/scroll-helpers";
 import "./index.scss";
@@ -36,7 +35,7 @@ import {
   hideLayers,
   setBasemap,
 } from "../../state/ducks/map";
-import { hasAdminAbilities } from "../../state/ducks/user";
+import { hasAdminAbilities, isInGroup } from "../../state/ducks/user";
 import emitter from "../../utils/emitter";
 const Util = require("../../js/utils.js");
 
@@ -124,25 +123,29 @@ class InputForm extends Component {
     return this.selectedCategoryConfig.fields
       .filter(field => field.isVisible)
       .reduce((memo, field) => {
+        const fieldConfig = fromJS(
+          this.selectedCategoryConfig.fields.find(f => f.name === field.name),
+        );
         return memo.set(
           field.name,
           Map({
-            [constants.FIELD_VALUE_KEY]: "",
-            [constants.FIELD_TRIGGER_VALUE_KEY]:
-              field.trigger && field.trigger.trigger_value,
-            [constants.FIELD_TRIGGER_TARGETS_KEY]:
-              field.trigger && fromJS(field.trigger.targets),
-            [constants.FIELD_VISIBILITY_KEY]: field.hidden_default
+            value: "",
+            config: fieldConfig,
+            trigger: field.trigger && field.trigger.trigger_value,
+            triggerTargets: field.trigger && fromJS(field.trigger.targets),
+            isVisible: field.hidden_default
               ? false
-              : true,
-            [constants.FIELD_RENDER_KEY]: prevFields.has(field.name)
-              ? prevFields.get(field.name).get(constants.FIELD_RENDER_KEY) + "_"
+              : fieldConfig.has("restrictToGroup")
+                ? this.props.isInGroup(
+                    fieldConfig.get("restrictToGroup"),
+                    this.props.datasetSlug,
+                  ) || this.props.hasAdminAbilities(this.props.datasetSlug)
+                : true,
+            renderKey: prevFields.has(field.name)
+              ? prevFields.getIn([field.name, "renderKey"]) + "_"
               : this.selectedCategoryConfig.category + field.name,
-            [constants.FIELD_AUTO_FOCUS_KEY]: prevFields.get(
-              constants.FIELD_AUTO_FOCUS_KEY,
-            ),
-            [constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY]:
-              field.advance_stage_on_value,
+            isAutoFocusing: prevFields.get("isAutoFocusing"),
+            advanceStage: field.advance_stage_on_value,
           }),
         );
       }, OrderedMap());
@@ -155,7 +158,7 @@ class InputForm extends Component {
     );
     this.isWithCustomGeometry =
       this.selectedCategoryConfig.fields.findIndex(
-        field => field.type === constants.MAP_DRAWING_TOOLBAR_TYPENAME,
+        field => field.type === "map_drawing_toolbar",
       ) >= 0;
     this.attachments = [];
     if (this.isWithCustomGeometry) {
@@ -168,19 +171,14 @@ class InputForm extends Component {
 
   onFieldChange({ fieldName, fieldStatus, isInitializing }) {
     fieldStatus = fieldStatus.set(
-      constants.FIELD_RENDER_KEY,
-      this.state.fields.get(fieldName).get(constants.FIELD_RENDER_KEY),
+      "renderKey",
+      this.state.fields.getIn([fieldName, "renderKey"]),
     );
 
     // Check if this field triggers the visibility of other fields(s)
-    if (fieldStatus.get(constants.FIELD_TRIGGER_VALUE_KEY) && !isInitializing) {
-      const isVisible =
-        fieldStatus.get(constants.FIELD_TRIGGER_VALUE_KEY) ===
-        fieldStatus.get(constants.FIELD_VALUE_KEY);
-      this.triggerFieldVisibility(
-        fieldStatus.get(constants.FIELD_TRIGGER_TARGETS_KEY),
-        isVisible,
-      );
+    if (fieldStatus.get("trigger") && !isInitializing) {
+      const isVisible = fieldStatus.get("trigger") === fieldStatus.get("value");
+      this.triggerFieldVisibility(fieldStatus.get("triggerTargets"), isVisible);
     }
 
     this.setState(({ fields }) => ({
@@ -191,8 +189,7 @@ class InputForm extends Component {
 
     // Check if this field should advance the current stage.
     if (
-      fieldStatus.get(constants.FIELD_ADVANCE_STAGE_ON_VALUE_KEY) ===
-        fieldStatus.get(constants.FIELD_VALUE_KEY) &&
+      fieldStatus.get("advanceStage") === fieldStatus.get("value") &&
       !isInitializing
     ) {
       this.validateForm(() => {
@@ -211,7 +208,7 @@ class InputForm extends Component {
       fields: this.state.fields.map((field, fieldName) => {
         return targets.includes(fieldName)
           ? field
-              .set(constants.FIELD_VISIBILITY_KEY, isVisible)
+              .set("isVisible", isVisible)
               .set(
                 "isAutoFocusing",
                 targets.indexOf(fieldName) === 0 && isVisible,
@@ -231,8 +228,8 @@ class InputForm extends Component {
       isValid,
     } = this.getFields().reduce(
       ({ validationErrors, isValid }, field) => {
-        if (!field.get(constants.FIELD_VALIDITY_KEY)) {
-          validationErrors.add(field.get(constants.FIELD_VALIDITY_MESSAGE_KEY));
+        if (!field.get("isValid")) {
+          validationErrors.add(field.get("message"));
           isValid = false;
         }
         return { validationErrors, isValid };
@@ -269,8 +266,8 @@ class InputForm extends Component {
 
     let attrs = {
       ...this.state.fields
-        .filter(state => !!state.get(constants.FIELD_VALUE_KEY))
-        .map(state => state.get(constants.FIELD_VALUE_KEY))
+        .filter(state => !!state.get("value"))
+        .map(state => state.get("value"))
         .toJS(),
       location_type: this.selectedCategoryConfig.category,
     };
@@ -298,7 +295,7 @@ class InputForm extends Component {
     // TODO: This logic is better suited for the FormField component,
     // perhaps in an onSave hook.
     this.selectedCategoryConfig.fields
-      .filter(field => field.type === constants.RICH_TEXTAREA_FIELD_TYPENAME)
+      .filter(field => field.type === "rich_textarea")
       .forEach(field => {
         attrs[field.name] = extractEmbeddedImages(attrs[field.name]);
       });
@@ -347,7 +344,7 @@ class InputForm extends Component {
       this.setState({ isFormSubmitting: false, showValidityStatus: false });
 
       emitter.emit(
-        constants.PLACE_COLLECTION_ADD_PLACE_EVENT,
+        "place-collection:add-place",
         this.selectedCategoryConfig.datasetSlug,
       );
 
@@ -358,10 +355,8 @@ class InputForm extends Component {
         if (fieldConfig.autocomplete) {
           Util.saveAutocompleteValue(
             fieldConfig.name,
-            this.state.fields
-              .get(fieldConfig.name)
-              .get(constants.FIELD_VALUE_KEY),
-            constants.AUTOFILL_DURATION_DAYS,
+            this.state.fields.get(fieldConfig.name).get("value"),
+            30, // 30 days
           );
         }
       });
@@ -425,9 +420,7 @@ class InputForm extends Component {
           ],
         })
       : this.state.fields
-    ).filter(field => {
-      return field.get(constants.FIELD_VISIBILITY_KEY);
-    });
+    ).filter(field => field.get("isVisible"));
   }
 
   getFieldsFromStage({ fields, stage }) {
@@ -472,28 +465,21 @@ class InputForm extends Component {
           onSubmit={evt => evt.preventDefault()}
         >
           {this.getFields()
-            .map((fieldState, fieldName) => {
-              const fieldConfig = this.selectedCategoryConfig.fields.find(
-                field => field.name === fieldName,
-              );
-              return (
-                fieldConfig.isVisible && (
-                  <FormField
-                    fieldConfig={fieldConfig}
-                    disabled={this.state.isFormSubmitting}
-                    fieldState={fieldState}
-                    isInitializing={this.state.isInitializing}
-                    key={fieldState.get(constants.FIELD_RENDER_KEY)}
-                    onAddAttachment={this.onAddAttachment.bind(this)}
-                    onFieldChange={this.onFieldChange.bind(this)}
-                    router={this.props.router}
-                    showValidityStatus={this.state.showValidityStatus}
-                    updatingField={this.state.updatingField}
-                    onClickSubmit={this.onSubmit.bind(this)}
-                  />
-                )
-              );
-            })
+            .map(field => (
+              <FormField
+                fieldConfig={field.get("config").toJS()}
+                disabled={this.state.isFormSubmitting}
+                fieldState={field}
+                isInitializing={this.state.isInitializing}
+                key={field.get("renderKey")}
+                onAddAttachment={this.onAddAttachment.bind(this)}
+                onFieldChange={this.onFieldChange.bind(this)}
+                router={this.props.router}
+                showValidityStatus={this.state.showValidityStatus}
+                updatingField={this.state.updatingField}
+                onClickSubmit={this.onSubmit.bind(this)}
+              />
+            ))
             .toArray()}
         </form>
         {this.state.isFormSubmitting && <Spinner />}
@@ -555,6 +541,7 @@ InputForm.propTypes = {
   isContinuingFormSession: PropTypes.bool,
   isFormResetting: PropTypes.bool,
   isFormSubmitting: PropTypes.bool,
+  isInGroup: PropTypes.func.isRequired,
   isLeavingForm: PropTypes.bool,
   isMapDragged: PropTypes.bool.isRequired,
   isSingleCategory: PropTypes.bool,
@@ -584,6 +571,8 @@ const mapStateToProps = state => ({
     datasetClientSlugSelector(state, datasetSlug),
   geometryStyle: geometryStyleSelector(state),
   hasAdminAbilities: datasetSlug => hasAdminAbilities(state, datasetSlug),
+  isInGroup: (groupName, datasetSlug) =>
+    isInGroup(state, groupName, datasetSlug),
   mapConfig: mapConfigSelector(state),
   mapLayers: mapLayersSelector(state),
   mapPosition: mapPositionSelector(state),

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -35,7 +35,7 @@ import {
   hideLayers,
   setBasemap,
 } from "../../state/ducks/map";
-import { hasAdminAbilities, isInGroup } from "../../state/ducks/user";
+import { hasAdminAbilities, isInAtLeastOneGroup } from "../../state/ducks/user";
 import emitter from "../../utils/emitter";
 const Util = require("../../js/utils.js");
 
@@ -139,9 +139,9 @@ class InputForm extends Component {
             // the administrators group.
             isVisible: field.hidden_default
               ? false
-              : fieldConfig.has("restrictToGroup")
-                ? this.props.isInGroup(
-                    fieldConfig.get("restrictToGroup"),
+              : fieldConfig.has("restrictToGroups")
+                ? this.props.isInAtLeastOneGroup(
+                    fieldConfig.get("restrictToGroups"),
                     this.props.datasetSlug,
                   ) || this.props.hasAdminAbilities(this.props.datasetSlug)
                 : true,
@@ -545,7 +545,7 @@ InputForm.propTypes = {
   isContinuingFormSession: PropTypes.bool,
   isFormResetting: PropTypes.bool,
   isFormSubmitting: PropTypes.bool,
-  isInGroup: PropTypes.func.isRequired,
+  isInAtLeastOneGroup: PropTypes.func.isRequired,
   isLeavingForm: PropTypes.bool,
   isMapDragged: PropTypes.bool.isRequired,
   isSingleCategory: PropTypes.bool,
@@ -575,8 +575,8 @@ const mapStateToProps = state => ({
     datasetClientSlugSelector(state, datasetSlug),
   geometryStyle: geometryStyleSelector(state),
   hasAdminAbilities: datasetSlug => hasAdminAbilities(state, datasetSlug),
-  isInGroup: (groupName, datasetSlug) =>
-    isInGroup(state, groupName, datasetSlug),
+  isInAtLeastOneGroup: (groupNames, datasetSlug) =>
+    isInAtLeastOneGroup(state, groupNames, datasetSlug),
   mapConfig: mapConfigSelector(state),
   mapLayers: mapLayersSelector(state),
   mapPosition: mapPositionSelector(state),

--- a/src/base/static/components/place-detail/editor-bar.js
+++ b/src/base/static/components/place-detail/editor-bar.js
@@ -23,7 +23,8 @@ const EditorBar = props => {
         onClick={props.onToggleEditMode}
       />
       {props.isEditModeToggled &&
-        props.isPlaceDetailEditable && (
+        props.isPlaceDetailEditable &&
+        props.isAdmin && (
           <EditorButton
             className="place-detail-editor-bar__remove-button"
             label={props.t("removeBtn")}
@@ -50,6 +51,7 @@ const EditorBar = props => {
 };
 
 EditorBar.propTypes = {
+  isAdmin: PropTypes.bool.isRequired,
   isGeocodingBarEnabled: PropTypes.bool,
   isPlaceDetailEditable: PropTypes.bool.isRequired,
   isTagBarEditable: PropTypes.bool.isRequired,

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -38,6 +38,7 @@ import { mapConfigSelector } from "../../state/ducks/map-config";
 import {
   hasUserAbilitiesInPlace,
   hasGroupAbilitiesInDatasets,
+  hasAdminAbilities,
 } from "../../state/ducks/user";
 import { isEditModeToggled, updateEditModeToggled } from "../../state/ducks/ui";
 
@@ -170,6 +171,7 @@ class PlaceDetail extends Component {
       >
         {(isPlaceDetailEditable || isTagBarEditable) && (
           <EditorBar
+            isAdmin={this.props.hasAdminAbilities(this.props.datasetSlug)}
             isEditModeToggled={this.props.isEditModeToggled}
             isPlaceDetailEditable={isPlaceDetailEditable}
             isTagBarEditable={isTagBarEditable}
@@ -268,6 +270,7 @@ PlaceDetail.propTypes = {
     username: PropTypes.string,
   }),
   datasetSlug: PropTypes.string.isRequired,
+  hasAdminAbilities: PropTypes.func.isRequired,
   hasGroupAbilitiesInDatasets: PropTypes.func.isRequired,
   hasUserAbilitiesInPlace: PropTypes.func.isRequired,
   isEditModeToggled: PropTypes.bool.isRequired,
@@ -293,6 +296,7 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
+  hasAdminAbilities: datasetSlug => hasAdminAbilities(state, datasetSlug),
   hasGroupAbilitiesInDatasets: ({ abilities, submissionSet, datasetSlugs }) =>
     hasGroupAbilitiesInDatasets({
       state,

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -64,6 +64,10 @@ class PlaceDetailEditor extends Component {
             .set("value", this.props.place[field.name])
             .set("config", fieldConfig)
             .set(
+              // A field will be hidden if it is explicitly declared as 
+              // hidden_default in the config, or if it is restricted to a
+              // group and the current user is not in that group or is not in
+              // the administrators group.
               "isVisible",
               field.hidden_default
                 ? false

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -64,7 +64,7 @@ class PlaceDetailEditor extends Component {
             .set("value", this.props.place[field.name])
             .set("config", fieldConfig)
             .set(
-              // A field will be hidden if it is explicitly declared as 
+              // A field will be hidden if it is explicitly declared as
               // hidden_default in the config, or if it is restricted to a
               // group and the current user is not in that group or is not in
               // the administrators group.

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -30,7 +30,7 @@ import {
   placePropType,
 } from "../../state/ducks/places";
 import { updateEditModeToggled } from "../../state/ducks/ui";
-import { isInGroup, hasAdminAbilities } from "../../state/ducks/user";
+import { isInAtLeastOneGroup, hasAdminAbilities } from "../../state/ducks/user";
 
 import { getCategoryConfig } from "../../utils/config-utils";
 
@@ -71,9 +71,9 @@ class PlaceDetailEditor extends Component {
               "isVisible",
               field.hidden_default
                 ? false
-                : fieldConfig.has("restrictToGroup")
-                  ? this.props.isInGroup(
-                      fieldConfig.get("restrictToGroup"),
+                : fieldConfig.has("restrictToGroups")
+                  ? this.props.isInAtLeastOneGroup(
+                      fieldConfig.get("restrictToGroups"),
                       this.props.place._datasetSlug,
                     ) ||
                     this.props.hasAdminAbilities(this.props.place._datasetSlug)
@@ -357,7 +357,7 @@ PlaceDetailEditor.propTypes = {
   container: PropTypes.object.isRequired,
   geometryStyle: geometryStyleProps.isRequired,
   hasAdminAbilities: PropTypes.func.isRequired,
-  isInGroup: PropTypes.func.isRequired,
+  isInAtLeastOneGroup: PropTypes.func.isRequired,
   isSubmitting: PropTypes.bool,
   onAddAttachment: PropTypes.func,
   onRequestEnd: PropTypes.func.isRequired,
@@ -376,8 +376,8 @@ PlaceDetailEditor.propTypes = {
 const mapStateToProps = state => ({
   activeMarker: activeMarkerSelector(state),
   hasAdminAbilities: datasetSlug => hasAdminAbilities(state, datasetSlug),
-  isInGroup: (groupName, datasetSlug) =>
-    isInGroup(state, groupName, datasetSlug),
+  isInAtLeastOneGroup: (groupNames, datasetSlug) =>
+    isInAtLeastOneGroup(state, groupNames, datasetSlug),
   geometryStyle: geometryStyleSelector(state),
   placeConfig: placeConfigSelector(state),
 });

--- a/src/base/static/state/ducks/user.js
+++ b/src/base/static/state/ducks/user.js
@@ -38,6 +38,11 @@ export const hasAdminAbilities = (state, datasetSlug) =>
     group =>
       group.dataset_slug === datasetSlug && group.name === "administrators",
   );
+export const isInGroup = (state, groupName, datasetSlug) =>
+  state.user.groups
+    .filter(group => group.dataset_slug === datasetSlug)
+    .map(group => group.name)
+    .includes(groupName);
 
 // Actions:
 const LOAD = "user/LOAD";

--- a/src/base/static/state/ducks/user.js
+++ b/src/base/static/state/ducks/user.js
@@ -38,11 +38,11 @@ export const hasAdminAbilities = (state, datasetSlug) =>
     group =>
       group.dataset_slug === datasetSlug && group.name === "administrators",
   );
-export const isInGroup = (state, groupName, datasetSlug) =>
+export const isInAtLeastOneGroup = (state, groupNames, datasetSlug) =>
   state.user.groups
     .filter(group => group.dataset_slug === datasetSlug)
     .map(group => group.name)
-    .includes(groupName);
+    .some(groupName => groupNames.includes(groupName));
 
 // Actions:
 const LOAD = "user/LOAD";

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -733,13 +733,13 @@
           },
           {
             "name": "delegates_header",
-            "restrictToGroup": "delegates",
+            "restrictToGroups": ["delegates"],
             "type": "informational_html",
             "content": "<h1>Budget Delegates section</h1><p>This section is intended to be completed by Budget Delegates.</p>"
           },
           {
             "prompt": "_(Equity Assessment Score)",
-            "restrictToGroup": "delegates",
+            "restrictToGroups": ["delegates"],
             "display_prompt": "_(Equity Assessment Score:)",
             "type": "big_radio",
             "name": "delegate_equity_score",
@@ -761,7 +761,7 @@
           },
           {
             "prompt": "_(Impact Assessment Score)",
-            "restrictToGroup": "delegates",
+            "restrictToGroups": ["delegates"],
             "display_prompt": "_(Impact Assessment Score:)",
             "type": "big_radio",
             "name": "delegate_impact_score",
@@ -783,7 +783,7 @@
           },
           {
             "prompt": "_(Feasibility Assessment Score)",
-            "restrictToGroup": "delegates",
+            "restrictToGroups": ["delegates"],
             "display_prompt": "_(Feasibility Assessment Score:)",
             "type": "big_radio",
             "name": "delegate_feasibility_score",
@@ -805,7 +805,7 @@
           },
           {
             "prompt": "_(Project Budget)",
-            "restrictToGroup": "delegates",
+            "restrictToGroups": ["delegates"],
             "display_prompt": "_(Project Budget:)",
             "type": "text",
             "placeholder": "...",
@@ -814,7 +814,7 @@
           },
           {
             "prompt": "_(Cost Estimation)",
-            "restrictToGroup": "delegates",
+            "restrictToGroups": ["delegates"],
             "display_prompt": "_(Project Cost Estimation:)",
             "type": "text",
             "placeholder": "...",
@@ -823,13 +823,13 @@
           },
           {
             "name": "staff_review_header",
-            "restrictToGroup": "tech-reviewers",
+            "restrictToGroups": ["tech-reviewers"],
             "type": "informational_html",
             "content": "<h1>Internal Staff Review Section</h1><p>This section is intended to be completed by members of the City of Durham internal staff committee.</p>"
           },
           {
             "prompt": "_(Equity Assessment Score)",
-            "restrictToGroup": "tech-reviewers",
+            "restrictToGroups": ["tech-reviewers"],
             "display_prompt": "_(Equity Assessment Score)",
             "type": "big_radio",
             "name": "staff_equity_score",
@@ -851,7 +851,7 @@
           },
           {
             "prompt": "_(Impact Assessment Score)",
-            "restrictToGroup": "tech-reviewers",
+            "restrictToGroups": ["tech-reviewers"],
             "display_prompt": "_(Impact Assessment Score)",
             "type": "big_radio",
             "name": "staff_impact_score",
@@ -873,7 +873,7 @@
           },
           {
             "prompt": "_(Feasibility Assessment Score)",
-            "restrictToGroup": "tech-reviewers",
+            "restrictToGroups": ["tech-reviewers"],
             "display_prompt": "_(Feasibility Assessment Score)",
             "type": "big_radio",
             "name": "staff_feasibility_score",
@@ -895,7 +895,7 @@
           },
           {
             "prompt": "_(Project Budget)",
-            "restrictToGroup": "tech-reviewers",
+            "restrictToGroups": ["tech-reviewers"],
             "type": "textarea",
             "placeholder": "...",
             "name": "staff_project_budget",
@@ -903,7 +903,7 @@
           },
           {
             "prompt": "_(Cost Estimation)",
-            "restrictToGroup": "tech-reviewers",
+            "restrictToGroups": ["tech-reviewers"],
             "type": "text",
             "placeholder": "...",
             "name": "staff_cost_estimation",

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -701,7 +701,7 @@
         "label": "_(Project Proposal)",
         "fields": [
           {
-            "prompt": "_(Project Name)",
+            "prompt": "_(Proposal Name)",
             "type": "text",
             "placeholder": "...",
             "name": "title",
@@ -713,7 +713,7 @@
             "type": "text",
             "placeholder": "...",
             "name": "related_ideas",
-            "optional": false
+            "optional": true
           },
           {
             "prompt": "_(Location(s): (address, intersection, or landmark name))",
@@ -732,7 +732,14 @@
             "optional": true
           },
           {
+            "name": "delegates_header",
+            "restrictToGroup": "delegates",
+            "type": "informational_html",
+            "content": "<h1>Budget Delegates section</h1><p>This section is intended to be completed by Budget Delegates.</p>"
+          },
+          {
             "prompt": "_(Equity Assessment Score)",
+            "restrictToGroup": "delegates",
             "display_prompt": "_(Equity Assessment Score:)",
             "type": "big_radio",
             "name": "delegate_equity_score",
@@ -754,6 +761,7 @@
           },
           {
             "prompt": "_(Impact Assessment Score)",
+            "restrictToGroup": "delegates",
             "display_prompt": "_(Impact Assessment Score:)",
             "type": "big_radio",
             "name": "delegate_impact_score",
@@ -775,6 +783,7 @@
           },
           {
             "prompt": "_(Feasibility Assessment Score)",
+            "restrictToGroup": "delegates",
             "display_prompt": "_(Feasibility Assessment Score:)",
             "type": "big_radio",
             "name": "delegate_feasibility_score",
@@ -796,6 +805,7 @@
           },
           {
             "prompt": "_(Project Budget)",
+            "restrictToGroup": "delegates",
             "display_prompt": "_(Project Budget:)",
             "type": "text",
             "placeholder": "...",
@@ -804,6 +814,7 @@
           },
           {
             "prompt": "_(Cost Estimation)",
+            "restrictToGroup": "delegates",
             "display_prompt": "_(Project Cost Estimation:)",
             "type": "text",
             "placeholder": "...",
@@ -812,11 +823,13 @@
           },
           {
             "name": "staff_review_header",
+            "restrictToGroup": "tech-reviewers",
             "type": "informational_html",
             "content": "<h1>Internal Staff Review Section</h1><p>This section is intended to be completed by members of the City of Durham internal staff committee.</p>"
           },
           {
             "prompt": "_(Equity Assessment Score)",
+            "restrictToGroup": "tech-reviewers",
             "display_prompt": "_(Equity Assessment Score)",
             "type": "big_radio",
             "name": "staff_equity_score",
@@ -838,6 +851,7 @@
           },
           {
             "prompt": "_(Impact Assessment Score)",
+            "restrictToGroup": "tech-reviewers",
             "display_prompt": "_(Impact Assessment Score)",
             "type": "big_radio",
             "name": "staff_impact_score",
@@ -859,6 +873,7 @@
           },
           {
             "prompt": "_(Feasibility Assessment Score)",
+            "restrictToGroup": "tech-reviewers",
             "display_prompt": "_(Feasibility Assessment Score)",
             "type": "big_radio",
             "name": "staff_feasibility_score",
@@ -880,6 +895,7 @@
           },
           {
             "prompt": "_(Project Budget)",
+            "restrictToGroup": "tech-reviewers",
             "type": "textarea",
             "placeholder": "...",
             "name": "staff_project_budget",
@@ -887,6 +903,7 @@
           },
           {
             "prompt": "_(Cost Estimation)",
+            "restrictToGroup": "tech-reviewers",
             "type": "text",
             "placeholder": "...",
             "name": "staff_cost_estimation",


### PR DESCRIPTION
This PR adds a way to restrict field visibility to members of a dataset group. It also sets up the `pbdurham` config to leverage this feature.

We also remove several uses of the `constants` object.

TODO
 - [x] should non-admins have the ability to delete places? Probably not I think...