### PR TITLE
chore(package-lock): upgrade npm/nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19376,6 +19376,7 @@
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -19518,7 +19519,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19544,6 +19546,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }


### PR DESCRIPTION
This PR include package-lock.json updates after upgrading to the latest nodejs stable: https://nodejs.org/en/

