### PR TITLE
Goldpbear/feature popups

### DIFF
--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -443,7 +443,7 @@ class MainMap extends Component {
 
   isMapEvent = evt => {
     // An event's className will be `overlays` when the event originates on
-    // the map itself (as opposed to on control overlays or on popups).
+    // the map itself (as opposed to on controls or on popups).
     return evt.target && evt.target.className === "overlays";
   };
 

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -441,12 +441,14 @@ class MainMap extends Component {
     });
   };
 
+  isMapEvent = evt => {
+    // An event's className will be `overlays` when the event originates on
+    // the map itself (as opposed to on control overlays or on popups).
+    return evt.target && evt.target.className === "overlays";
+  };
+
   beginFeatureQuery = evt => {
-    if (evt.target.className !== "overlays") {
-      // The mousedown and touchstart event's className will be `overlays` when
-      // the event originates on the map itself. We want to prevent feature
-      // queries when `className` is anything else (such as when the user
-      // clicks on control overlays or on popups).
+    if (!this.isMapEvent(event)) {
       return;
     }
 
@@ -465,6 +467,10 @@ class MainMap extends Component {
   };
 
   endFeatureQuery = evt => {
+    if (!this.isMapEvent(evt)) {
+      return;
+    }
+
     const feature = this.queriedFeatures[0];
 
     if (
@@ -487,7 +493,9 @@ class MainMap extends Component {
       this.props.mapLayerPopupSelector(feature.layer.id) &&
       // When `center.x` matches `mouseX` and `center.y` matches `mouseY`, the
       // user has clicked in place (as opposed to clicking, dragging, then
-      // releasing). We wouldn't need to worry about tracking this information
+      // releasing). We only want to render popups on in-place clicks.
+      //
+      // We wouldn't need to worry about tracking this information
       // if we used the `onClick` listener, but as explained above we avoid
       // `onClick` for performance reasons.
       evt.center.x === this.mouseX &&

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -21,6 +21,13 @@ export const mapCenterpointSelector = state => ({
 export const drawModeActiveSelector = state => state.map.isDrawModeActive;
 export const mapContainerDimensionsSeletor = state =>
   state.map.mapContainerDimensions;
+export const mapLayerPopupSelector = (layerId, state) => {
+  const metadata = Object.values(state.map.layerGroupsMetadata).find(
+    layerGroupMetadata => layerGroupMetadata.layerIds.includes(layerId),
+  );
+
+  return metadata && metadata.popupContent ? metadata.popupContent : null;
+};
 // Return information about visible layer groups which are configured to be
 // filterable with a slider.
 export const filterableLayerGroupsMetadataSelector = state =>
@@ -224,6 +231,7 @@ export function loadMapStyle(mapConfig, datasetsConfig) {
     (memo, layerGroup) => ({
       ...memo,
       [layerGroup.id]: {
+        popupContent: layerGroup.popupContent,
         filterSlider: layerGroup.filterSlider,
         isBasemap: !!layerGroup.basemap,
         isVisible: !!layerGroup.visibleDefault,

--- a/src/flavors/defaultflavor/config.json
+++ b/src/flavors/defaultflavor/config.json
@@ -140,6 +140,7 @@
       },
       {
         "id": "sample-json-b",
+        "popupContent": "<h3>City name:</h3><p>{{CITYNAME}}</p>",
         "mapboxLayers": [
           {
             "id": "sample-json-b-labels",
@@ -1286,7 +1287,7 @@
   "pages": [
     {
       "slug": "getinvolved",
-      "lang": "en_US",
+      "lang": "en",
       "content": [
         "<h1>Get involved</h1>",
         "<p>Want to help out? Excellent!</p>",
@@ -1298,7 +1299,7 @@
     },
     {
       "slug": "about",
-      "lang": "en_US",
+      "lang": "en",
       "content": [
         "<h1>Welcome</h1>",
         "<p>We are a community of residents and stakeholders who are monitoring important issues in our community.</p>",


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/44
Closes: https://github.com/jalMogo/mgmt/issues/160

Restore the ability to add popups with content optionally derived from feature properties. 

A `layerGroup` may define a `popupContent` attribute, which should be an HTML string to render in the popup. Feature properties may be referenced with a Handlebars-like syntax, e.g.: `{{CITYNAME}}` would look up the value the `CITYNAME` property for the clicked-on feature.