### PR TITLE
fix(autocompleteField): restore proper styling

### DIFF
--- a/src/base/static/components/form-fields/types/autocomplete-combobox-field.js
+++ b/src/base/static/components/form-fields/types/autocomplete-combobox-field.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import Autocomplete from "accessible-autocomplete/react";
+import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 
 import "./autocomplete-combobox-field.scss";
 


### PR DESCRIPTION
The CSS for the `accessible-autocomplete` combobox dropdown fields got removed at some point; this PR restores it.