### PR TITLE
Map performance improvements

### DIFF
--- a/src/base/static/components/app.js
+++ b/src/base/static/components/app.js
@@ -64,6 +64,7 @@ import {
 import {
   createFeaturesInGeoJSONSource,
   updateMapViewport,
+  updateMapContainerDimensions,
 } from "../state/ducks/map";
 import { recordGoogleAnalyticsHit } from "../utils/analytics";
 
@@ -221,7 +222,7 @@ class App extends Component {
       this.templateContainerRef.current,
     ).getBoundingClientRect();
 
-    this.props.updateMapViewport({
+    this.props.updateMapContainerDimensions({
       width: templateDims.width,
       height: templateDims.height,
     });
@@ -582,6 +583,7 @@ App.propTypes = {
   storyChapters: PropTypes.array.isRequired,
   // TODO: shape of this:
   updateLayout: PropTypes.func.isRequired,
+  updateMapContainerDimensions: PropTypes.func.isRequired,
   updateMapViewport: PropTypes.func.isRequired,
   updatePlacesLoadStatus: PropTypes.func.isRequired,
   updateUIVisibility: PropTypes.func.isRequired,
@@ -643,6 +645,8 @@ const mapDispatchToProps = dispatch => ({
   updatePlacesLoadStatus: loadStatus =>
     dispatch(updatePlacesLoadStatus(loadStatus)),
   updateLayout: () => dispatch(updateLayout()),
+  updateMapContainerDimensions: newDimensions =>
+    dispatch(updateMapContainerDimensions(newDimensions)),
   updateMapViewport: newViewport => dispatch(updateMapViewport(newViewport)),
   updateUIVisibility: (componentName, isVisible) =>
     dispatch(updateUIVisibility(componentName, isVisible)),

--- a/src/base/static/components/form-fields/field-definitions.js
+++ b/src/base/static/components/form-fields/field-definitions.js
@@ -231,7 +231,10 @@ export default {
   [constants.GEOCODING_FIELD_TYPENAME]: {
     getValidator: getPermissiveValidator,
     getComponent: (fieldConfig, context) => (
-      <GeocodingField {...getSharedFieldProps(fieldConfig, context)} />
+      <GeocodingField
+        {...getSharedFieldProps(fieldConfig, context)}
+        onUpdateMapViewport={context.props.onUpdateMapViewport}
+      />
     ),
     getInitialValue: ({ value }) => value,
     getResponseComponent: () => null,

--- a/src/base/static/components/form-fields/types/geocoding-field.js
+++ b/src/base/static/components/form-fields/types/geocoding-field.js
@@ -7,8 +7,6 @@ import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import "./geocoding-field.scss";
 
-import { updateMapViewport } from "../../../state/ducks/map";
-
 import { mapConfigSelector } from "../../../state/ducks/map-config";
 
 // TODO: Consolidate Util methods used here.
@@ -59,7 +57,7 @@ class GeocodingField extends Component {
               isWithGeocodingError: false,
             });
 
-            this.props.updateMapViewport({
+            this.props.onUpdateMapViewport({
               latitude: locationGeometry.coordinates[1],
               longitude: locationGeometry.coordinates[0],
               zoom: 14,
@@ -126,7 +124,7 @@ GeocodingField.propTypes = {
   onChange: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func,
   placeholder: PropTypes.string,
-  updateMapViewport: PropTypes.func.isRequired,
+  onUpdateMapViewport: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   isTriggeringGeocode: PropTypes.bool,
   value: PropTypes.string,
@@ -136,11 +134,6 @@ const mapStateToProps = state => ({
   mapConfig: mapConfigSelector(state),
 });
 
-const mapDispatchToProps = dispatch => ({
-  updateMapViewport: viewport => dispatch(updateMapViewport(viewport)),
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(translate("GeocodingField")(GeocodingField));
+export default connect(mapStateToProps)(
+  translate("GeocodingField")(GeocodingField),
+);

--- a/src/base/static/components/input-form/form-category-menu-wrapper.js
+++ b/src/base/static/components/input-form/form-category-menu-wrapper.js
@@ -6,6 +6,7 @@ import { translate } from "react-i18next";
 import { darken } from "@material-ui/core/styles/colorManipulator";
 
 import InputFormCategorySelector from "./input-form-category-selector";
+import InputForm from "../input-form";
 
 import { placeConfigSelector } from "../../state/ducks/place-config";
 import { hasGroupAbilitiesInDatasets } from "../../state/ducks/user";
@@ -14,6 +15,7 @@ import { getCategoryConfig } from "../../utils/config-utils";
 import { updateUIVisibility } from "../../state/ducks/ui";
 
 import { datasetUrlSelector } from "../../state/ducks/datasets";
+import { mapViewportPropType } from "../../state/ducks/map";
 
 const alertBackground = "#ffc107"; // bright yellow-orange
 const DragMapAlert = styled("div")({
@@ -74,7 +76,7 @@ class FormCategoryMenuWrapper extends Component {
     this.props.updateSpotlightMaskVisibility(true);
   }
 
-  onCategoryChange(selectedCategory) {
+  onCategoryChange = selectedCategory => {
     const categoryConfig = getCategoryConfig(
       this.props.placeConfig,
       selectedCategory,
@@ -86,7 +88,7 @@ class FormCategoryMenuWrapper extends Component {
       datasetUrl: this.props.datasetUrlSelector(categoryConfig.datasetSlug),
       datasetSlug: categoryConfig.datasetSlug,
     });
-  }
+  };
 
   render() {
     return (
@@ -104,19 +106,28 @@ class FormCategoryMenuWrapper extends Component {
             />
           </>
         )}
-        {this.state.selectedCategory
-          ? this.props.render(
-              this.state,
-              this.props,
-              this.onCategoryChange.bind(this),
-            )
-          : null}
+        {this.state.selectedCategory && (
+          <InputForm
+            contentPanelInnerContainerRef={
+              this.props.contentPanelInnerContainerRef
+            }
+            selectedCategory={this.state.selectedCategory}
+            datasetUrl={this.state.datasetUrl}
+            datasetSlug={this.state.datasetSlug}
+            isMapDraggedOrZoomed={this.props.isMapDraggedOrZoomed}
+            isSingleCategory={this.state.isSingleCategory}
+            onCategoryChange={this.onCategoryChange}
+            mapViewport={this.props.mapViewport}
+            onUpdateMapViewport={this.props.onUpdateMapViewport}
+          />
+        )}
       </>
     );
   }
 }
 
 FormCategoryMenuWrapper.propTypes = {
+  contentPanelInnerContainerRef: PropTypes.object.isRequired,
   datasetUrlSelector: PropTypes.func.isRequired,
   hasAnonAbilitiesInDataset: PropTypes.func.isRequired,
   hasGroupAbilitiesInDatasets: PropTypes.func.isRequired,
@@ -127,7 +138,8 @@ FormCategoryMenuWrapper.propTypes = {
   ]),
   containers: PropTypes.instanceOf(NodeList),
   isMapDraggedOrZoomed: PropTypes.bool.isRequired,
-  render: PropTypes.func.isRequired,
+  mapViewport: mapViewportPropType.isRequired,
+  onUpdateMapViewport: PropTypes.func.isRequired,
   updateMapCenterpointVisibility: PropTypes.func.isRequired,
   updateMapDraggedOrZoomed: PropTypes.func.isRequired,
   updateSpotlightMaskVisibility: PropTypes.func.isRequired,

--- a/src/base/static/components/input-form/form-category-menu-wrapper.js
+++ b/src/base/static/components/input-form/form-category-menu-wrapper.js
@@ -8,10 +8,6 @@ import { darken } from "@material-ui/core/styles/colorManipulator";
 import InputFormCategorySelector from "./input-form-category-selector";
 
 import { placeConfigSelector } from "../../state/ducks/place-config";
-import {
-  updateMapDraggedOrZoomed,
-  mapDraggedOrZoomedSelector,
-} from "../../state/ducks/map";
 import { hasGroupAbilitiesInDatasets } from "../../state/ducks/user";
 import { hasAnonAbilitiesInDataset } from "../../state/ducks/datasets-config";
 import { getCategoryConfig } from "../../utils/config-utils";
@@ -104,6 +100,7 @@ class FormCategoryMenuWrapper extends Component {
               onCategoryChange={this.onCategoryChange.bind(this)}
               selectedCategory={this.state.selectedCategory}
               visibleCategoryConfigs={this.visibleCategoryConfigs}
+              isMapDraggedOrZoomed={this.props.isMapDraggedOrZoomed}
             />
           </>
         )}
@@ -148,15 +145,12 @@ const mapStateToProps = state => ({
     }),
   hasAnonAbilitiesInDataset: ({ abilities, submissionSet, datasetSlug }) =>
     hasAnonAbilitiesInDataset({ state, abilities, submissionSet, datasetSlug }),
-  isMapDraggedOrZoomed: mapDraggedOrZoomedSelector(state),
   placeConfig: placeConfigSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({
   updateMapCenterpointVisibility: isVisible =>
     dispatch(updateUIVisibility("mapCenterpoint", isVisible)),
-  updateMapDraggedOrZoomed: isMapDraggedOrZoomed =>
-    dispatch(updateMapDraggedOrZoomed(isMapDraggedOrZoomed)),
   updateSpotlightMaskVisibility: isVisible =>
     dispatch(updateUIVisibility("spotlightMask", isVisible)),
 });

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -30,9 +30,9 @@ import {
   setActiveDrawGeometryId,
 } from "../../state/ducks/map-drawing-toolbar";
 import {
-  mapCenterpointSelector,
   createFeaturesInGeoJSONSource,
   updateLayerGroupVisibility,
+  mapViewportPropType,
 } from "../../state/ducks/map";
 import {
   hasAdminAbilities,
@@ -312,7 +312,7 @@ class InputForm extends Component {
           ? { "marker-symbol": this.props.activeMarker }
           : this.props.geometryStyle;
     } else {
-      const { longitude, latitude } = this.props.mapCenterpoint;
+      const { longitude, latitude } = this.props.mapViewport;
       attrs.geometry = {
         type: "Point",
         coordinates: [longitude, latitude],
@@ -548,6 +548,7 @@ class InputForm extends Component {
                   showValidityStatus={this.state.showValidityStatus}
                   updatingField={this.state.updatingField}
                   onClickSubmit={this.onSubmit.bind(this)}
+                  onUpdateMapViewport={this.props.onUpdateMapViewport}
                 />
               ))
               .toArray()}
@@ -628,8 +629,9 @@ InputForm.propTypes = {
   isSingleCategory: PropTypes.bool,
   layout: PropTypes.string.isRequired,
   mapConfig: PropTypes.object.isRequired,
-  mapCenterpoint: PropTypes.object,
+  mapViewport: mapViewportPropType.isRequired,
   onCategoryChange: PropTypes.func,
+  onUpdateMapViewport: PropTypes.func.isRequired,
   placeConfig: PropTypes.object.isRequired,
   renderCount: PropTypes.number,
   selectedCategory: PropTypes.string.isRequired,
@@ -659,7 +661,6 @@ const mapStateToProps = state => ({
     isInAtLeastOneGroup(state, groupNames, datasetSlug),
   layout: layoutSelector(state),
   mapConfig: mapConfigSelector(state),
-  mapCenterpoint: mapCenterpointSelector(state),
   placeConfig: placeConfigSelector(state),
 });
 

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -31,7 +31,6 @@ import {
 } from "../../state/ducks/map-drawing-toolbar";
 import {
   mapCenterpointSelector,
-  mapDraggedOrZoomedSelector,
   createFeaturesInGeoJSONSource,
   updateLayerGroupVisibility,
 } from "../../state/ducks/map";
@@ -658,7 +657,6 @@ const mapStateToProps = state => ({
     }),
   isInAtLeastOneGroup: (groupNames, datasetSlug) =>
     isInAtLeastOneGroup(state, groupNames, datasetSlug),
-  isMapDraggedOrZoomed: mapDraggedOrZoomedSelector(state),
   layout: layoutSelector(state),
   mapConfig: mapConfigSelector(state),
   mapCenterpoint: mapCenterpointSelector(state),

--- a/src/base/static/components/molecules/map-centerpoint.js
+++ b/src/base/static/components/molecules/map-centerpoint.js
@@ -1,13 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
-import { connect } from "react-redux";
 import { translate } from "react-i18next";
-
-import {
-  mapDraggingOrZoomingSelector,
-  mapDraggedOrZoomedSelector,
-} from "../../state/ducks/map";
 
 const MapCenterpointX = styled("span")({
   display: "block",
@@ -102,11 +96,4 @@ MapCenterpoint.propTypes = {
   t: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => ({
-  isMapDraggedOrZoomed: mapDraggedOrZoomedSelector(state),
-  isMapDraggingOrZooming: mapDraggingOrZoomingSelector(state),
-});
-
-export default connect(mapStateToProps)(
-  translate("MapCenterpoint")(MapCenterpoint),
-);
+export default translate("MapCenterpoint")(MapCenterpoint);

--- a/src/base/static/components/molecules/map-layer-panel-section.js
+++ b/src/base/static/components/molecules/map-layer-panel-section.js
@@ -140,7 +140,7 @@ MapLayerSelector.defaultProps = {
 class MapLayerPanelSection extends Component {
   onToggleLayerGroup = (layerGroupId, layerGroupMetadata) => {
     if (layerGroupMetadata.isBasemap && layerGroupMetadata.isVisible) {
-      // Prevent toggling current visible basemaps.
+      // Prevent toggling the current visible basemap.
       return;
     }
 
@@ -162,8 +162,8 @@ class MapLayerPanelSection extends Component {
           const layerGroupMetadata = this.props.layerGroupsMetadata[lg.id];
           const sourcesStatus = layerGroupMetadata.sourceIds.map(
             sourceId =>
-              this.props.sourcesMetadata[sourceId]
-                ? this.props.sourcesMetadata[sourceId].loadStatus
+              this.props.mapSourcesLoadStatus[sourceId]
+                ? this.props.mapSourcesLoadStatus[sourceId]
                 : "unloaded",
           );
 
@@ -215,6 +215,7 @@ MapLayerPanelSection.propTypes = {
     }),
   ),
   layerGroupsMetadata: PropTypes.object.isRequired,
+  mapSourcesLoadStatus: PropTypes.object.isRequired,
   sourcesMetadata: sourcesMetadataPropType.isRequired,
   title: PropTypes.string,
   updateLayerGroupVisibility: PropTypes.func.isRequired,

--- a/src/base/static/components/organisms/content-panel.js
+++ b/src/base/static/components/organisms/content-panel.js
@@ -6,7 +6,6 @@ import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 
 import CustomPage from "./custom-page";
-import InputForm from "../input-form";
 import FormCategoryMenuWrapper from "../input-form/form-category-menu-wrapper";
 import PlaceDetail from "../place-detail";
 
@@ -16,6 +15,7 @@ import {
   pageSlugSelector,
   uiVisibilitySelector,
 } from "../../state/ducks/ui";
+import { mapViewportPropType } from "../../state/ducks/map";
 import { focusedPlaceSelector, placePropType } from "../../state/ducks/places";
 import { pageSelector } from "../../state/ducks/pages-config";
 
@@ -118,23 +118,11 @@ class ContentPanel extends Component {
           )}
           {this.props.contentPanelComponent === "InputForm" && (
             <FormCategoryMenuWrapper
+              contentPanelInnerContainerRef={this.contentPanelInnerContainerRef}
               isMapDraggedOrZoomed={this.props.isMapDraggedOrZoomed}
+              mapViewport={this.props.mapViewport}
+              onUpdateMapViewport={this.props.onUpdateMapViewport}
               updateMapDraggedOrZoomed={this.props.updateMapDraggedOrZoomed}
-              render={(state, props, onCategoryChange) => {
-                return (
-                  <InputForm
-                    {...props}
-                    contentPanelInnerContainerRef={
-                      this.contentPanelInnerContainerRef
-                    }
-                    selectedCategory={state.selectedCategory}
-                    datasetUrl={state.datasetUrl}
-                    datasetSlug={state.datasetSlug}
-                    isSingleCategory={state.isSingleCategory}
-                    onCategoryChange={onCategoryChange}
-                  />
-                );
-              }}
             />
           )}
         </ContentPanelInnerContainer>
@@ -152,6 +140,7 @@ ContentPanel.propTypes = {
   languageCode: PropTypes.string.isRequired,
   layout: PropTypes.string.isRequired,
   mapContainerRef: PropTypes.object.isRequired,
+  mapViewport: mapViewportPropType.isRequired,
   onUpdateMapViewport: PropTypes.func.isRequired,
   pageSelector: PropTypes.func.isRequired,
   pageSlug: PropTypes.string,

--- a/src/base/static/components/organisms/content-panel.js
+++ b/src/base/static/components/organisms/content-panel.js
@@ -108,14 +108,17 @@ class ContentPanel extends Component {
               }
             />
           )}
-          {this.props.contentPanelComponent === "PlaceDetail" && (
-            <PlaceDetail
-              contentPanelInnerContainerRef={this.contentPanelInnerContainerRef}
-              mapContainerRef={this.props.mapContainerRef}
-              onUpdateMapViewport={this.props.onUpdateMapViewport}
-              scrollToResponseId={null}
-            />
-          )}
+          {this.props.contentPanelComponent === "PlaceDetail" &&
+            this.props.focusedPlace && (
+              <PlaceDetail
+                contentPanelInnerContainerRef={
+                  this.contentPanelInnerContainerRef
+                }
+                mapContainerRef={this.props.mapContainerRef}
+                onUpdateMapViewport={this.props.onUpdateMapViewport}
+                scrollToResponseId={null}
+              />
+            )}
           {this.props.contentPanelComponent === "InputForm" && (
             <FormCategoryMenuWrapper
               contentPanelInnerContainerRef={this.contentPanelInnerContainerRef}

--- a/src/base/static/components/organisms/content-panel.js
+++ b/src/base/static/components/organisms/content-panel.js
@@ -108,18 +108,18 @@ class ContentPanel extends Component {
               }
             />
           )}
-          {this.props.contentPanelComponent === "PlaceDetail" &&
-            this.props.focusedPlace && (
-              <PlaceDetail
-                contentPanelInnerContainerRef={
-                  this.contentPanelInnerContainerRef
-                }
-                mapContainerRef={this.props.mapContainerRef}
-                scrollToResponseId={null}
-              />
-            )}
+          {this.props.contentPanelComponent === "PlaceDetail" && (
+            <PlaceDetail
+              contentPanelInnerContainerRef={this.contentPanelInnerContainerRef}
+              mapContainerRef={this.props.mapContainerRef}
+              onUpdateMapViewport={this.props.onUpdateMapViewport}
+              scrollToResponseId={null}
+            />
+          )}
           {this.props.contentPanelComponent === "InputForm" && (
             <FormCategoryMenuWrapper
+              isMapDraggedOrZoomed={this.props.isMapDraggedOrZoomed}
+              updateMapDraggedOrZoomed={this.props.updateMapDraggedOrZoomed}
               render={(state, props, onCategoryChange) => {
                 return (
                   <InputForm
@@ -147,12 +147,15 @@ ContentPanel.propTypes = {
   contentPanelComponent: PropTypes.string,
   focusedPlace: placePropType,
   history: PropTypes.object.isRequired,
+  isMapDraggedOrZoomed: PropTypes.bool.isRequired,
   isRightSidebarVisible: PropTypes.bool.isRequired,
   languageCode: PropTypes.string.isRequired,
   layout: PropTypes.string.isRequired,
   mapContainerRef: PropTypes.object.isRequired,
+  onUpdateMapViewport: PropTypes.func.isRequired,
   pageSelector: PropTypes.func.isRequired,
   pageSlug: PropTypes.string,
+  updateMapDraggedOrZoomed: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/base/static/components/organisms/geocode-address-bar.js
+++ b/src/base/static/components/organisms/geocode-address-bar.js
@@ -77,6 +77,7 @@ class GeocodeAddressBar extends Component {
           placeholder={this.props.t("placeholderMsg")}
           isTriggeringGeocode={this.state.isTriggeringGeocode}
           value={this.state.value}
+          onUpdateMapViewport={this.props.onUpdateMapViewport}
         />
       </GeocodeAddressBarWrapper>
     );
@@ -88,6 +89,7 @@ GeocodeAddressBar.propTypes = {
   isRightSidebarVisible: PropTypes.bool.isRequired,
   layout: PropTypes.string.isRequired,
   mapConfig: PropTypes.object.isRequired,
+  onUpdateMapViewport: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
 };
 

--- a/src/base/static/components/organisms/left-sidebar.js
+++ b/src/base/static/components/organisms/left-sidebar.js
@@ -61,13 +61,16 @@ const LeftSidebar = props => (
       <CloseButton onClick={() => props.setLeftSidebarExpanded(false)}>
         &#10005;
       </CloseButton>
-      {props.leftSidebarComponent === "MapLayerPanel" && <MapLayerPanel />}
+      {props.leftSidebarComponent === "MapLayerPanel" && (
+        <MapLayerPanel mapSourcesLoadStatus={props.mapSourcesLoadStatus} />
+      )}
     </LeftSidebarInnerContainer>
   </LeftSidebarOuterContainer>
 );
 
 LeftSidebar.propTypes = {
   isLeftSidebarExpanded: PropTypes.bool.isRequired,
+  mapSourcesLoadStatus: PropTypes.object.isRequired,
   setLeftSidebarExpanded: PropTypes.func.isRequired,
   leftSidebarComponent: PropTypes.string,
   mapLegendPanelConfig: PropTypes.shape({

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -435,16 +435,16 @@ class MainMap extends Component {
       !this.state.isMapDraggingOrZooming
     ) {
       this.setState({
-        isMapDraggingOrZooming: true
-      })
+        isMapDraggingOrZooming: true,
+      });
     } else if (
       !evt.isDragging &&
       !evt.isZooming &&
       this.state.isMapDraggingOrZooming
     ) {
       this.setState({
-        isMapDraggingOrZooming: false
-      })
+        isMapDraggingOrZooming: false,
+      });
       this.props.onUpdateMapDraggedOrZoomed(true);
     }
   };

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -25,6 +25,7 @@ import {
   updateLayers,
   updateMapContainerDimensions,
   mapContainerDimensionsSeletor,
+  loadInitialMapViewport,
 } from "../../state/ducks/map";
 import { datasetsSelector, datasetsPropType } from "../../state/ducks/datasets";
 import {
@@ -254,6 +255,9 @@ class MainMap extends Component {
     this.map.off("sourcedata");
     this.map.off("draw.update");
     this.map.off("draw.create");
+    // On unmount, save the current map viewport so we can restore it if we 
+    // return to the map template.
+    this.props.loadInitialMapViewport(this.props.mapViewport);
   }
 
   // This function gets called a lot, so we throttle it.
@@ -583,6 +587,7 @@ MainMap.propTypes = {
       }),
     ),
   }).isRequired,
+  loadInitialMapViewport: PropTypes.func.isRequired,
   mapConfig: mapConfigPropType.isRequired,
   mapContainerDimensions: PropTypes.shape({
     width: PropTypes.number.isRequired,
@@ -636,6 +641,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  loadInitialMapViewport: newViewport =>
+    dispatch(loadInitialMapViewport(newViewport)),
   setActiveDrawGeometryId: id => dispatch(setActiveDrawGeometryId(id)),
   setLeftSidebarExpanded: isExpanded =>
     dispatch(setLeftSidebarExpanded(isExpanded)),

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -16,18 +16,16 @@ import {
   interactiveLayerIdsSelector,
   mapDraggingOrZoomingSelector,
   mapStyleSelector,
-  mapViewportSelector,
   mapViewportPropType,
   mapStylePropType,
-  updateMapViewport,
   updateSourceLoadStatus,
   sourcesMetadataSelector,
-  updateMapDraggedOrZoomed,
-  updateMapDraggingOrZooming,
   updateFeaturesInGeoJSONSource,
   sourcesMetadataPropType,
   updateSources,
   updateLayers,
+  updateMapContainerDimensions,
+  mapContainerDimensionsSeletor,
 } from "../../state/ducks/map";
 import { datasetsSelector, datasetsPropType } from "../../state/ducks/datasets";
 import {
@@ -56,7 +54,7 @@ import {
 import { filtersSelector } from "../../state/ducks/filters";
 import { uiVisibilitySelector } from "../../state/ducks/ui";
 import { createGeoJSONFromPlaces } from "../../utils/place-utils";
-import { updateUIVisibility } from "../../state/ducks/ui";
+import MapCenterpoint from "../molecules/map-centerpoint";
 
 import emitter from "../../utils/emitter";
 
@@ -144,6 +142,7 @@ CustomControl.defaultProps = {
 class MainMap extends Component {
   state = {
     isMapLoaded: false,
+    isMapDraggingOrZooming: false,
   };
 
   mapRef = createRef();
@@ -158,28 +157,28 @@ class MainMap extends Component {
     // these events to a ref of the map because react-map-gl does not expose
     // the event binding API itself.
     this.map = this.mapRef.current.getMap();
-    this.map.on("error", evt => {
-      if (
-        evt.sourceId &&
-        this.props.sourcesMetadata[evt.sourceId].loadStatus !== "error"
-      ) {
-        this.props.updateSourceLoadStatus(evt.sourceId, "error");
-      }
-    });
-
-    this.map.on("sourcedata", evt => {
-      if (evt.sourceId.startsWith("mapbox-gl-draw")) {
-        return;
-      }
-
-      const loadStatus = this.map.isSourceLoaded(evt.sourceId)
-        ? "loaded"
-        : "loading";
-
-      if (this.props.sourcesMetadata[evt.sourceId].loadStatus !== loadStatus) {
-        this.props.updateSourceLoadStatus(evt.sourceId, loadStatus);
-      }
-    });
+    //    this.map.on("error", evt => {
+    //      if (
+    //        evt.sourceId &&
+    //        this.props.sourcesMetadata[evt.sourceId].loadStatus !== "error"
+    //      ) {
+    //        this.props.updateSourceLoadStatus(evt.sourceId, "error");
+    //      }
+    //    });
+    //
+    //    this.map.on("sourcedata", evt => {
+    //      if (evt.sourceId.startsWith("mapbox-gl-draw")) {
+    //        return;
+    //      }
+    //
+    //      const loadStatus = this.map.isSourceLoaded(evt.sourceId)
+    //        ? "loaded"
+    //        : "loading";
+    //
+    //      if (this.props.sourcesMetadata[evt.sourceId].loadStatus !== loadStatus) {
+    //        this.props.updateSourceLoadStatus(evt.sourceId, loadStatus);
+    //      }
+    //    });
 
     if (!this.props.mapConfig.options.disableDrawing) {
       this.draw = new MapboxDraw({
@@ -273,7 +272,7 @@ class MainMap extends Component {
       this.props.mapContainerRef.current,
     ).getBoundingClientRect();
 
-    this.props.updateMapViewport({
+    this.props.updateMapContainerDimensions({
       height: containerDims.height,
       width: containerDims.width,
     });
@@ -330,7 +329,7 @@ class MainMap extends Component {
       // Drawing mode has been entered.
       this.map.on("dragend", () => {
         const { lng, lat } = this.map.getCenter();
-        this.props.updateMapViewport({
+        this.props.onUpdateMapViewport({
           latitude: lat,
           longitude: lng,
         });
@@ -414,7 +413,7 @@ class MainMap extends Component {
 
   endFeatureQuery = () => {
     if (
-      !this.props.isMapDraggingOrZooming &&
+      !this.state.isMapDraggingOrZooming &&
       this.queriedFeatures.length &&
       this.queriedFeatures[0].properties &&
       this.queriedFeatures[0].properties._clientSlug
@@ -433,17 +432,20 @@ class MainMap extends Component {
   onInteractionStateChange = evt => {
     if (
       (evt.isDragging || evt.isZooming) &&
-      !this.props.isMapDraggingOrZooming
+      !this.state.isMapDraggingOrZooming
     ) {
-      this.props.updateMapDraggingOrZooming(true);
+      this.setState({
+        isMapDraggingOrZooming: true
+      })
     } else if (
       !evt.isDragging &&
       !evt.isZooming &&
-      this.props.isMapDraggingOrZooming
+      this.state.isMapDraggingOrZooming
     ) {
-      this.props.updateMapDraggingOrZooming(false);
-      this.props.updateMapDraggedOrZoomed(true);
-      this.props.updateSpotlightMaskVisibility(false);
+      this.setState({
+        isMapDraggingOrZooming: false
+      })
+      this.props.onUpdateMapDraggedOrZoomed(true);
     }
   };
 
@@ -467,8 +469,8 @@ class MainMap extends Component {
         <MapGL
           attributionControl={false}
           ref={this.mapRef}
-          width={this.props.mapViewport.width}
-          height={this.props.mapViewport.height}
+          width={this.props.mapContainerDimensions.width}
+          height={this.props.mapContainerDimensions.height}
           latitude={this.props.mapViewport.latitude}
           longitude={this.props.mapViewport.longitude}
           pitch={this.props.mapViewport.pitch}
@@ -501,7 +503,7 @@ class MainMap extends Component {
             // where react-map-gl needs to set the width or height of the map
             // container.
             const { width, height, ...rest } = viewport;
-            this.props.updateMapViewport(
+            this.props.onUpdateMapViewport(
               rest,
               this.isMapTransitioning
                 ? false
@@ -515,15 +517,21 @@ class MainMap extends Component {
           onInteractionStateChange={this.onInteractionStateChange}
           onLoad={this.onMapLoad}
         >
+          {this.props.isMapCenterpointVisible && (
+            <MapCenterpoint
+              isMapDraggingOrZooming={this.state.isMapDraggingOrZooming}
+              isMapDraggedOrZoomed={this.props.isMapDraggedOrZoomed}
+            />
+          )}
           {this.state.isMapLoaded && (
             <MapControlsContainer>
               <NavigationControl
                 onViewportChange={viewport =>
-                  this.props.updateMapViewport(viewport)
+                  this.props.onUpdateMapViewport(viewport)
                 }
               />
               <GeolocateControl
-                updateMapViewport={this.props.updateMapViewport}
+                updateMapViewport={this.props.onUpdateMapViewport}
               />
               {this.props.leftSidebarConfig.panels.map(panel => (
                 <CustomControl
@@ -553,7 +561,8 @@ MainMap.propTypes = {
   interactiveLayerIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   isContentPanelVisible: PropTypes.bool.isRequired,
   isDrawModeActive: PropTypes.bool.isRequired,
-  isMapDraggingOrZooming: PropTypes.bool.isRequired,
+  isMapCenterpointVisible: PropTypes.bool.isRequired,
+  isMapDraggedOrZoomed: PropTypes.bool.isRequired,
   isRightSidebarVisible: PropTypes.bool.isRequired,
   isInviteModalOpen: PropTypes.bool.isRequired,
   leftSidebarConfig: PropTypes.shape({
@@ -568,6 +577,10 @@ MainMap.propTypes = {
     ),
   }).isRequired,
   mapConfig: mapConfigPropType.isRequired,
+  mapContainerDimensions: PropTypes.shape({
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+  }),
   mapContainerWidthDeclaration: PropTypes.string.isRequired,
   mapContainerHeightDeclaration: PropTypes.string.isRequired,
   mapContainerRef: PropTypes.object.isRequired,
@@ -579,15 +592,15 @@ MainMap.propTypes = {
   setLeftSidebarExpanded: PropTypes.func.isRequired,
   setLeftSidebarComponent: PropTypes.func.isRequired,
   sourcesMetadata: sourcesMetadataPropType.isRequired,
-  updateMapDraggedOrZoomed: PropTypes.func.isRequired,
-  updateMapDraggingOrZooming: PropTypes.func.isRequired,
+  onUpdateMapDraggedOrZoomed: PropTypes.func.isRequired,
   updateFeaturesInGeoJSONSource: PropTypes.func.isRequired,
   updateLayers: PropTypes.func.isRequired,
-  updateMapViewport: PropTypes.func.isRequired,
+  onUpdateMapViewport: PropTypes.func.isRequired,
   updateSources: PropTypes.func.isRequired,
   updateSourceLoadStatus: PropTypes.func.isRequired,
-  updateSpotlightMaskVisibility: PropTypes.func.isRequired,
+  onUpdateSpotlightMaskVisibility: PropTypes.func.isRequired,
   datasets: datasetsPropType,
+  updateMapContainerDimensions: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -600,12 +613,13 @@ const mapStateToProps = state => ({
   isContentPanelVisible: uiVisibilitySelector("contentPanel", state),
   isDrawModeActive: drawModeActiveSelector(state),
   isInviteModalOpen: uiVisibilitySelector("inviteModal", state),
+  isMapCenterpointVisible: uiVisibilitySelector("mapCenterpoint", state),
   isMapDraggingOrZooming: mapDraggingOrZoomingSelector(state),
   isRightSidebarVisible: uiVisibilitySelector("rightSidebar", state),
   leftSidebarConfig: leftSidebarConfigSelector(state),
   interactiveLayerIds: interactiveLayerIdsSelector(state),
   mapConfig: mapConfigSelector(state),
-  mapViewport: mapViewportSelector(state),
+  mapContainerDimensions: mapContainerDimensionsSeletor(state),
   mapStyle: mapStyleSelector(state),
   placeFilters: filtersSelector(state),
   placeSelector: placeId => placeSelector(state, placeId),
@@ -619,20 +633,15 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setLeftSidebarExpanded(isExpanded)),
   setLeftSidebarComponent: component =>
     dispatch(setLeftSidebarComponent(component)),
-  updateMapDraggedOrZoomed: isDraggedOrZoomed =>
-    dispatch(updateMapDraggedOrZoomed(isDraggedOrZoomed)),
-  updateMapDraggingOrZooming: isDraggingOrZooming =>
-    dispatch(updateMapDraggingOrZooming(isDraggingOrZooming)),
   updateFeaturesInGeoJSONSource: (sourceId, newFeatures) =>
     dispatch(updateFeaturesInGeoJSONSource(sourceId, newFeatures)),
-  updateMapViewport: viewport => dispatch(updateMapViewport(viewport)),
   updateSourceLoadStatus: (sourceId, loadStatus) =>
     dispatch(updateSourceLoadStatus(sourceId, loadStatus)),
   updateSources: (newSourceId, newSource) =>
     dispatch(updateSources(newSourceId, newSource)),
   updateLayers: newLayer => dispatch(updateLayers(newLayer)),
-  updateSpotlightMaskVisibility: isVisible =>
-    dispatch(updateUIVisibility("spotlightMask", isVisible)),
+  updateMapContainerDimensions: newDimensions =>
+    dispatch(updateMapContainerDimensions(newDimensions)),
 });
 
 export default withRouter(

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -255,7 +255,7 @@ class MainMap extends Component {
     this.map.off("sourcedata");
     this.map.off("draw.update");
     this.map.off("draw.create");
-    // On unmount, save the current map viewport so we can restore it if we 
+    // On unmount, save the current map viewport so we can restore it if we
     // return to the map template.
     this.props.loadInitialMapViewport(this.props.mapViewport);
   }

--- a/src/base/static/components/organisms/map-layer-panel.js
+++ b/src/base/static/components/organisms/map-layer-panel.js
@@ -16,6 +16,7 @@ const MapLayerPanel = props => (
         <MapLayerPanelSection
           key={section.id}
           layerGroups={section.layerGroups}
+          mapSourcesLoadStatus={props.mapSourcesLoadStatus}
           title={section.title}
         />
       ))}
@@ -23,6 +24,7 @@ const MapLayerPanel = props => (
 );
 
 MapLayerPanel.propTypes = {
+  mapSourcesLoadStatus: PropTypes.object.isRequired,
   mapLayerPanelConfig: PropTypes.shape({
     id: PropTypes.string.isRequired,
     component: PropTypes.string.isRequired,

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -54,7 +54,6 @@ import {
 import { placePropType, focusedPlaceSelector } from "../../state/ducks/places";
 import {
   removeFocusedGeoJSONFeatures,
-  updateMapViewport,
   updateFocusedGeoJSONFeatures,
   updateLayerGroupVisibility,
 } from "../../state/ducks/map";
@@ -162,7 +161,7 @@ class PlaceDetail extends Component {
         newViewport.zoom = story.zoom;
       }
 
-      this.props.updateMapViewport(newViewport);
+      this.props.onUpdateMapViewport(newViewport);
     } else if (
       this.props.focusedPlace.geometry.type === "LineString" ||
       this.props.focusedPlace.geometry.type === "Polygon"
@@ -174,7 +173,7 @@ class PlaceDetail extends Component {
         { padding: 50 },
       );
 
-      this.props.updateMapViewport({
+      this.props.onUpdateMapViewport({
         latitude: newViewport.latitude,
         longitude: newViewport.longitude,
         transitionDuration: story ? 3000 : 200,
@@ -190,7 +189,7 @@ class PlaceDetail extends Component {
         newViewport.zoom = story.zoom;
       }
 
-      this.props.updateMapViewport(newViewport);
+      this.props.onUpdateMapViewport(newViewport);
     }
 
     if (story && !story.spotlight) {
@@ -428,15 +427,14 @@ PlaceDetail.propTypes = {
   updateEditModeToggled: PropTypes.func.isRequired,
   updateFocusedGeoJSONFeatures: PropTypes.func.isRequired,
   updateLayerGroupVisibility: PropTypes.func.isRequired,
-  updateMapViewport: PropTypes.func.isRequired,
   updateSpotlightMaskVisibility: PropTypes.func.isRequired,
+  onUpdateMapViewport: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = dispatch => ({
   removeFocusedGeoJSONFeatures: () => dispatch(removeFocusedGeoJSONFeatures()),
   updateEditModeToggled: isToggled =>
     dispatch(updateEditModeToggled(isToggled)),
-  updateMapViewport: newViewport => dispatch(updateMapViewport(newViewport)),
   updateSpotlightMaskVisibility: isVisible =>
     dispatch(updateUIVisibility("spotlightMask", isVisible)),
   updateFocusedGeoJSONFeatures: newFeatures =>

--- a/src/base/static/components/templates/map.js
+++ b/src/base/static/components/templates/map.js
@@ -180,6 +180,34 @@ class MapTemplate extends Component {
     }
 
     this.recaculateContainerSize();
+
+ //   // URL parameters passed through by the router.
+ //   const { params } = this.props.match;
+
+ //   params.zoom &&
+ //     params.lat &&
+ //     params.lng &&
+ //     this.props.updateMapViewport({
+ //       zoom: params.zoom,
+ //       lat: params.lat,
+ //       lng: params.lng,
+ //     });
+
+ //   this.props.updateUIVisibility(
+ //     "contentPanel",
+ //     !!(params.pageSlug || params.datasetClientSlug),
+ //   );
+
+ //   this.props.updateUIVisibility(
+ //     "mapCenterpoint",
+ //     this.props.location.pathname === "/new",
+ //   );
+ //   this.props.updateUIVisibility("spotlightMask", (params.datasetClientSlug));
+ //   this.props.updateUIVisibility("addPlaceButton", true);
+ //   this.props.focusedPlaceId &&
+ //     this.props.updateFocusedPlaceId(this.props.focusedPlaceId);
+ //   this.props.contentPanelComponent &&
+ //     this.props.updateContentPanelComponent(this.props.contentPanelComponent);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/base/static/components/templates/map.js
+++ b/src/base/static/components/templates/map.js
@@ -46,9 +46,16 @@ import {
   mapConfigPropType,
 } from "../../state/ducks/map-config";
 import {
+  createFeaturesInGeoJSONSource,
   initialMapViewportSelector,
   mapViewportPropType,
 } from "../../state/ducks/map";
+import {
+  placeExists,
+  updateFocusedPlaceId,
+  updateScrollToResponseId,
+  loadPlaceAndSetIgnoreFlag,
+} from "../../state/ducks/places";
 
 import {
   getMainContentAreaWidth,
@@ -102,7 +109,7 @@ class MapTemplate extends Component {
     zoom &&
       lat &&
       lng &&
-      this.props.updateMapViewport({
+      this.onUpdateMapViewport({
         zoom: parseFloat(zoom),
         lat: parseFloat(lat),
         lng: parseFloat(lng),
@@ -180,34 +187,6 @@ class MapTemplate extends Component {
     }
 
     this.recaculateContainerSize();
-
- //   // URL parameters passed through by the router.
- //   const { params } = this.props.match;
-
- //   params.zoom &&
- //     params.lat &&
- //     params.lng &&
- //     this.props.updateMapViewport({
- //       zoom: params.zoom,
- //       lat: params.lat,
- //       lng: params.lng,
- //     });
-
- //   this.props.updateUIVisibility(
- //     "contentPanel",
- //     !!(params.pageSlug || params.datasetClientSlug),
- //   );
-
- //   this.props.updateUIVisibility(
- //     "mapCenterpoint",
- //     this.props.location.pathname === "/new",
- //   );
- //   this.props.updateUIVisibility("spotlightMask", (params.datasetClientSlug));
- //   this.props.updateUIVisibility("addPlaceButton", true);
- //   this.props.focusedPlaceId &&
- //     this.props.updateFocusedPlaceId(this.props.focusedPlaceId);
- //   this.props.contentPanelComponent &&
- //     this.props.updateContentPanelComponent(this.props.contentPanelComponent);
   }
 
   componentDidUpdate(prevProps) {
@@ -350,7 +329,10 @@ class MapTemplate extends Component {
     return (
       <>
         {this.props.isGeocodeAddressBarEnabled && (
-          <GeocodeAddressBar mapConfig={this.props.mapConfig} />
+          <GeocodeAddressBar
+            mapConfig={this.props.mapConfig}
+            onUpdateMapViewport={this.onUpdateMapViewport}
+          />
         )}
         <MapContainer
           ref={this.mapContainerRef}
@@ -382,6 +364,7 @@ class MapTemplate extends Component {
             isMapDraggedOrZoomed={this.state.isMapDraggedOrZoomed}
             languageCode={this.props.languageCode}
             mapContainerRef={this.mapContainerRef}
+            mapViewport={this.state.mapViewport}
             onUpdateMapViewport={this.onUpdateMapViewport}
             updateMapDraggedOrZoomed={isMapDraggedOrZoomed =>
               this.setState({
@@ -441,7 +424,6 @@ MapTemplate.propTypes = {
   }).isRequired,
   placeConfig: placeConfigPropType.isRequired,
   placeExists: PropTypes.func.isRequired,
-  updateMapViewport: PropTypes.func.isRequired,
   uiConfiguration: PropTypes.string.isRequired,
   updateUIVisibility: PropTypes.func.isRequired,
   updateActivePage: PropTypes.func.isRequired,
@@ -492,7 +474,6 @@ const mapDispatchToProps = dispatch => ({
     dispatch(createFeaturesInGeoJSONSource(sourceId, newFeatures)),
   loadPlaceAndSetIgnoreFlag: placeModel =>
     dispatch(loadPlaceAndSetIgnoreFlag(placeModel)),
-  updateMapViewport: mapViewport => dispatch(updateMapViewport(mapViewport)),
   updateUIVisibility: (componentName, isVisible) =>
     dispatch(updateUIVisibility(componentName, isVisible)),
   updateActivePage: pageSlug => dispatch(updateActivePage(pageSlug)),

--- a/src/base/static/index.js
+++ b/src/base/static/index.js
@@ -1,11 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { createStore } from "redux";
-<<<<<<< HEAD
 import { BrowserRouter as Router } from "react-router-dom";
-=======
-import { BrowserRouter as Router } from "react-router-dom"
->>>>>>> refactor(app): add react router
 
 import App from "./components/app";
 import reducer from "./state/reducers";

--- a/src/base/static/index.js
+++ b/src/base/static/index.js
@@ -1,7 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { createStore } from "redux";
+<<<<<<< HEAD
 import { BrowserRouter as Router } from "react-router-dom";
+=======
+import { BrowserRouter as Router } from "react-router-dom"
+>>>>>>> refactor(app): add react router
 
 import App from "./components/app";
 import reducer from "./state/reducers";

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -542,8 +542,8 @@
             "source": "pbdurham",
             "layout": {
               "icon-allow-overlap": true,
-              "icon-anchor": ["step", ["zoom"], "center", 10, "bottom"],
-              "icon-size": ["step", ["zoom"], 0.3, 10, 0.4],
+              "icon-anchor": ["step", ["zoom"], "center", 13, "bottom"],
+              "icon-size": ["step", ["zoom"], 0.3, 13, 0.4],
               "icon-image": [
                 "step",
                 ["zoom"],
@@ -564,7 +564,7 @@
                   "dot-ffd614.png",
                   "__no-icon-image__"
                 ],
-                10,
+                13,
                 [
                   "match",
                   ["get", "location_type"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -126,10 +126,10 @@ module.exports = {
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     extractSCSS,
     new CompressionPlugin(),
-    new WorkboxPlugin.InjectManifest({
-      swSrc: path.join("src", "sw.js"),
-      swDest: path.join(outputPath, "service-worker.js"),
-    }),
+    //    new WorkboxPlugin.InjectManifest({
+    //      swSrc: path.join("src", "sw.js"),
+    //      swDest: path.join(outputPath, "service-worker.js"),
+    //    }),
   ],
   devtool: isProd ? false : "cheap-eval-souce-map",
   devServer: {


### PR DESCRIPTION
(This branch is based off of `goldpbear/replace-backbone-router`. I'll treat https://github.com/mapseed/platform/pull/1242 as a feature branch.)

This PR improves overall map performance, including zooming and panning and focused geometry selection, by cutting down on the number of Redux dispatches required.

TODO
 - [x] restore viewport on return to map template
 - [x] source load feedback