### PR TITLE
Jalmogo/tags ui

### DIFF
--- a/src/base/static/state/ducks/datasets.js
+++ b/src/base/static/state/ducks/datasets.js
@@ -25,21 +25,20 @@ export function updateDatasetsLoadStatus(loadStatus) {
 }
 
 export function loadDatasets(datasets) {
-  const getTagDisplayName = (dataset, tag) => {
-    const parentNodes = [];
+  const getTagDisplayName = (tag, tags) => {
+    const nodes = [];
 
     let node = tag;
     while (node.parent) {
-      const parentNode = dataset.tags.find(tag => tag.id === node.parent);
-      parentNodes.push(parentNode);
-      node = node.parent;
+      nodes.push(node);
+      const parentNode = tags.find(tag => tag.id === node.parent);
+      node = parentNode;
     }
+    nodes.push(node);
+
     // Traversing the tag tree produces an array in backward order, so
     // return the reversed array.
-    return parentNodes
-      .reverse()
-      .map(parent => parent.name)
-      .concat([tag.name]);
+    return nodes.reverse().map(node => node.name);
   };
 
   const getBFSForTag = (tag, tags) => {
@@ -66,7 +65,7 @@ export function loadDatasets(datasets) {
       }))
       .map(tag => ({
         ...tag,
-        displayName: getTagDisplayName(dataset, tag),
+        displayName: getTagDisplayName(tag, dataset.tags),
       }));
 
     // Re-order our tags so that they are grouped by BFS


### PR DESCRIPTION
 - [x] depends on merging https://github.com/mapseed/api/pull/166 first
 - [x] deploy this onto durham staging with the ingested TR tags

This PR adds some UI updates to make the tag selection menu more untuitive.

Here is an example to test: https://pbdurham-staging.mapseed.org/idea/6006

Before:

![2019-03-04-205825_858x785_escrotum](https://user-images.githubusercontent.com/42042460/53838379-c2826a00-3f49-11e9-816b-87aeb5bdfe8a.png)

After:

![2019-03-05-133442_802x793_escrotum](https://user-images.githubusercontent.com/42042460/53839078-789a8380-3f4b-11e9-835b-a7bd6092cb9b.png)

