### PR TITLE
fix(dashboardTemplate)

### DIFF
--- a/src/base/static/components/templates/dashboard.js
+++ b/src/base/static/components/templates/dashboard.js
@@ -4,6 +4,8 @@ import { jsx } from "@emotion/core";
 import PropTypes from "prop-types";
 import moment from "moment";
 import "moment-timezone";
+import { withRouter } from "react-router-dom";
+
 import Button from "@material-ui/core/Button";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -177,7 +179,7 @@ class Dashboard extends React.Component {
 
   componentDidMount() {
     if (!this.props.hasAdminAbilities(this.state.dashboard.datasetSlug)) {
-      this.props.router.navigate("/", { trigger: true });
+      this.props.history.push("/");
     }
   }
 
@@ -514,4 +516,4 @@ const mapStateToProps = state => ({
   datasetsConfig: datasetsConfigSelector(state),
 });
 
-export default connect(mapStateToProps)(Dashboard);
+export default withRouter(connect(mapStateToProps)(Dashboard));

--- a/src/flavors/pbdemo/config.json
+++ b/src/flavors/pbdemo/config.json
@@ -2,8 +2,8 @@
   "datasets": [
     {
       "slug": "pbdemo",
-      "url": "https://api.heyduwamish.org/api/v2/smartercleanup/datasets/pbdemo",
-      "clientSlug": "idea",
+      "url": "https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/pbdemo",
+      "clientSlug": "demo-idea",
       "anonymous_permissions": [
         {
           "abilities": ["retrieve", "create"],
@@ -26,7 +26,7 @@
       "url": "https://dev-api.heyduwamish.org/api/v2/smartercleanup/datasets/pbdemo-projects",
       "slug": "pbdemo-projects",
       "owner": "smartercleanup",
-      "clientSlug": "project",
+      "clientSlug": "demo-project",
       "anonymous_permissions": [
         {
           "abilities": ["retrieve", "create"],
@@ -88,6 +88,13 @@
     ]
   },
   "dashboard": [
+    {
+      "datasetSlug": "pbdurham-projects",
+      "surveyMetrics": {
+        "wards": true,
+        "budget": true
+      }
+    },
     {
       "datasetSlug": "pbdurham",
       "surveyMetrics": {
@@ -1687,6 +1694,32 @@
       }
     ],
     "fields": [
+      {
+        "id": "ward",
+        "type": "radio",
+        "prompt": "_(Is this project located in Ward 1, Ward 2, Ward 3, or Citywide?)",
+        "display_prompt": "_(Ward:)",
+        "label": "_(Ward:)",
+        "optional": true,
+        "content": [
+          {
+            "label": "_(Ward 1)",
+            "value": "ward_1"
+          },
+          {
+            "label": "_(Ward 2)",
+            "value": "ward_2"
+          },
+          {
+            "label": "_(Ward 3)",
+            "value": "ward_3"
+          },
+          {
+            "label": "_(Citywide)",
+            "value": "citywide"
+          }
+        ]
+      },
       {
         "id": "private-ethnicity",
         "autocomplete": false,

--- a/src/flavors/pbdemo/config.json
+++ b/src/flavors/pbdemo/config.json
@@ -98,8 +98,7 @@
     {
       "datasetSlug": "pbdurham",
       "surveyMetrics": {
-        "categories": true,
-        "demographics": true
+        "categories": true
       }
     }
   ],


### PR DESCRIPTION
Fixes for the `pbdemo` flavor dashboard.

Add react router HOC. Also add projects dataset to `pbdemo` dashboard and remove demographics category from the dashboard.