### PR TITLE
Offline menu and add place button fixes

### DIFF
--- a/src/base/static/components/molecules/user-menu.js
+++ b/src/base/static/components/molecules/user-menu.js
@@ -208,10 +208,12 @@ class UserMenu extends React.Component {
                 )}
             </MenuItem>
             <MenuItem>
-              <OfflineDownloadMenu
-                offlineBoundingBox={this.props.offlineBoundingBox}
-                mapLayerConfigs={this.props.mapLayerConfigs}
-              />
+              {this.props.offlineBoundingBox && (
+                <OfflineDownloadMenu
+                  offlineBoundingBox={this.props.offlineBoundingBox}
+                  mapLayerConfigs={this.props.mapLayerConfigs}
+                />
+              )}
             </MenuItem>
             <MenuItem>
               <div>

--- a/src/base/static/js/views/app-view.js
+++ b/src/base/static/js/views/app-view.js
@@ -932,7 +932,6 @@ export default Backbone.View.extend({
     );
 
     store.dispatch(setCurrentTemplate("map"));
-    store.dispatch(setAddPlaceButtonVisibility(true));
     this.setMapDimensions();
   },
   viewList: async function() {


### PR DESCRIPTION
Fixes 3 regressions:
 - offline menu shouldn't rendered when it isn't enabled in the config
 - the add place button shouldn't render if the user doesn't have permissions in the config
 - private places weren't loading because of user fetch race condition