### PR TITLE
chore(deploy.js): rewrite uncompressed bundle requests to compressed equivalents

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -126,6 +126,19 @@ function updateMetadata() {
       }),
     )
     .concat(
+      glob.sync("./www/**/*.bundle.{js,css}").map(filepath => {
+        filepath = path.relative("./www", filepath);
+        const gzippedFilepath = path.relative("./www", `${filepath}.gz`);
+
+        // Enable a rewrite rule on S3 that directs requests to uncompressed
+        // bundles to their compressed equivalents.
+        params = {
+          WebsiteRedirectLocation: `/${gzippedFilepath}`,
+        };
+        return copyObjectPromise(buildParams(filepath, params));
+      }),
+    )
+    .concat(
       glob
         .sync("./www/static/css/images/markers/spritesheet*")
         .map(filepath => {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -139,6 +139,16 @@ function updateMetadata() {
       }),
     )
     .concat(
+      glob.sync("./www/**/*.bundle.{js,css}.gz").map(filepath => {
+        filepath = path.relative("./www", filepath);
+
+        params = {
+          CacheControl: "max-age=31536000",
+        };
+        return copyObjectPromise(buildParams(filepath, params));
+      }),
+    )
+    .concat(
       glob
         .sync("./www/static/css/images/markers/spritesheet*")
         .map(filepath => {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -143,7 +143,7 @@ function updateMetadata() {
         filepath = path.relative("./www", filepath);
 
         params = {
-          CacheControl: "max-age=31536000",
+          CacheControl: "max-age=31536000", // One year
         };
         return copyObjectPromise(buildParams(filepath, params));
       }),


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/264

We also add a caching policy for bundle assets of one year.