### PR TITLE
feat: publish/unpublish workflow

### DIFF
--- a/src/base/static/components/app.js
+++ b/src/base/static/components/app.js
@@ -6,12 +6,10 @@ import browserUpdate from "browser-update";
 import styled from "react-emotion";
 
 import SiteHeader from "./organisms/site-header";
-import InfoModal from "./organisms/info-modal";
 import {
   currentTemplateSelector,
   updateLayout,
   layoutSelector,
-  uiVisibilitySelector,
 } from "../state/ducks/ui";
 import {
   ShaTemplate,
@@ -164,7 +162,6 @@ class App extends Component {
             ref={this.templateContainerRef}
             layout={this.props.layout}
           >
-            {this.props.isInfoModalOpen && <InfoModal />}
             {this.props.currentTemplate === "sha" && <ShaTemplate />}
             {this.props.currentTemplate === "map" && (
               <Suspense fallback={<div>Loading...</div>}>
@@ -202,7 +199,6 @@ App.propTypes = {
   currentTemplate: PropTypes.string.isRequired,
   datasetConfigs: datasetConfigPropType,
   hasGroupAbilitiesInDatasets: PropTypes.func.isRequired,
-  isInfoModalOpen: PropTypes.bool.isRequired,
   languageCode: PropTypes.string.isRequired,
   layout: PropTypes.string.isRequired,
   loadDatasets: PropTypes.func.isRequired,
@@ -229,7 +225,6 @@ const mapStateToProps = state => ({
       datasetSlugs,
       submissionSet,
     }),
-  isInfoModalOpen: uiVisibilitySelector("infoModal", state),
   layout: layoutSelector(state),
   storyConfig: storyConfigSelector(state),
   storyChapters: storyChaptersSelector(state),

--- a/src/base/static/components/app.js
+++ b/src/base/static/components/app.js
@@ -29,9 +29,7 @@ import {
   datasetConfigPropType,
 } from "../state/ducks/datasets-config";
 import { loadDatasets } from "../state/ducks/datasets";
-import {
-  hasGroupAbilitiesInDatasets,
-} from "../state/ducks/user";
+import { hasGroupAbilitiesInDatasets } from "../state/ducks/user";
 import {
   appConfigSelector,
   appConfigPropType,

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -71,7 +71,7 @@ class InputForm extends Component {
       currentStage: 1,
       isInfoModalOpen: false,
       infoModalHeader: "",
-      infoModalContent: [],
+      infoModalBody: [],
       routeOnClose: null,
     };
   }

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -9,6 +9,7 @@ import FormField from "../form-fields/form-field";
 import WarningMessagesContainer from "../ui-elements/warning-messages-container";
 import FormStageHeaderBar from "../molecules/form-stage-header-bar";
 import FormStageControlBar from "../molecules/form-stage-control-bar";
+import InfoModal from "../organisms/info-modal";
 
 import { translate } from "react-i18next";
 import { extractEmbeddedImages } from "../../utils/embedded-images";
@@ -38,11 +39,7 @@ import {
   hasGroupAbilitiesInDatasets,
   isInAtLeastOneGroup,
 } from "../../state/ducks/user";
-import {
-  updateUIVisibility,
-  layoutSelector,
-  updateIndoModalContent,
-} from "../../state/ducks/ui";
+import { updateUIVisibility, layoutSelector } from "../../state/ducks/ui";
 import { jumpTo } from "../../utils/scroll-helpers";
 
 const Util = require("../../js/utils.js");
@@ -72,6 +69,10 @@ class InputForm extends Component {
       showValidityStatus: false,
       isMapPositioned: false,
       currentStage: 1,
+      isInfoModalOpen: false,
+      infoModalHeader: "",
+      infoModalContent: [],
+      routeOnClose: null,
     };
   }
 
@@ -389,28 +390,38 @@ class InputForm extends Component {
       // can_access_protected privileges, add the Place to the places duck and
       // route the user to the Place's detail view, explaining that the Place
       // is not visible to the general public.
-      this.setState({ isFormSubmitting: false, showValidityStatus: false });
-      this.defaultPostSave(placeResponse);
-      this.props.updateInfoModalVisibility(true);
-      this.props.updateInfoModalContent({
-        header: this.props.t("privateSubmissionModalHeader"),
-        body: [this.props.t("privateSubmissionModalBodyAdmin")],
+      this.setState({
+        isInfoModalOpen: true,
+        infoModalHeader: this.props.t("privateSubmissionModalHeader"),
+        infoModalBody: [this.props.t("privateSubmissionModalBodyAdmin")],
+        routeOnClose: `${this.props.datasetClientSlugSelector(
+          this.props.datasetSlug,
+        )}/${placeResponse.id}`,
       });
+      this.defaultPostSave(placeResponse);
     } else if (placeResponse.private) {
       // If this is a private Place and the current user does not have
       // can_access_protected privileges, confirm the Place's submission but do
       // not add the Place to the places duck, and route to the root.
       this.setState({ isFormSubmitting: false, showValidityStatus: false });
-      this.props.router.navigate("/", { trigger: true });
-      this.props.updateInfoModalVisibility(true);
-      this.props.updateInfoModalContent({
-        header: this.props.t("privateSubmissionModalHeader"),
-        body: [this.props.t("privateSubmissionModalBodyNonAdmin")],
+      this.setState({
+        isInfoModalOpen: true,
+        infoModalHeader: this.props.t("privateSubmissionModalHeader"),
+        infoModalBody: [this.props.t("privateSubmissionModalBodyNonAdmin")],
+        routeOnClose: "/",
       });
     } else {
       // If the Place is note private, follow the default route-to-detail-view
       // behavior.
       this.defaultPostSave(placeResponse);
+      this.props.router.navigate(
+        `${this.props.datasetClientSlugSelector(this.props.datasetSlug)}/${
+          placeResponse.id
+        }`,
+        {
+          trigger: true,
+        },
+      );
     }
 
     this.props.setActiveDrawGeometryId(null);
@@ -438,15 +449,6 @@ class InputForm extends Component {
     });
 
     this.setState({ isFormSubmitting: false, showValidityStatus: false });
-
-    this.props.router.navigate(
-      `${this.props.datasetClientSlugSelector(this.props.datasetSlug)}/${
-        placeResponse.id
-      }`,
-      {
-        trigger: true,
-      },
-    );
   }
 
   getStageStartField() {
@@ -495,90 +497,104 @@ class InputForm extends Component {
     };
 
     return (
-      <div className="input-form">
-        {this.selectedCategoryConfig.multi_stage && (
-          <FormStageHeaderBar
-            stageConfig={
-              this.selectedCategoryConfig.multi_stage[
-                this.state.currentStage - 1
-              ]
-            }
-          />
-        )}
-        {this.state.formValidationErrors.size > 0 && (
-          <WarningMessagesContainer
-            errors={[...this.state.formValidationErrors]}
-            headerMsg={this.props.t("validationHeader")}
-          />
-        )}
-        <form
-          id="mapseed-input-form"
-          className={cn.form}
-          onSubmit={evt => evt.preventDefault()}
-        >
-          {this.getFields()
-            .map(field => (
-              <FormField
-                fieldConfig={field.get("config").toJS()}
-                disabled={this.state.isFormSubmitting}
-                fieldState={field}
-                isInitializing={this.state.isInitializing}
-                key={field.get("renderKey")}
-                onAddAttachment={this.onAddAttachment.bind(this)}
-                onFieldChange={this.onFieldChange.bind(this)}
-                router={this.props.router}
-                showValidityStatus={this.state.showValidityStatus}
-                updatingField={this.state.updatingField}
-                onClickSubmit={this.onSubmit.bind(this)}
-              />
-            ))
-            .toArray()}
-        </form>
-        {this.state.isFormSubmitting && <Spinner />}
-
-        {this.selectedCategoryConfig.multi_stage && (
-          <FormStageControlBar
-            onClickAdvanceStage={() => {
-              this.validateForm(() => {
-                jumpTo({
-                  contentPanelInnerContainerRef: this.props
-                    .contentPanelInnerContainerRef,
-                  scrollPosition: 0,
-                  layout: this.props.layout,
-                });
-                this.setState({
-                  currentStage: this.state.currentStage + 1,
-                  showValidityStatus: false,
-                  formValidationErrors: new Set(),
-                });
+      <>
+        <InfoModal
+          isModalOpen={this.state.isInfoModalOpen}
+          header={this.state.infoModalHeader}
+          body={this.state.infoModalBody}
+          onClose={() => {
+            this.setState({ isInfoModalOpen: false });
+            this.state.routeOnClose &&
+              this.props.router.navigate(this.state.routeOnClose, {
+                trigger: true,
               });
-            }}
-            onClickRetreatStage={() => {
-              if (
-                this.state.currentStage === 1 &&
-                !this.props.isSingleCategory
-              ) {
-                this.props.onCategoryChange(null);
-              } else {
-                jumpTo({
-                  contentPanelInnerContainerRef: this.props
-                    .contentPanelInnerContainerRef,
-                  scrollPosition: 0,
-                  layout: this.props.layout,
-                });
-                this.setState({
-                  currentStage: this.state.currentStage - 1,
-                  showValidityStatus: false,
-                  formValidationErrors: new Set(),
-                });
+          }}
+        />
+        <div className="input-form">
+          {this.selectedCategoryConfig.multi_stage && (
+            <FormStageHeaderBar
+              stageConfig={
+                this.selectedCategoryConfig.multi_stage[
+                  this.state.currentStage - 1
+                ]
               }
-            }}
-            currentStage={this.state.currentStage}
-            numStages={this.selectedCategoryConfig.multi_stage.length}
-            isSingleCategory={this.props.isSingleCategory}
-          />
-        )}
-      </div>
+            />
+          )}
+          {this.state.formValidationErrors.size > 0 && (
+            <WarningMessagesContainer
+              errors={[...this.state.formValidationErrors]}
+              headerMsg={this.props.t("validationHeader")}
+            />
+          )}
+          <form
+            id="mapseed-input-form"
+            className={cn.form}
+            onSubmit={evt => evt.preventDefault()}
+          >
+            {this.getFields()
+              .map(field => (
+                <FormField
+                  fieldConfig={field.get("config").toJS()}
+                  disabled={this.state.isFormSubmitting}
+                  fieldState={field}
+                  isInitializing={this.state.isInitializing}
+                  key={field.get("renderKey")}
+                  onAddAttachment={this.onAddAttachment.bind(this)}
+                  onFieldChange={this.onFieldChange.bind(this)}
+                  router={this.props.router}
+                  showValidityStatus={this.state.showValidityStatus}
+                  updatingField={this.state.updatingField}
+                  onClickSubmit={this.onSubmit.bind(this)}
+                />
+              ))
+              .toArray()}
+          </form>
+          {this.state.isFormSubmitting && <Spinner />}
+
+          {this.selectedCategoryConfig.multi_stage && (
+            <FormStageControlBar
+              onClickAdvanceStage={() => {
+                this.validateForm(() => {
+                  jumpTo({
+                    contentPanelInnerContainerRef: this.props
+                      .contentPanelInnerContainerRef,
+                    scrollPosition: 0,
+                    layout: this.props.layout,
+                  });
+                  this.setState({
+                    currentStage: this.state.currentStage + 1,
+                    showValidityStatus: false,
+                    formValidationErrors: new Set(),
+                  });
+                });
+              }}
+              onClickRetreatStage={() => {
+                if (
+                  this.state.currentStage === 1 &&
+                  !this.props.isSingleCategory
+                ) {
+                  this.props.onCategoryChange(null);
+                } else {
+                  jumpTo({
+                    contentPanelInnerContainerRef: this.props
+                      .contentPanelInnerContainerRef,
+                    scrollPosition: 0,
+                    layout: this.props.layout,
+                  });
+                  this.setState({
+                    currentStage: this.state.currentStage - 1,
+                    showValidityStatus: false,
+                    formValidationErrors: new Set(),
+                  });
+                }
+              }}
+              currentStage={this.state.currentStage}
+              numStages={this.selectedCategoryConfig.multi_stage.length}
+              isSingleCategory={this.props.isSingleCategory}
+            />
+          )}
+        </div>
+      </>
     );
   }
 }
@@ -617,8 +633,6 @@ InputForm.propTypes = {
   setActiveDrawingTool: PropTypes.func.isRequired,
   setActiveDrawGeometryId: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
-  updateInfoModalContent: PropTypes.func.isRequired,
-  updateInfoModalVisibility: PropTypes.func.isRequired,
   updateMapCenterpointVisibility: PropTypes.func.isRequired,
   updateSpotlightMaskVisibility: PropTypes.func.isRequired,
   createFeaturesInGeoJSONSource: PropTypes.func.isRequired,
@@ -654,9 +668,6 @@ const mapDispatchToProps = dispatch => ({
   setActiveDrawingTool: activeDrawingTool =>
     dispatch(setActiveDrawingTool(activeDrawingTool)),
   createPlace: place => dispatch(createPlace(place)),
-  updateInfoModalContent: content => dispatch(updateIndoModalContent(content)),
-  updateInfoModalVisibility: isVisible =>
-    dispatch(updateUIVisibility("infoModal", isVisible)),
   updateLayerGroupVisibility: (layerGroupId, isVisible) =>
     dispatch(updateLayerGroupVisibility(layerGroupId, isVisible)),
   updateSpotlightMaskVisibility: isVisible =>

--- a/src/base/static/components/organisms/info-modal.js
+++ b/src/base/static/components/organisms/info-modal.js
@@ -1,68 +1,45 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Modal from "react-modal";
-import { connect } from "react-redux";
-
-import {
-  infoModalContentSelector,
-  updateUIVisibility,
-  uiVisibilitySelector,
-} from "../../state/ducks/ui";
 
 import "./info-modal.scss";
 
 Modal.setAppElement("#site-wrap");
 
-class InfoModal extends Component {
-  render() {
-    return (
-      <Modal
-        className="mapseed-info-modal"
-        overlayClassName="mapseed-info-modal__overlay"
-        isOpen={this.props.isInfoModalVisible}
-      >
-        <div className="mapseed-info-modal__header-bar">
-          <h3 className="mapseed-info-modal__header-content">
-            {this.props.infoModalContent.header}
-          </h3>
-          <button
-            className="mapseed-info-modal__close-btn"
-            onClick={() => this.props.updateInfoModalVisibility(false)}
-          >
-            &#10005;
-          </button>
-        </div>
-        <div className="mapseed-info-modal__body">
-          {this.props.infoModalContent.body.map((paragraph, i) => {
-            return (
-              <p className="mapseed-info-modal__paragraph" key={i}>
-                {paragraph}
-              </p>
-            );
-          })}
-        </div>
-      </Modal>
-    );
-  }
-}
+const InfoModal = props => (
+  <Modal
+    className="mapseed-info-modal"
+    overlayClassName="mapseed-info-modal__overlay"
+    isOpen={props.isModalOpen}
+  >
+    <div className="mapseed-info-modal__header-bar">
+      <h3 className="mapseed-info-modal__header-content">{props.header}</h3>
+      <button className="mapseed-info-modal__close-btn" onClick={props.onClose}>
+        &#10005;
+      </button>
+    </div>
+    <div className="mapseed-info-modal__body">
+      {props.body.map((paragraph, i) => {
+        return (
+          <p className="mapseed-info-modal__paragraph" key={i}>
+            {paragraph}
+          </p>
+        );
+      })}
+    </div>
+  </Modal>
+);
 
 InfoModal.propTypes = {
-  infoModalContent: PropTypes.object.isRequired,
-  isInfoModalVisible: PropTypes.bool.isRequired,
-  updateInfoModalVisibility: PropTypes.func.isRequired,
+  body: PropTypes.arrayOf(PropTypes.string).isRequired,
+  header: PropTypes.string.isRequired,
+  isModalOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => ({
-  infoModalContent: infoModalContentSelector(state),
-  isInfoModalVisible: uiVisibilitySelector("infoModal", state),
-});
+InfoModal.defaultProps = {
+  body: [],
+  header: "",
+};
 
-const mapDispatchToProps = dispatch => ({
-  updateInfoModalVisibility: isVisible =>
-    dispatch(updateUIVisibility("infoModal", isVisible)),
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(InfoModal);
+export default InfoModal;

--- a/src/base/static/components/organisms/info-modal.js
+++ b/src/base/static/components/organisms/info-modal.js
@@ -1,55 +1,39 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Modal from "react-modal";
+import { connect } from "react-redux";
+
+import {
+  infoModalContentSelector,
+  updateUIVisibility,
+  uiVisibilitySelector,
+} from "../../state/ducks/ui";
 
 import "./info-modal.scss";
 
-Modal.setAppElement("#main");
+Modal.setAppElement("#site-wrap");
 
 class InfoModal extends Component {
-  constructor(props) {
-    super(props);
-
-    // TODO: This state should be pushed higher once we port the AppView,
-    // and we'll make this a stateless component.
-    this.state = {
-      isModalOpen: true,
-    };
-  }
-
-  onClickCloseBtn(evt) {
-    this.setState({
-      isModalOpen: false,
-    });
-  }
-
   render() {
     return (
       <Modal
         className="mapseed-info-modal"
         overlayClassName="mapseed-info-modal__overlay"
-        isOpen={this.state.isModalOpen}
-        parentSelector={() => document.getElementById(this.props.parentId)}
+        isOpen={this.props.isInfoModalVisible}
       >
         <div className="mapseed-info-modal__header-bar">
           <h3 className="mapseed-info-modal__header-content">
-            {this.props.headerImgSrc && (
-              <img
-                className="mapseed-info-modal__header-img"
-                src={this.props.headerImgSrc}
-              />
-            )}
-            {this.props.header}
+            {this.props.infoModalContent.header}
           </h3>
           <button
             className="mapseed-info-modal__close-btn"
-            onClick={this.onClickCloseBtn.bind(this)}
+            onClick={() => this.props.updateInfoModalVisibility(false)}
           >
             &#10005;
           </button>
         </div>
         <div className="mapseed-info-modal__body">
-          {this.props.body.map((paragraph, i) => {
+          {this.props.infoModalContent.body.map((paragraph, i) => {
             return (
               <p className="mapseed-info-modal__paragraph" key={i}>
                 {paragraph}
@@ -63,10 +47,22 @@ class InfoModal extends Component {
 }
 
 InfoModal.propTypes = {
-  header: PropTypes.string,
-  body: PropTypes.arrayOf(PropTypes.string),
-  headerImgSrc: PropTypes.string,
-  parentId: PropTypes.string.isRequired,
+  infoModalContent: PropTypes.object.isRequired,
+  isInfoModalVisible: PropTypes.bool.isRequired,
+  updateInfoModalVisibility: PropTypes.func.isRequired,
 };
 
-export default InfoModal;
+const mapStateToProps = state => ({
+  infoModalContent: infoModalContentSelector(state),
+  isInfoModalVisible: uiVisibilitySelector("infoModal", state),
+});
+
+const mapDispatchToProps = dispatch => ({
+  updateInfoModalVisibility: isVisible =>
+    dispatch(updateUIVisibility("infoModal", isVisible)),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(InfoModal);

--- a/src/base/static/components/organisms/info-modal.scss
+++ b/src/base/static/components/organisms/info-modal.scss
@@ -12,6 +12,7 @@
 }
 
 .mapseed-info-modal__overlay {
+  z-index: 999;
   position: fixed;
   top: 0px;
   left: 0px;

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -83,6 +83,11 @@ class PlaceDetail extends Component {
   componentDidMount() {
     this.updateMapViewport();
     this.updateEditability();
+    jumpTo({
+      contentPanelInnerContainerRef: this.props.contentPanelInnerContainerRef,
+      scrollPositon: 0,
+      layout: this.props.layout,
+    });
   }
 
   componentDidUpdate(prevProps) {

--- a/src/base/static/components/place-detail/pbdurham-project-proposal-field-summary.js
+++ b/src/base/static/components/place-detail/pbdurham-project-proposal-field-summary.js
@@ -121,6 +121,13 @@ const Title = styled(SmallTitle)({
   marginBottom: "8px",
 });
 
+const UnpublishedWarning = styled("div")({
+  backgroundColor: "#ffc107",
+  color: "#6b5001",
+  borderRadius: "8px",
+  padding: "8px",
+});
+
 const PBDurhamProjectProposalFieldSummary = props => {
   const equityScore = parseFloat(props.place["delegate_equity_score"]) || 0;
   const impactScore = parseFloat(props.place["delegate_impact_score"]) || 0;
@@ -129,6 +136,11 @@ const PBDurhamProjectProposalFieldSummary = props => {
 
   return (
     <div>
+      {props.place.private && (
+        <UnpublishedWarning>
+          {props.t("unpublishedWarningMsg")}
+        </UnpublishedWarning>
+      )}
       {props.place.attachments
         .filter(attachment => attachment.type === "CO")
         .map((attachment, i) => (

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -62,7 +62,18 @@ class PlaceDetailEditor extends Component {
         fields = fields.set(
           field.name,
           Map()
-            .set("value", this.props.place[field.name])
+            .set(
+              "value",
+              field.name === "private"
+                // Private fields will be returned with a true or false value, 
+                // which should be mapped to the "yes"/"no" values of the field
+                // which manipulates the private setting.
+                // TODO: This should be better encapsulated.
+                ? this.props.place["private"]
+                  ? "yes"
+                  : "no"
+                : this.props.place[field.name],
+            )
             .set("config", fieldConfig)
             .set(
               // A field will be hidden if it is explicitly declared as

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -65,11 +65,11 @@ class PlaceDetailEditor extends Component {
             .set(
               "value",
               field.name === "private"
-                // Private fields will be returned with a true or false value, 
-                // which should be mapped to the "yes"/"no" values of the field
-                // which manipulates the private setting.
-                // TODO: This should be better encapsulated.
-                ? this.props.place["private"]
+                ? // Private fields will be returned with a true or false value,
+                  // which should be mapped to the "yes"/"no" values of the field
+                  // which manipulates the private setting.
+                  // TODO: This should be better encapsulated.
+                  this.props.place["private"]
                   ? "yes"
                   : "no"
                 : this.props.place[field.name],

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -28,9 +28,7 @@ import {
   hasAnonAbilitiesInAnyDataset,
   datasetSlugsSelector,
 } from "../state/ducks/datasets-config";
-import {
-  hasGroupAbilitiesInDatasets,
-} from "../state/ducks/user";
+import { hasGroupAbilitiesInDatasets } from "../state/ducks/user";
 
 import { recordGoogleAnalyticsHit } from "../utils/analytics";
 

--- a/src/base/static/js/routes.js
+++ b/src/base/static/js/routes.js
@@ -28,7 +28,9 @@ import {
   hasAnonAbilitiesInAnyDataset,
   datasetSlugsSelector,
 } from "../state/ducks/datasets-config";
-import { hasGroupAbilitiesInDatasets } from "../state/ducks/user";
+import {
+  hasGroupAbilitiesInDatasets,
+} from "../state/ducks/user";
 
 import { recordGoogleAnalyticsHit } from "../utils/analytics";
 
@@ -247,6 +249,12 @@ mixpanel.init(MIXPANEL_TOKEN);
             include_submissions: true,
             include_tags: true,
           },
+          includePrivate: hasGroupAbilitiesInDatasets({
+            state: this.store.getState(),
+            abilities: ["can_access_protected"],
+            datasetSlugs: [datasetConfig.slug],
+            submissionSet: "places",
+          }),
         });
 
         if (response) {

--- a/src/base/static/state/ducks/ui.js
+++ b/src/base/static/state/ducks/ui.js
@@ -9,7 +9,6 @@ export const contentPanelComponentSelector = state =>
   state.ui.contentPanelComponent;
 export const pageSlugSelector = state => state.ui.activePageSlug;
 export const layoutSelector = state => state.ui.layout;
-export const infoModalContentSelector = state => state.ui.infoModalContent;
 
 // Actions:
 const UPDATE_CURRENT_TEMPLATE = "ui/UPDATE_CURRENT_TEMPLATE";
@@ -18,7 +17,6 @@ const UPDATE_UI_VISIBILITY = "ui/UPDATE_UI_VISIBILITY";
 const UPDATE_ACTIVE_PAGE = "ui/UPDATE_ACTIVE_PAGE";
 const UPDATE_CONTENT_PANEL_COMPONENT = "ui/UPDATE_CONTENT_PANEL_COMPONENT";
 const UPDATE_LAYOUT = "ui/UPDATE_LAYOUT";
-const UPDATE_INFO_MODAL_CONTENT = "ui/UPDATE_INFO_MODAL_CONTENT";
 
 // Action creators:
 export function updateCurrentTemplate(templateName) {
@@ -51,12 +49,6 @@ export function updateLayout() {
     payload: getLayout(),
   };
 }
-export function updateIndoModalContent(content) {
-  return {
-    type: UPDATE_INFO_MODAL_CONTENT,
-    payload: content,
-  };
-}
 
 // Reducers:
 const INITIAL_STATE = {
@@ -64,17 +56,12 @@ const INITIAL_STATE = {
   uiVisibility: {
     addPlaceButton: false,
     contentPanel: false,
-    infoModal: false,
     inviteModal: false,
     mapCenterpoint: false,
     spotlightMask: false,
     rightSidebar: false,
   },
   contentPanelComponent: null,
-  infoModalContent: {
-    header: "",
-    body: [],
-  },
   leftSidebarComponent: null,
   currentTemplate: "map",
   isEditModeToggled: false,
@@ -116,11 +103,6 @@ export default function reducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         layout: action.payload,
-      };
-    case UPDATE_INFO_MODAL_CONTENT:
-      return {
-        ...state,
-        infoModalContent: action.payload,
       };
     default:
       return state;

--- a/src/base/static/state/ducks/ui.js
+++ b/src/base/static/state/ducks/ui.js
@@ -9,6 +9,7 @@ export const contentPanelComponentSelector = state =>
   state.ui.contentPanelComponent;
 export const pageSlugSelector = state => state.ui.activePageSlug;
 export const layoutSelector = state => state.ui.layout;
+export const infoModalContentSelector = state => state.ui.infoModalContent;
 
 // Actions:
 const UPDATE_CURRENT_TEMPLATE = "ui/UPDATE_CURRENT_TEMPLATE";
@@ -17,6 +18,7 @@ const UPDATE_UI_VISIBILITY = "ui/UPDATE_UI_VISIBILITY";
 const UPDATE_ACTIVE_PAGE = "ui/UPDATE_ACTIVE_PAGE";
 const UPDATE_CONTENT_PANEL_COMPONENT = "ui/UPDATE_CONTENT_PANEL_COMPONENT";
 const UPDATE_LAYOUT = "ui/UPDATE_LAYOUT";
+const UPDATE_INFO_MODAL_CONTENT = "ui/UPDATE_INFO_MODAL_CONTENT";
 
 // Action creators:
 export function updateCurrentTemplate(templateName) {
@@ -49,6 +51,12 @@ export function updateLayout() {
     payload: getLayout(),
   };
 }
+export function updateIndoModalContent(content) {
+  return {
+    type: UPDATE_INFO_MODAL_CONTENT,
+    payload: content,
+  };
+}
 
 // Reducers:
 const INITIAL_STATE = {
@@ -56,12 +64,17 @@ const INITIAL_STATE = {
   uiVisibility: {
     addPlaceButton: false,
     contentPanel: false,
+    infoModal: false,
     inviteModal: false,
     mapCenterpoint: false,
     spotlightMask: false,
     rightSidebar: false,
   },
   contentPanelComponent: null,
+  infoModalContent: {
+    header: "",
+    body: [],
+  },
   leftSidebarComponent: null,
   currentTemplate: "map",
   isEditModeToggled: false,
@@ -103,6 +116,11 @@ export default function reducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         layout: action.payload,
+      };
+    case UPDATE_INFO_MODAL_CONTENT:
+      return {
+        ...state,
+        infoModalContent: action.payload,
       };
     default:
       return state;

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -675,6 +675,24 @@
         "label": "_(Project Proposal)",
         "fields": [
           {
+            "name": "private",
+            "type": "big_radio",
+            "restrictToGroups": ["administrators"],
+            "prompt": "_(Publish or unpublish this project. Published projects will be visible to all users. Unpublished projects will be visible to administrators, delegates, and technical reviewers.)",
+            "forced_default_value": "yes",
+            "content": [
+              {
+                "label": "_(Published)",
+                "value": "no"
+              },
+              {
+                "label": "_(Unpublished)",
+                "value": "yes"
+              }
+            ],
+            "optional": false
+          },
+          {
             "prompt": "_(Proposal Name)",
             "type": "text",
             "placeholder": "...",

--- a/src/locales/en_US/InputForm.json
+++ b/src/locales/en_US/InputForm.json
@@ -1,6 +1,6 @@
 {
-  "validationHeader":
-    "Your post is looking good, but we need some more information before we can proceed.",
+  "validationHeader": "Your post is looking good, but we need some more information before we can proceed.",
   "privateSubmissionModalHeader": "Thank you!",
-  "privateSubmissionModalBody": "Your information was submitted successfully, and will remain private."
+  "privateSubmissionModalBodyNonAdmin": "Your information was submitted successfully, and will remain private.",
+  "privateSubmissionModalBodyAdmin": "Your information was submitted successfully as a validated administrator of this site. It will be visible to you and other administrators, but will remain hidden for other users."
 }

--- a/src/locales/en_US/PBDurhamProjectProposalFieldSummary.json
+++ b/src/locales/en_US/PBDurhamProjectProposalFieldSummary.json
@@ -12,5 +12,6 @@
   "highlyImpactfulMsg": "Citizen and City of Durham reviewers have determined this project would be highly impactful",
   "moderatelyImpactfulMsg": "Citizen and City of Durham reviewers have determined this projet would be moderately impactful",
   "notImpactfulMsg": "Citize and City of Durham reviewers have determined this project may not be impactful",
-  "relatedIdeasHeader": "Related ideas:"
+  "relatedIdeasHeader": "Related ideas:",
+  "unpublishedWarningMsg": "This Project is currently unpublished. It will be visible to administrators, delegates, and technical reviewers. Please log in as an administrator to publish this Project for the general public."
 }


### PR DESCRIPTION
Depends on: https://github.com/mapseed/api/pull/170

This PR introduces a publish/unpublish workflow leveraging our private places feature.

When creating a Place, there are now three scenarios that can occur:
* A non-private Place is created, leading to the normal route-to-detail-view behavior
* A private Place is created by someone *with* `can_access_protected` permissions, leading to the normal route-to-detail-view-behavior accompanied by a modal dialog explaining that even though the submitter can see the private Place's detail view, others will not be able to
* A private Place is created *without* `can_access_protected` permissions, leading to a route-to-root behavior accompanied by a modal dialog confirming the successful submission

We also refactor the `pbdurham` config to add a publish/unpublish field to the projects form.

This PR also restores the `InfoModal`, which I think broke in the `AppView` port.