### PR TITLE
Jalmogo/mississippi flavor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,7 +7716,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8131,7 +8132,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8187,6 +8189,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8230,12 +8233,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15721,6 +15726,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "react-virtualized": "^9.20.1",
     "recharts": "^1.4.1",
     "redux": "^4.0.0",
+    "reselect": "^4.0.0",
     "shelljs": "^0.5.3",
     "throttle-debounce": "^2.1.0",
     "turf-extent": "^1.0.4",

--- a/src/base/static/components/app.tsx
+++ b/src/base/static/components/app.tsx
@@ -47,7 +47,10 @@ import {
 import { loadDatasets } from "../state/ducks/datasets";
 import { loadDashboardConfig } from "../state/ducks/dashboard-config";
 import { appConfigPropType, loadAppConfig } from "../state/ducks/app-config";
-import { loadMapConfig } from "../state/ducks/map-config";
+import {
+  loadMapConfig,
+  defaultMapViewportSelector,
+} from "../state/ducks/map-config";
 import { loadDatasetsConfig } from "../state/ducks/datasets-config";
 import { loadPlaceConfig } from "../state/ducks/place-config";
 import { loadAnalysisTargets } from "../state/ducks/analysis";
@@ -61,7 +64,7 @@ import {
   pageExistsSelector,
 } from "../state/ducks/pages-config";
 import { loadNavBarConfig } from "../state/ducks/nav-bar-config";
-import { loadMapStyle } from "../state/ducks/map";
+import { loadMapStyle, mapViewportPropType } from "../state/ducks/map";
 import { updatePlacesLoadStatus, loadPlaces } from "../state/ducks/places";
 import { loadCustomComponentsConfig } from "../state/ducks/custom-components-config";
 import { loadUser } from "../state/ducks/user";
@@ -125,6 +128,7 @@ const Fallback = () => {
 const statePropTypes = {
   appConfig: appConfigPropType,
   currentTemplate: PropTypes.string.isRequired,
+  defaultMapViewport: mapViewportPropType,
   datasetsConfig: datasetsConfigPropType,
   datasetSlugs: PropTypes.array.isRequired,
   hasAnonAbilitiesInAnyDataset: PropTypes.func.isRequired,
@@ -216,15 +220,7 @@ class App extends Component<Props, State> {
     // map template from another template. This allows us to "save" a viewport
     // when routing away from the map template, and restore it when routing back
     // to the map template.
-    initialMapViewport: {
-      minZoom: 0,
-      maxZoom: 18,
-      latitude: 0,
-      longitude: 0,
-      zoom: 0,
-      bearing: 0,
-      pitch: 0,
-    },
+    initialMapViewport: this.props.defaultMapViewport,
     defaultLanguage: {
       code: "en",
       label: "English",
@@ -385,9 +381,7 @@ class App extends Component<Props, State> {
       currentLanguageCode: i18next.language,
       defaultLanguage: resolvedConfig.flavor.defaultLanguage,
       isInitialDataLoaded: true,
-      initialMapViewport: {
-        ...resolvedConfig.map.options.mapViewport,
-      },
+      initialMapViewport: this.props.defaultMapViewport,
     });
 
     window.addEventListener("resize", this.props.updateLayout);
@@ -744,6 +738,7 @@ const mapStateToProps = (
 ): StateProps => ({
   appConfig: appConfigSelector(state),
   currentTemplate: currentTemplateSelector(state),
+  defaultMapViewport: defaultMapViewportSelector(state),
   datasetSlugs: datasetSlugsSelector(state),
   datasetsConfig: datasetsConfigSelector(state),
   hasAnonAbilitiesInAnyDataset: (submissionSet, abilities) =>

--- a/src/base/static/components/app.tsx
+++ b/src/base/static/components/app.tsx
@@ -310,7 +310,7 @@ class App extends Component<Props, State> {
     this.props.loadPagesConfig(resolvedConfig.pages);
     this.props.loadNavBarConfig(resolvedConfig.nav_bar);
     this.props.loadCustomComponentsConfig(resolvedConfig.custom_components);
-    this.props.loadMapStyle(resolvedConfig.map, resolvedConfig.datasets);
+    this.props.loadMapStyle(resolvedConfig.mapStyle, resolvedConfig.datasets);
     resolvedConfig.dashboard &&
       this.props.loadDashboardConfig(resolvedConfig.dashboard);
     resolvedConfig.right_sidebar.is_visible_default &&

--- a/src/base/static/components/form-fields/types/geocoding-field.js
+++ b/src/base/static/components/form-fields/types/geocoding-field.js
@@ -7,7 +7,7 @@ import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import "./geocoding-field.scss";
 
-import { mapConfigSelector } from "../../../state/ducks/map-config";
+import { mapConfigSelector, mapConfigPropType } from "../../../state/ducks/map-config";
 
 // TODO: Consolidate Util methods used here.
 import Util from "../../../js/utils.js";
@@ -45,8 +45,8 @@ class GeocodingField extends Component {
 
     Util[this.geocodingEngine].geocode({
       location: address,
-      hint: this.props.mapConfig.geocode_hint,
-      bbox: this.props.mapConfig.geocode_bounding_box,
+      hint: this.props.mapConfig.geocodeHint,
+      bbox: this.props.mapConfig.geocodeBoundingBox,
       options: {
         success: data => {
           const locationGeometry =
@@ -123,7 +123,7 @@ class GeocodingField extends Component {
 
 GeocodingField.propTypes = {
   formId: PropTypes.string.isRequired,
-  mapConfig: PropTypes.object.isRequired,
+  mapConfig: mapConfigPropType,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func,

--- a/src/base/static/components/form-fields/types/geocoding-field.js
+++ b/src/base/static/components/form-fields/types/geocoding-field.js
@@ -7,7 +7,10 @@ import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import "./geocoding-field.scss";
 
-import { mapConfigSelector, mapConfigPropType } from "../../../state/ducks/map-config";
+import {
+  mapConfigSelector,
+  mapConfigPropType,
+} from "../../../state/ducks/map-config";
 
 // TODO: Consolidate Util methods used here.
 import Util from "../../../js/utils.js";

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -18,7 +18,6 @@ import { extractEmbeddedImages } from "../../utils/embedded-images";
 
 import { getCategoryConfig } from "../../utils/config-utils";
 import { toClientGeoJSONFeature } from "../../utils/place-utils";
-import { mapConfigSelector } from "../../state/ducks/map-config";
 import { placeConfigSelector } from "../../state/ducks/place-config";
 import { createPlace } from "../../state/ducks/places";
 import {
@@ -29,6 +28,8 @@ import {
   createFeaturesInGeoJSONSource,
   updateLayerGroupVisibility,
   mapViewportPropType,
+  layerGroupsMetadataSelector,
+  layerGroupsMetadataPropType,
 } from "../../state/ducks/map";
 import {
   hasAdminAbilities,
@@ -136,11 +137,11 @@ class InputForm extends Component {
     );
 
     hideOthers &&
-      this.props.mapConfig.layerGroups
-        .filter(layerGroup => !layerGroupIds.includes(layerGroup.id))
-        .forEach(layerGroup =>
-          this.props.updateLayerGroupVisibility(layerGroup.id, false),
-        );
+    this.props.layerGroupsMetadata.allIds
+      .filter(layerGroupId => !layerGroupIds.includes(layerGroupId))
+      .forEach(layerGroupId =>
+        this.props.updateLayerGroupVisibility(layerGroupId, false),
+      );
   }
 
   getNewFields(prevFields) {
@@ -657,8 +658,8 @@ InputForm.propTypes = {
   isMapDraggedOrZoomed: PropTypes.bool.isRequired,
   isRightSidebarVisible: PropTypes.bool.isRequired,
   isSingleCategory: PropTypes.bool,
+  layerGroupsMetadata: layerGroupsMetadataPropType,
   layout: PropTypes.string.isRequired,
-  mapConfig: PropTypes.object.isRequired,
   mapViewport: mapViewportPropType.isRequired,
   onCategoryChange: PropTypes.func,
   onUpdateMapViewport: PropTypes.func.isRequired,
@@ -691,8 +692,8 @@ const mapStateToProps = state => ({
   isInAtLeastOneGroup: (groupNames, datasetSlug) =>
     isInAtLeastOneGroup(state, groupNames, datasetSlug),
   isRightSidebarVisible: uiVisibilitySelector("rightSidebar", state),
+  layerGroupsMetadata: layerGroupsMetadataSelector(state),
   layout: layoutSelector(state),
-  mapConfig: mapConfigSelector(state),
   placeConfig: placeConfigSelector(state),
 });
 

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -28,8 +28,8 @@ import {
   createFeaturesInGeoJSONSource,
   updateLayerGroupVisibility,
   mapViewportPropType,
-  layerGroupsMetadataSelector,
-  layerGroupsMetadataPropType,
+  layerGroupsSelector,
+  layerGroupsPropType,
 } from "../../state/ducks/map";
 import {
   hasAdminAbilities,
@@ -137,7 +137,7 @@ class InputForm extends Component {
     );
 
     hideOthers &&
-    this.props.layerGroupsMetadata.allIds
+    this.props.layerGroups.allIds
       .filter(layerGroupId => !layerGroupIds.includes(layerGroupId))
       .forEach(layerGroupId =>
         this.props.updateLayerGroupVisibility(layerGroupId, false),
@@ -658,7 +658,7 @@ InputForm.propTypes = {
   isMapDraggedOrZoomed: PropTypes.bool.isRequired,
   isRightSidebarVisible: PropTypes.bool.isRequired,
   isSingleCategory: PropTypes.bool,
-  layerGroupsMetadata: layerGroupsMetadataPropType,
+  layerGroups: layerGroupsPropType,
   layout: PropTypes.string.isRequired,
   mapViewport: mapViewportPropType.isRequired,
   onCategoryChange: PropTypes.func,
@@ -692,7 +692,7 @@ const mapStateToProps = state => ({
   isInAtLeastOneGroup: (groupNames, datasetSlug) =>
     isInAtLeastOneGroup(state, groupNames, datasetSlug),
   isRightSidebarVisible: uiVisibilitySelector("rightSidebar", state),
-  layerGroupsMetadata: layerGroupsMetadataSelector(state),
+  layerGroups: layerGroupsSelector(state),
   layout: layoutSelector(state),
   placeConfig: placeConfigSelector(state),
 });

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -137,11 +137,11 @@ class InputForm extends Component {
     );
 
     hideOthers &&
-    this.props.layerGroups.allIds
-      .filter(layerGroupId => !layerGroupIds.includes(layerGroupId))
-      .forEach(layerGroupId =>
-        this.props.updateLayerGroupVisibility(layerGroupId, false),
-      );
+      this.props.layerGroups.allIds
+        .filter(layerGroupId => !layerGroupIds.includes(layerGroupId))
+        .forEach(layerGroupId =>
+          this.props.updateLayerGroupVisibility(layerGroupId, false),
+        );
   }
 
   getNewFields(prevFields) {

--- a/src/base/static/components/molecules/map-layer-panel-section.js
+++ b/src/base/static/components/molecules/map-layer-panel-section.js
@@ -12,12 +12,12 @@ import { FontAwesomeIcon } from "../atoms/imagery";
 import { HorizontalRule } from "../atoms/layout";
 import { TinyTitle } from "../atoms/typography";
 
-import { mapConfigSelector } from "../../state/ducks/map-config";
 import {
   sourcesMetadataSelector,
-  layerGroupsMetadataSelector,
-  updateLayerGroupVisibility,
   sourcesMetadataPropType,
+  layerGroupsMetadataSelector,
+  layerGroupsMetadataPropType,
+  updateLayerGroupVisibility,
 } from "../../state/ducks/map";
 
 const MapLayerSelectorContainer = styled("div")({
@@ -176,7 +176,7 @@ class MapLayerPanelSection extends Component {
           // Assume at first that all sources consumed by layers in this
           // layerGroup have loaded.
           let loadStatus = "loaded";
-          const layerGroupMetadata = this.props.layerGroupsMetadata[
+          const layerGroupMetadata = this.props.layerGroupsMetadata.byId[
             layerGroup.id
           ];
           const sourcesStatus = layerGroupMetadata.sourceIds.map(
@@ -210,7 +210,7 @@ class MapLayerPanelSection extends Component {
               title={layerGroup.title}
               loadStatus={loadStatus}
               isLayerGroupVisible={
-                this.props.layerGroupsMetadata[layerGroup.id].isVisible
+                this.props.layerGroupsMetadata.byId[layerGroup.id].isVisible
               }
               isSelected={true}
               onToggleLayerGroup={() =>
@@ -227,21 +227,13 @@ class MapLayerPanelSection extends Component {
 
 MapLayerPanelSection.propTypes = {
   layerPanelSectionIndex: PropTypes.number.isRequired,
-  mapConfig: PropTypes.shape({
-    layerGroups: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        info: PropTypes.string,
-      }),
-    ),
-  }),
   layerGroups: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,
     }),
   ),
-  layerGroupsMetadata: PropTypes.object.isRequired,
+  layerGroupsMetadata: layerGroupsMetadataPropType.isRequired,
   mapSourcesLoadStatus: PropTypes.object.isRequired,
   sourcesMetadata: sourcesMetadataPropType.isRequired,
   t: PropTypes.func.isRequired,
@@ -251,7 +243,6 @@ MapLayerPanelSection.propTypes = {
 
 const mapStateToProps = state => ({
   layerGroupsMetadata: layerGroupsMetadataSelector(state),
-  mapConfig: mapConfigSelector(state),
   sourcesMetadata: sourcesMetadataSelector(state),
 });
 

--- a/src/base/static/components/organisms/geocode-address-bar.js
+++ b/src/base/static/components/organisms/geocode-address-bar.js
@@ -11,6 +11,7 @@ import { uiVisibilitySelector, layoutSelector } from "../../state/ducks/ui";
 
 import { getMainContentAreaWidth } from "../../utils/layout-utils";
 import { Mixpanel } from "../../utils/mixpanel";
+import { mapConfigPropType } from "../../state/ducks/map-config";
 
 const GeocodeAddressBarWrapper = styled(props => (
   <form onSubmit={props.onSubmit} className={props.className}>
@@ -93,7 +94,7 @@ GeocodeAddressBar.propTypes = {
   isContentPanelVisible: PropTypes.bool.isRequired,
   isRightSidebarVisible: PropTypes.bool.isRequired,
   layout: PropTypes.string.isRequired,
-  mapConfig: PropTypes.object.isRequired,
+  mapConfig: mapConfigPropType,
   onUpdateMapViewport: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
 };

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -17,7 +17,6 @@ import {
   sourcesMetadataSelector,
   updateFeaturesInGeoJSONSource,
   sourcesMetadataPropType,
-  updateSources,
   updateLayers,
   updateMapContainerDimensions,
   mapContainerDimensionsSeletor,
@@ -534,7 +533,6 @@ MainMap.propTypes = {
   updateFeaturesInGeoJSONSource: PropTypes.func.isRequired,
   updateLayers: PropTypes.func.isRequired,
   onUpdateMapViewport: PropTypes.func.isRequired,
-  updateSources: PropTypes.func.isRequired,
   onUpdateInitialMapViewport: PropTypes.func.isRequired,
   onUpdateSourceLoadStatus: PropTypes.func.isRequired,
   onUpdateSpotlightMaskVisibility: PropTypes.func.isRequired,
@@ -570,8 +568,6 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setLeftSidebarComponent(component)),
   updateFeaturesInGeoJSONSource: (sourceId, newFeatures) =>
     dispatch(updateFeaturesInGeoJSONSource(sourceId, newFeatures)),
-  updateSources: (newSourceId, newSource) =>
-    dispatch(updateSources(newSourceId, newSource)),
   updateLayers: newLayer => dispatch(updateLayers(newLayer)),
   updateMapContainerDimensions: newDimensions =>
     dispatch(updateMapContainerDimensions(newDimensions)),

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -422,7 +422,7 @@ class MainMap extends Component {
               rest,
               this.isMapTransitioning
                 ? false
-                : this.props.mapConfig.options.scrollZoomAroundCenter,
+                : this.props.mapConfig.scrollZoomAroundCenter,
             );
           }}
           onTransitionStart={() => (this.isMapTransitioning = true)}
@@ -513,7 +513,7 @@ MainMap.propTypes = {
       }),
     ),
   }).isRequired,
-  mapConfig: mapConfigPropType.isRequired,
+  mapConfig: mapConfigPropType,
   mapContainerDimensions: PropTypes.shape({
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,

--- a/src/base/static/components/organisms/main-map.js
+++ b/src/base/static/components/organisms/main-map.js
@@ -22,7 +22,7 @@ import {
   updateMapContainerDimensions,
   mapContainerDimensionsSeletor,
   filterableLayerGroupsMetadataSelector,
-  filterableLayerGroupMetadataPropType,
+  filterableLayerGroupPropType,
   mapLayerPopupSelector,
 } from "../../state/ducks/map";
 import { datasetsSelector, datasetsPropType } from "../../state/ducks/datasets";
@@ -492,7 +492,7 @@ MainMap.propTypes = {
   activeMarker: PropTypes.string,
   activeEditPlaceId: PropTypes.number,
   filterableLayerGroupsMetadata: PropTypes.arrayOf(
-    filterableLayerGroupMetadataPropType,
+    filterableLayerGroupPropType,
   ),
   filteredPlaces: PropTypes.arrayOf(placePropType).isRequired,
   history: PropTypes.object.isRequired,

--- a/src/base/static/components/organisms/map-filter-slider-container.js
+++ b/src/base/static/components/organisms/map-filter-slider-container.js
@@ -5,7 +5,7 @@ import { css, jsx } from "@emotion/core";
 import { connect } from "react-redux";
 
 import {
-  filterableLayerGroupMetadataPropType,
+  filterableLayerGroupPropType,
   updateLayerFilters,
 } from "../../state/ducks/map";
 import { layoutSelector } from "../../state/ducks/ui";
@@ -107,7 +107,7 @@ const MapFilterSlider = ({
 };
 
 MapFilterSlider.propTypes = {
-  metadata: filterableLayerGroupMetadataPropType,
+  metadata: filterableLayerGroupPropType,
   updateLayerFilters: PropTypes.func.isRequired,
 };
 
@@ -138,7 +138,7 @@ const MapFilterSliderContainer = props => {
 
 MapFilterSliderContainer.propTypes = {
   filterableLayerGroupsMetadata: PropTypes.arrayOf(
-    filterableLayerGroupMetadataPropType,
+    filterableLayerGroupPropType,
   ),
   layout: PropTypes.string.isRequired,
   updateLayerFilters: PropTypes.func.isRequired,

--- a/src/base/static/components/organisms/map-layer-panel.js
+++ b/src/base/static/components/organisms/map-layer-panel.js
@@ -5,7 +5,10 @@ import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import { jsx, css } from "@emotion/core";
 
-import { leftSidebarPanelConfigSelector } from "../../state/ducks/left-sidebar";
+import {
+  leftSidebarPanelConfigSelector,
+  leftSidebarConfigPropType,
+} from "../../state/ducks/left-sidebar";
 import { SmallTitle } from "../atoms/typography";
 import MapLayerPanelSection from "../molecules/map-layer-panel-section";
 
@@ -26,7 +29,7 @@ const MapLayerPanel = props => (
           <MapLayerPanelSection
             key={section.id}
             layerPanelSectionIndex={layerPanelSectionIndex}
-            layerGroups={section.layerGroups}
+            layerGroupPanels={section.layerGroups}
             mapSourcesLoadStatus={props.mapSourcesLoadStatus}
             title={section.title}
           />
@@ -37,23 +40,7 @@ const MapLayerPanel = props => (
 
 MapLayerPanel.propTypes = {
   mapSourcesLoadStatus: PropTypes.object.isRequired,
-  mapLayerPanelConfig: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    component: PropTypes.string.isRequired,
-    title: PropTypes.string,
-    content: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        title: PropTypes.string,
-        layerGroups: PropTypes.arrayOf(
-          PropTypes.shape({
-            id: PropTypes.string.isRequired,
-            title: PropTypes.string.isRequired,
-          }),
-        ),
-      }),
-    ),
-  }),
+  mapLayerPanelConfig: leftSidebarConfigPropType,
   t: PropTypes.func.isRequired,
   visibleBasemapId: PropTypes.string,
 };

--- a/src/base/static/components/organisms/offline-download-menu.js
+++ b/src/base/static/components/organisms/offline-download-menu.js
@@ -11,13 +11,8 @@ import {
   ModalFooter,
   modalStyles,
 } from "../atoms/layout";
-import {
-  offlineConfigPropType,
-} from "../../state/ducks/map-config";
-import {
-  mapSourcesPropType,
-  mapSourcesSelector,
-} from "../../state/ducks/map";
+import { offlineConfigPropType } from "../../state/ducks/map-config";
+import { mapSourcesPropType, mapSourcesSelector } from "../../state/ducks/map";
 
 import Modal from "react-modal";
 import { connect } from "react-redux";

--- a/src/base/static/components/organisms/offline-download-menu.js
+++ b/src/base/static/components/organisms/offline-download-menu.js
@@ -12,10 +12,12 @@ import {
   modalStyles,
 } from "../atoms/layout";
 import {
-  mapLayerConfigsPropType,
   offlineConfigPropType,
-  mapLayerConfigsSelector,
 } from "../../state/ducks/map-config";
+import {
+  mapSourcesPropType,
+  mapSourcesSelector,
+} from "../../state/ducks/map";
 
 import Modal from "react-modal";
 import { connect } from "react-redux";
@@ -23,7 +25,7 @@ Modal.setAppElement("#site-wrap");
 
 const fetchOfflineData = (
   offlineBoundingBox,
-  mapLayerConfigs,
+  mapSources,
   setPercentDownloaded,
   setPhase,
 ) => {
@@ -34,7 +36,7 @@ const fetchOfflineData = (
     .reduce(
       (urls, { zoom, lat, lng }) =>
         urls.concat(
-          mapLayerConfigs
+          mapSources
             .filter(
               layer => layer.type && ["raster", "vector"].includes(layer.type),
             )
@@ -49,7 +51,7 @@ const fetchOfflineData = (
       [],
     )
     .concat(
-      mapLayerConfigs
+      mapSources
         .filter(layer => layer.type && layer.type === "geojson")
         .map(mapLayerConfig => mapLayerConfig.data),
     )
@@ -116,7 +118,7 @@ const OfflineDownloadMenu = props => {
                     onClick={() => {
                       fetchOfflineData(
                         props.offlineBoundingBox,
-                        props.mapLayerConfigs,
+                        props.mapSources,
                         setPercentDownloaded,
                         setPhase,
                       );
@@ -167,12 +169,12 @@ const OfflineDownloadMenu = props => {
 };
 
 OfflineDownloadMenu.propTypes = {
-  mapLayerConfigs: mapLayerConfigsPropType.isRequired,
+  mapSources: mapSourcesPropType.isRequired,
   offlineBoundingBox: offlineConfigPropType.isRequired,
 };
 
 const mapStateToProps = state => ({
-  mapLayerConfigs: mapLayerConfigsSelector(state),
+  mapSources: mapSourcesSelector(state),
 });
 
 export default connect(mapStateToProps)(OfflineDownloadMenu);

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -269,7 +269,6 @@ const NavBarHamburger = styled("i")({
   },
 });
 
-
 const navItemMappings = {
   // eslint-disable-next-line react/display-name
   internal_link: linkProps => (

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -27,7 +27,7 @@ import {
   dashboardConfigSelector,
   dashboardConfigPropType,
 } from "../../state/ducks/dashboard-config";
-import { currentTemplateSelector } from "../../state/ducks/ui";
+import { currentTemplateSelector, resetUi } from "../../state/ducks/ui";
 import {
   isLeftSidebarExpandedSelector,
   setLeftSidebarComponent,
@@ -269,22 +269,6 @@ const NavBarHamburger = styled("i")({
   },
 });
 
-const LogoTitleWrapper = styled(props => (
-  <InternalLink
-    className={props.className}
-    href={`/${props.zoom}/${props.lat}/${props.lng}`}
-  >
-    {props.children}
-  </InternalLink>
-))(() => ({
-  display: "flex",
-  alignItems: "center",
-  textDecoration: "none",
-
-  [mq[0]]: {
-    width: "100%",
-  },
-}));
 
 const navItemMappings = {
   // eslint-disable-next-line react/display-name
@@ -365,6 +349,7 @@ class SiteHeader extends React.Component {
   };
 
   render() {
+    const viewport = this.props.mapConfig.options.mapViewport;
     return (
       <SiteHeaderWrapper isHeaderExpanded={this.state.isHeaderExpanded}>
         <HamburgerTitleWrapper>
@@ -375,10 +360,22 @@ class SiteHeader extends React.Component {
               });
             }}
           />
-          <LogoTitleWrapper
-            zoom={this.props.mapConfig.options.mapViewport.zoom.toFixed(2)}
-            lat={this.props.mapConfig.options.mapViewport.latitude.toFixed(5)}
-            lng={this.props.mapConfig.options.mapViewport.longitude.toFixed(5)}
+          <InternalLink
+            href={`/${viewport.zoom.toFixed(1)}/${viewport.latitude.toFixed(
+              5,
+            )}/${viewport.longitude.toFixed(5)}`}
+            onClick={() => {
+              this.props.resetUi();
+            }}
+            css={{
+              display: "flex",
+              alignItems: "center",
+              textDecoration: "none",
+
+              [mq[0]]: {
+                width: "100%",
+              },
+            }}
           >
             {this.props.appConfig.logo && (
               <SiteLogo
@@ -391,7 +388,7 @@ class SiteHeader extends React.Component {
                 {this.props.t("siteTitle", this.props.appConfig.name)}
               </SiteTitle>
             )}
-          </LogoTitleWrapper>
+          </InternalLink>
         </HamburgerTitleWrapper>
         <nav
           aria-label="navigation header"
@@ -499,6 +496,7 @@ SiteHeader.propTypes = {
   dashboardConfig: dashboardConfigPropType,
   setLeftSidebarComponent: PropTypes.func.isRequired,
   setLeftSidebarExpanded: PropTypes.func.isRequired,
+  resetUi: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -515,6 +513,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setLeftSidebarComponent(componentName)),
   setLeftSidebarExpanded: isExpanded =>
     dispatch(setLeftSidebarExpanded(isExpanded)),
+  resetUi: () => dispatch(resetUi()),
 });
 
 export default withRouter(

--- a/src/base/static/components/organisms/site-header.js
+++ b/src/base/static/components/organisms/site-header.js
@@ -22,7 +22,10 @@ import {
   appConfigSelector,
   appConfigPropType,
 } from "../../state/ducks/app-config";
-import { mapConfigSelector } from "../../state/ducks/map-config";
+import {
+  mapConfigSelector,
+  mapConfigPropType,
+} from "../../state/ducks/map-config";
 import {
   dashboardConfigSelector,
   dashboardConfigPropType,
@@ -348,7 +351,7 @@ class SiteHeader extends React.Component {
   };
 
   render() {
-    const viewport = this.props.mapConfig.options.mapViewport;
+    const viewport = this.props.mapConfig.defaultMapViewport;
     return (
       <SiteHeaderWrapper isHeaderExpanded={this.state.isHeaderExpanded}>
         <HamburgerTitleWrapper>
@@ -481,15 +484,7 @@ SiteHeader.propTypes = {
   currentLanguageCode: PropTypes.string.isRequired,
   currentTemplate: PropTypes.string.isRequired,
   isLeftSidebarExpanded: PropTypes.bool.isRequired,
-  mapConfig: PropTypes.shape({
-    options: PropTypes.shape({
-      mapViewport: PropTypes.shape({
-        latitude: PropTypes.number.isRequired,
-        longitude: PropTypes.number.isRequired,
-        zoom: PropTypes.number.isRequired,
-      }).isRequired,
-    }).isRequired,
-  }).isRequired,
+  mapConfig: mapConfigPropType,
   navBarConfig: navBarConfigPropType,
   onChangeLanguage: PropTypes.func.isRequired,
   dashboardConfig: dashboardConfigPropType,

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -56,8 +56,8 @@ import {
   removeFocusedGeoJSONFeatures,
   updateFocusedGeoJSONFeatures,
   updateLayerGroupVisibility,
-  layerGroupsMetadataSelector,
-  layerGroupsMetadataPropType,
+  layerGroupsSelector,
+  layerGroupsPropType,
 } from "../../state/ducks/map";
 import { customComponentsConfigSelector } from "../../state/ducks/custom-components-config";
 
@@ -135,7 +135,7 @@ class PlaceDetail extends Component {
         this.props.updateLayerGroupVisibility(layerGroupId, true),
       );
       // Hide all other layers.
-      this.props.layerGroupsMetadata.allIds
+      this.props.layerGroups.allIds
         .filter(
           layerGroupId =>
             !featuredPlace.visibleLayerGroupIds.includes(layerGroupId),
@@ -421,7 +421,7 @@ PlaceDetail.propTypes = {
   hasUserAbilitiesInPlace: PropTypes.func.isRequired,
   isEditModeToggled: PropTypes.bool.isRequired,
   isGeocodingBarEnabled: PropTypes.bool,
-  layerGroupsMetadata: layerGroupsMetadataPropType,
+  layerGroups: layerGroupsPropType,
   layout: PropTypes.string.isRequired,
   mapContainerRef: PropTypes.object.isRequired,
   placeConfig: PropTypes.object.isRequired,
@@ -465,7 +465,7 @@ const mapStateToProps = state => ({
   hasUserAbilitiesInPlace: ({ submitter, isSubmitterEditingSupported }) =>
     hasUserAbilitiesInPlace({ state, submitter, isSubmitterEditingSupported }),
   isEditModeToggled: isEditModeToggled(state),
-  layerGroupsMetadata: layerGroupsMetadataSelector(state),
+  layerGroups: layerGroupsSelector(state),
   layout: layoutSelector(state),
   commentFormConfig: commentFormConfigSelector(state),
   supportConfig: supportConfigSelector(state),

--- a/src/base/static/components/place-detail/index.js
+++ b/src/base/static/components/place-detail/index.js
@@ -39,10 +39,6 @@ import {
   featuredPlacesPropType,
 } from "../../state/ducks/featured-places-config";
 import {
-  mapConfigSelector,
-  mapConfigPropType,
-} from "../../state/ducks/map-config";
-import {
   userPropType,
   userSelector,
   hasUserAbilitiesInPlace,
@@ -60,6 +56,8 @@ import {
   removeFocusedGeoJSONFeatures,
   updateFocusedGeoJSONFeatures,
   updateLayerGroupVisibility,
+  layerGroupsMetadataSelector,
+  layerGroupsMetadataPropType,
 } from "../../state/ducks/map";
 import { customComponentsConfigSelector } from "../../state/ducks/custom-components-config";
 
@@ -137,13 +135,13 @@ class PlaceDetail extends Component {
         this.props.updateLayerGroupVisibility(layerGroupId, true),
       );
       // Hide all other layers.
-      this.props.mapConfig.layerGroups
+      this.props.layerGroupsMetadata.allIds
         .filter(
-          layerGroup =>
-            !featuredPlace.visibleLayerGroupIds.includes(layerGroup.id),
+          layerGroupId =>
+            !featuredPlace.visibleLayerGroupIds.includes(layerGroupId),
         )
-        .forEach(layerGroup =>
-          this.props.updateLayerGroupVisibility(layerGroup.id, false),
+        .forEach(layerGroupId =>
+          this.props.updateLayerGroupVisibility(layerGroupId, false),
         );
     }
 
@@ -423,8 +421,8 @@ PlaceDetail.propTypes = {
   hasUserAbilitiesInPlace: PropTypes.func.isRequired,
   isEditModeToggled: PropTypes.bool.isRequired,
   isGeocodingBarEnabled: PropTypes.bool,
+  layerGroupsMetadata: layerGroupsMetadataPropType,
   layout: PropTypes.string.isRequired,
-  mapConfig: mapConfigPropType,
   mapContainerRef: PropTypes.object.isRequired,
   placeConfig: PropTypes.object.isRequired,
   removeFocusedGeoJSONFeatures: PropTypes.func.isRequired,
@@ -467,8 +465,8 @@ const mapStateToProps = state => ({
   hasUserAbilitiesInPlace: ({ submitter, isSubmitterEditingSupported }) =>
     hasUserAbilitiesInPlace({ state, submitter, isSubmitterEditingSupported }),
   isEditModeToggled: isEditModeToggled(state),
+  layerGroupsMetadata: layerGroupsMetadataSelector(state),
   layout: layoutSelector(state),
-  mapConfig: mapConfigSelector(state),
   commentFormConfig: commentFormConfigSelector(state),
   supportConfig: supportConfigSelector(state),
   placeConfig: placeConfigSelector(state),

--- a/src/base/static/components/place-detail/kittitas-fire-ready-field-summary.js
+++ b/src/base/static/components/place-detail/kittitas-fire-ready-field-summary.js
@@ -81,7 +81,6 @@ const KittitasFireReadyFieldSummary = props => {
 };
 
 KittitasFireReadyFieldSummary.propTypes = {
-  fields: PropTypes.array.isRequired,
   place: placePropType.isRequired,
 };
 

--- a/src/base/static/components/templates/map.tsx
+++ b/src/base/static/components/templates/map.tsx
@@ -95,7 +95,7 @@ const statePropTypes = {
   isSpotlightMaskVisible: PropTypes.bool.isRequired,
   mapSources: mapSourcesPropType,
   layout: PropTypes.string.isRequired,
-  mapConfig: mapConfigPropType.isRequired,
+  mapConfig: mapConfigPropType,
   navBarConfig: navBarConfigPropType.isRequired,
   placeConfig: placeConfigPropType.isRequired,
   placeExists: PropTypes.func.isRequired,

--- a/src/base/static/components/templates/map.tsx
+++ b/src/base/static/components/templates/map.tsx
@@ -53,8 +53,8 @@ import {
 } from "../../state/ducks/map-config";
 import {
   createFeaturesInGeoJSONSource,
-  mapViewportPropType,
-  mapSourceNamesSelector,
+  mapSourcesSelector,
+  mapSourcesPropType,
 } from "../../state/ducks/map";
 import {
   placeExists,
@@ -93,7 +93,7 @@ const statePropTypes = {
   isRightSidebarEnabled: PropTypes.bool.isRequired,
   isRightSidebarVisible: PropTypes.bool.isRequired,
   isSpotlightMaskVisible: PropTypes.bool.isRequired,
-  mapSourceNames: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  mapSources: mapSourcesPropType,
   layout: PropTypes.string.isRequired,
   mapConfig: mapConfigPropType.isRequired,
   navBarConfig: navBarConfigPropType.isRequired,
@@ -201,7 +201,7 @@ class MapTemplate extends Component<Props, State> {
     // "loaded": All data for this source has finished. Rendering may or may not
     //     be in progress.
     // "error": An error occurred when fetching data for this source.
-    mapSourcesLoadStatus: this.props.mapSourceNames.reduce(
+    mapSourcesLoadStatus: Object.keys(this.props.mapSources).reduce(
       (memo, groupName: string) => ({
         ...memo,
         [groupName]: "unloaded",
@@ -589,7 +589,7 @@ const mapStateToProps = (
   isRightSidebarEnabled: isRightSidebarEnabledSelector(state),
   isRightSidebarVisible: uiVisibilitySelector("rightSidebar", state),
   isSpotlightMaskVisible: uiVisibilitySelector("spotlightMask", state),
-  mapSourceNames: mapSourceNamesSelector(state),
+  mapSources: mapSourcesSelector(state),
   layout: layoutSelector(state),
   mapConfig: mapConfigSelector(state),
   navBarConfig: navBarConfigSelector(state),

--- a/src/base/static/state/ducks/left-sidebar.js
+++ b/src/base/static/state/ducks/left-sidebar.js
@@ -1,3 +1,5 @@
+import PropTypes from "prop-types";
+
 // Selectors:
 export const leftSidebarConfigSelector = state => {
   return state.leftSidebar.config;
@@ -13,6 +15,25 @@ export const isLeftSidebarExpandedSelector = state => {
 export const leftSidebarComponentSelector = state => {
   return state.leftSidebar.activeComponentName;
 };
+
+// Selectors:
+export const leftSidebarConfigPropType = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  component: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  content: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string,
+      layerGroups: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string.isRequired,
+          title: PropTypes.string.isRequired,
+        }),
+      ),
+    }),
+  ),
+});
 
 // Actions:
 const LOAD = "left-sidebar/LOAD";

--- a/src/base/static/state/ducks/map-config.js
+++ b/src/base/static/state/ducks/map-config.js
@@ -1,14 +1,8 @@
 import PropTypes from "prop-types";
 
+// TODO: Remove this Duck, and nest this confuguration under AppConfig.map.
+
 // PropTypes:
-export const mapLayerConfigsPropType = PropTypes.arrayOf(
-  PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    type: PropTypes.string.isRequired,
-    tiles: PropTypes.arrayOf(PropTypes.string),
-    data: PropTypes.string,
-  }),
-);
 
 export const offlineConfigPropType = PropTypes.shape({
   southWest: PropTypes.shape({
@@ -24,20 +18,6 @@ export const offlineConfigPropType = PropTypes.shape({
 // Selectors:
 export const mapConfigSelector = state => {
   return state.mapConfig;
-};
-export const mapLayerConfigsSelector = state => {
-  // TODO: consider using this data structure in our config/store,
-  // instead of the current mapbox schema:
-  const sources = state.mapConfig.mapboxSources;
-  return Object.keys(sources).map(key => ({ id: key, ...sources[key] }));
-};
-export const mapLayerGroupsSelector = state => {
-  return state.mapConfig.layerGroups;
-};
-export const mapPlaceLayersSelector = state => {
-  return state.mapConfig.layers.filter(
-    layer => layer.type && layer.type === "place",
-  );
 };
 export const offlineConfigSelector = state => {
   return state.mapConfig.offlineBoundingBox;
@@ -62,74 +42,12 @@ export const mapConfigPropType = PropTypes.shape({
   geocode_field_label: PropTypes.string,
   geocode_hint: PropTypes.arrayOf(PropTypes.number),
   geocode_bounding_box: PropTypes.arrayOf(PropTypes.number),
-  options: PropTypes.shape({
-    mapViewport: PropTypes.shape({
-      latitude: PropTypes.number.isRequired,
-      longitude: PropTypes.number.isRequired,
-      zoom: PropTypes.number.isRequired,
-      pitch: PropTypes.number,
-      bearing: PropTypes.number,
-      minZoom: PropTypes.number,
-      maxZoom: PropTypes.number,
-    }).isRequired,
-  }).isRequired,
-  mapboxSources: PropTypes.objectOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      tiles: PropTypes.arrayOf(PropTypes.string),
-      tileSize: PropTypes.number,
-      attribution: PropTypes.string,
-      data: PropTypes.string,
-    }),
-  ).isRequired,
   offlineBoundingBox: offlineConfigPropType,
-  layers: mapLayerConfigsPropType,
-  layerGroups: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      interactive: PropTypes.bool,
-      datasetSlug: PropTypes.string,
-      visibleDefault: PropTypes.bool,
-      basemap: PropTypes.bool,
-      mapboxLayers: PropTypes.arrayOf(
-        PropTypes.shape({
-          id: PropTypes.string.isRequired,
-          type: PropTypes.string.isRequired,
-          source: PropTypes.string,
-          filter: PropTypes.array,
-          "source-layer": PropTypes.string,
-          paint: PropTypes.object,
-          layout: PropTypes.object,
-        }),
-      ).isRequired,
-      mapboxFocusedLayers: PropTypes.arrayOf(
-        PropTypes.shape({
-          id: PropTypes.string.isRequired,
-          type: PropTypes.string.isRequired,
-          source: PropTypes.string,
-          filter: PropTypes.array,
-          "source-layer": PropTypes.string,
-          paint: PropTypes.object,
-          layout: PropTypes.object,
-        }),
-      ),
-    }),
-  ).isRequired,
 });
 
 // Reducers:
-// TODO(luke): refactor our current implementation in AppView to use
 const INITIAL_STATE = {
   geocoding_bar_enabled: false,
-  options: {
-    mapViewport: {
-      zoom: 10,
-      latitude: 0,
-      longitude: 0,
-    },
-  },
-  mapboxSources: {},
-  layerGroups: [],
 };
 
 export default function reducer(state = INITIAL_STATE, action) {

--- a/src/base/static/state/ducks/map-config.js
+++ b/src/base/static/state/ducks/map-config.js
@@ -1,7 +1,5 @@
 import PropTypes from "prop-types";
 
-// TODO: Remove this Duck, and nest this confuguration under AppConfig.map.
-
 // PropTypes:
 
 export const offlineConfigPropType = PropTypes.shape({
@@ -19,35 +17,47 @@ export const offlineConfigPropType = PropTypes.shape({
 export const mapConfigSelector = state => {
   return state.mapConfig;
 };
+export const defaultMapViewportSelector = state => {
+  return state.mapConfig.defaultMapViewport;
+};
 export const offlineConfigSelector = state => {
   return state.mapConfig.offlineBoundingBox;
 };
 export const geocodeAddressBarEnabledSelector = state =>
-  state.mapConfig.geocoding_bar_enabled;
+  state.mapConfig.geocodingBarEnabled;
 
 // Actions:
 const LOAD = "map-config/LOAD";
 
 // Action creators:
 export function loadMapConfig(config) {
-  config.geocoding_bar_enabled = !!config.geocoding_bar_enabled;
-
   return { type: LOAD, payload: config };
 }
 
 export const mapConfigPropType = PropTypes.shape({
-  geolocation_enabled: PropTypes.bool,
-  geocoding_bar_enabled: PropTypes.bool,
-  geocoding_engine: PropTypes.string,
-  geocode_field_label: PropTypes.string,
-  geocode_hint: PropTypes.arrayOf(PropTypes.number),
-  geocode_bounding_box: PropTypes.arrayOf(PropTypes.number),
+  geolocationEnabled: PropTypes.bool,
+  geocodingBarEnabled: PropTypes.bool,
+  geocodingEngine: PropTypes.string,
+  geocodeFieldLabel: PropTypes.string,
+  geocodeHint: PropTypes.arrayOf(PropTypes.number),
+  geocodeBoundingBox: PropTypes.arrayOf(PropTypes.number),
   offlineBoundingBox: offlineConfigPropType,
-});
+  scrollZoomAroundCenter: PropTypes.bool,
+  defaultMapViewport: PropTypes.object.isRequired,
+}).isRequired;
 
 // Reducers:
 const INITIAL_STATE = {
-  geocoding_bar_enabled: false,
+  geocodingBarEnabled: false,
+  scrollZoomAroundCenter: false,
+  defaultMapViewport: {
+    zoom: 10,
+    latitude: 0,
+    longitude: 0,
+    maxZoom: 18,
+    minZoom: 1,
+    pitch: 15,
+  },
 };
 
 export default function reducer(state = INITIAL_STATE, action) {
@@ -56,6 +66,10 @@ export default function reducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         ...action.payload,
+        defaultMapViewport: {
+          ...state.defaultMapViewport,
+          ...action.payload.mapViewport,
+        },
       };
     default:
       return state;

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -552,26 +552,15 @@ export default function reducer(state = INITIAL_STATE, action) {
     case LOAD_STYLE_AND_METADATA:
       return {
         ...state,
+        ...action.payload,
         style: {
           ...state.style,
           ...action.payload.style,
         },
-        layers: action.payload.layers,
-        layerGroups: {
-          byId: {
-            ...state.layerGroups.byId,
-            ...action.payload.layerGroups.byId,
-          },
-          allIds: state.layerGroups.allIds.concat(
-            action.payload.layerGroups.allIds,
-          ),
+        mapContainerDimensions: {
+          ...state.mapContainerDimensions,
+          ...action.payload.mapContainerDimensions,
         },
-        sourcesMetadata: {
-          ...state.sourcesMetadata,
-          ...action.payload.sourcesMetadata,
-        },
-        basemapLayerIds: action.payload.basemapLayerIds,
-        interactiveLayerIds: action.payload.interactiveLayerIds,
       };
     case RESET_UI:
       return {

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -621,9 +621,6 @@ export default function reducer(state = INITIAL_STATE, action) {
         style: {
           ...state.style,
         },
-        // Set visibility on all layers making up this layer group. Also
-        // update basemap layer visibility if this layer group is a
-        // basemap.
       };
     case UPDATE_LAYERS:
       return {

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -49,7 +49,6 @@ export const mapStylePropType = PropTypes.shape({
   layers: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      // groupId: PropTypes.string.isRequired,
       type: PropTypes.string.isRequired,
       source: PropTypes.string,
       "source-layer": PropTypes.string,

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -144,7 +144,6 @@ const LOAD_STYLE_AND_METADATA = "map/LOAD_STYLE_AND_METADATA";
 const UPDATE_LAYER_GROUP_VISIBILITY = "map/UPDATE_LAYER_GROUP_VISIBILITY";
 const UPDATE_FOCUSED_GEOJSON_FEATURES = "map/UPDATE_FOCUSED_GEOJSON_FEATURES";
 const REMOVE_FOCUSED_GEOJSON_FEATURES = "map/REMOVE_FOCUSED_GEOJSON_FEATURES";
-const UPDATE_SOURCES = "map/UPDATE_SOURCES";
 const UPDATE_LAYERS = "map/UPDATE_LAYERS";
 const UPDATE_MAP_CONTAINER_DIMENSIONS = "map/UPDATE_MAP_CONTAINER_DIMENSIONS";
 const UPDATE_LAYER_FILTERS = "map/UPDATE_LAYER_FILTERS";
@@ -163,13 +162,6 @@ export function removeFocusedGeoJSONFeatures() {
   return {
     type: REMOVE_FOCUSED_GEOJSON_FEATURES,
     payload: null,
-  };
-}
-
-export function updateSources(newSourceId, newSource) {
-  return {
-    type: UPDATE_SOURCES,
-    payload: { newSourceId, newSource },
   };
 }
 
@@ -674,17 +666,6 @@ export default function reducer(state = INITIAL_STATE, action) {
             },
           };
         }),
-      };
-    case UPDATE_SOURCES:
-      return {
-        ...state,
-        style: {
-          ...state.style,
-          sources: {
-            ...state.style.sources,
-            [action.payload.newSourceId]: action.payload.newSource,
-          },
-        },
       };
     case UPDATE_LAYERS:
       return {

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -15,7 +15,7 @@ export const mapViewportPropType = PropTypes.shape({
   transitionEasing: PropTypes.func,
   minZoom: PropTypes.number.isRequired,
   maxZoom: PropTypes.number.isRequired,
-});
+}).isRequired;
 
 const filterSliderPropType = PropTypes.shape({
   initialValue: PropTypes.number,
@@ -414,13 +414,6 @@ const INITIAL_STATE = {
   sourcesMetadata: {},
   basemapLayerIds: [],
   interactiveLayerIds: [],
-  defaults: {
-    mapViewport: {
-      zoom: 10,
-      latitude: 0,
-      longitude: 0,
-    },
-  },
 };
 
 export default function reducer(state = INITIAL_STATE, action) {

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -89,8 +89,8 @@ export const sourcesMetadataPropType = PropTypes.objectOf(
 // SELECTORS:
 ////////////////////////////////////////////////////////////////////////////////
 
-const getStyle = state => state.style;
-const getLayers = state => state.layers;
+const getStyle = state => state.map.style;
+const getLayers = state => state.map.layers;
 export const mapStyleSelector = createSelector(
   [getStyle, getLayers],
   (style, layers) => {

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -1,3 +1,5 @@
+import { createSelector } from "reselect";
+
 import PropTypes from "prop-types";
 import { RESET_UI } from "./ui";
 
@@ -86,13 +88,22 @@ export const sourcesMetadataPropType = PropTypes.objectOf(
 ////////////////////////////////////////////////////////////////////////////////
 // SELECTORS:
 ////////////////////////////////////////////////////////////////////////////////
-export const mapStyleSelector = state => ({
-  ...state.map.style,
-  layers: state.map.layers.map(layer => {
-    const { groupId, ...mapboxLayer } = layer;
-    return mapboxLayer;
-  }),
-});
+
+const getStyle = state => state.style;
+const getLayers = state => state.layers;
+export const mapStyleSelector = createSelector(
+  [getStyle, getLayers],
+  (style, layers) => {
+    return {
+      ...style,
+      layers: layers.map(layer => {
+        const { groupId, ...mapboxLayer } = layer;
+        return mapboxLayer;
+      }),
+    };
+  },
+);
+
 export const mapSourcesSelector = state => state.map.style.sources;
 export const sourcesMetadataSelector = state => state.map.sourcesMetadata;
 export const layerGroupsSelector = state => state.map.layerGroups;

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -15,7 +15,7 @@ export const mapViewportPropType = PropTypes.shape({
   transitionEasing: PropTypes.func,
   minZoom: PropTypes.number.isRequired,
   maxZoom: PropTypes.number.isRequired,
-}).isRequired;
+});
 
 const filterSliderPropType = PropTypes.shape({
   initialValue: PropTypes.number,

--- a/src/base/static/state/ducks/ui.js
+++ b/src/base/static/state/ducks/ui.js
@@ -17,8 +17,15 @@ const UPDATE_UI_VISIBILITY = "ui/UPDATE_UI_VISIBILITY";
 const UPDATE_ACTIVE_PAGE = "ui/UPDATE_ACTIVE_PAGE";
 const UPDATE_CONTENT_PANEL_COMPONENT = "ui/UPDATE_CONTENT_PANEL_COMPONENT";
 const UPDATE_LAYOUT = "ui/UPDATE_LAYOUT";
+export const RESET_UI = "ui/RESET";
 
 // Action creators:
+export function resetUi() {
+  return {
+    type: RESET_UI,
+  };
+}
+
 export function updateCurrentTemplate(templateName) {
   return { type: UPDATE_CURRENT_TEMPLATE, payload: templateName };
 }
@@ -98,6 +105,23 @@ export default function reducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         isEditModeToggled: action.payload,
+      };
+    case RESET_UI:
+      return {
+        ...state,
+        activePageSlug: null,
+        uiVisibility: {
+          ...state.uiVisibility,
+          contentPanel: false,
+          inviteModal: false,
+          mapCenterpoint: false,
+          spotlightMask: false,
+          rightSidebar: false,
+        },
+        contentPanelComponent: null,
+        leftSidebarComponent: null,
+        currentTemplate: "map",
+        isEditModeToggled: false,
       };
     case UPDATE_LAYOUT:
       return {

--- a/src/flavors/argentina/config.json
+++ b/src/flavors/argentina/config.json
@@ -59,22 +59,21 @@
     ]
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "cartodb_enabled": true,
-    "geocoding_enabled": false,
-    "geocode_field_label": "Enter an address...",
-    "geocode_bounding_box": [39.830159, -75.478821, 40.167331, -74.781189],
-    "options": {
-      "mapViewport": {
-        "latitude": -33.41863,
-        "longitude": -59.50497,
-        "zoom": 7,
-        "pitch": 0,
-        "minZoom": 1,
-        "maxZoom": 19
-      }
-    },
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEnabled": false,
+    "geocodeFieldLabel": "Enter an address...",
+    "geocodeBoundingBox": [39.830159, -75.478821, 40.167331, -74.781189],
+    "mapViewport": {
+      "latitude": -33.41863,
+      "longitude": -59.50497,
+      "zoom": 7,
+      "pitch": 0,
+      "minZoom": 1,
+      "maxZoom": 19
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm": {
         "type": "raster",

--- a/src/flavors/bellevue-bike-share/config.json
+++ b/src/flavors/bellevue-bike-share/config.json
@@ -39,20 +39,20 @@
     }
   },
   "map": {
-    "geolocation_enabled": false,
-    "geolocation_onload": false,
-    "cartodb_enabled": true,
-    "geocoding_enabled": false,
-    "options": {
-      "mapViewport": {
-        "latitude": 47.61306,
-        "longitude": -122.19538,
-        "zoom": 13.5,
-        "pitch": 30,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "geolocationEnabled": false,
+    "geolocationOnload": false,
+    "cartodbEnabled": true,
+    "geocodingEnabled": false,
+    "mapViewport": {
+      "latitude": 47.61306,
+      "longitude": -122.19538,
+      "zoom": 13.5,
+      "pitch": 30,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "f4": {
         "type": "raster",

--- a/src/flavors/central-puget-sound/config.json
+++ b/src/flavors/central-puget-sound/config.json
@@ -65,17 +65,17 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "options": {
-      "mapViewport": {
-        "latitude": 47.66909,
-        "longitude": -122.39593,
-        "zoom": 8,
-        "minZoom": 1,
-        "maxZoom": 18,
-        "pitch": 30
-      }
-    },
+    "geolocationEnabled": true,
+    "mapViewport": {
+      "latitude": 47.66909,
+      "longitude": -122.39593,
+      "zoom": 8,
+      "minZoom": 1,
+      "maxZoom": 18,
+      "pitch": 30
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "satellite": {
         "type": "raster",
@@ -1782,9 +1782,7 @@
         "icon_url": "/static/css/images/markers/marker-only-flush.png",
         "value": "only-flush",
         "visibleLayerGroupIds": ["mw"],
-=======
         "label": "I will reduce wastewater pollution",
->>>>>>> refactor(flavorConfigs): remove gettext syntax
         "fields": [
           {
             "name": "address",
@@ -4420,50 +4418,46 @@
     }
   ],
   "featuredPlaces": {
-      "header": "Example projects",
-      "default_zoom": 18,
-      "visibleLayerGroupIds": [
-        "satellite",
-        "mwfeatured",
-        "mw-featured-projects"
-      ],
-      "order": [
-        {
-          "placeId": 3737,
-          "zoom": 18
-        },
-        {
-          "placeId": 3363,
-          "zoom": 18
-        },
-        {
-          "placeId": 3360,
-          "zoom": 18
-        },
-        {
-          "placeId": 3362,
-          "zoom": 18
-        },
-        {
-          "placeId": 3330
-        },
-        {
-          "placeId": 3331,
-          "zoom": 14
-        },
-        {
-          "placeId": 3747,
-          "zoom": 18
-        },
-        {
-          "placeId": 3748,
-          "zoom": 18
-        },
-        {
-          "placeId": 7072,
-          "zoom": 18
-        }
-      ]
+    "header": "Example projects",
+    "default_zoom": 18,
+    "visibleLayerGroupIds": ["satellite", "mwfeatured", "mw-featured-projects"],
+    "order": [
+      {
+        "placeId": 3737,
+        "zoom": 18
+      },
+      {
+        "placeId": 3363,
+        "zoom": 18
+      },
+      {
+        "placeId": 3360,
+        "zoom": 18
+      },
+      {
+        "placeId": 3362,
+        "zoom": 18
+      },
+      {
+        "placeId": 3330
+      },
+      {
+        "placeId": 3331,
+        "zoom": 14
+      },
+      {
+        "placeId": 3747,
+        "zoom": 18
+      },
+      {
+        "placeId": 3748,
+        "zoom": 18
+      },
+      {
+        "placeId": 7072,
+        "zoom": 18
+      }
+    ]
   },
   "cluster": {
     "animate": true,

--- a/src/flavors/creatingcascadia/config.json
+++ b/src/flavors/creatingcascadia/config.json
@@ -44,22 +44,21 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "cartodb_enabled": true,
-    "geocoding_enabled": false,
-    "geocode_field_label": "Enter an address...",
-    "geocode_bounding_box": [39.830159, -75.478821, 40.167331, -74.781189],
-    "options": {
-      "mapViewport": {
-        "latitude": 47.671,
-        "longitude": -122.594,
-        "zoom": 5.31,
-        "pitch": 0,
-        "minZoom": 1,
-        "maxZoom": 18.4
-      }
-    },
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEnabled": false,
+    "geocodeFieldLabel": "Enter an address...",
+    "geocodeBoundingBox": [39.830159, -75.478821, 40.167331, -74.781189],
+    "mapViewport": {
+      "latitude": 47.671,
+      "longitude": -122.594,
+      "zoom": 5.31,
+      "pitch": 0,
+      "minZoom": 1,
+      "maxZoom": 18.4
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "streets": {
         "type": "raster",

--- a/src/flavors/defaultflavor/config.json
+++ b/src/flavors/defaultflavor/config.json
@@ -52,16 +52,16 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "options": {
-      "mapViewport": {
-        "latitude": 47.53722,
-        "longitude": -122.32573,
-        "zoom": 16,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "geolocationEnabled": true,
+    "mapViewport": {
+      "latitude": 47.53722,
+      "longitude": -122.32573,
+      "zoom": 16,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "sample-json-a": {
         "type": "geojson",
@@ -1293,18 +1293,18 @@
     }
   ],
   "featuredPlaces": {
-      "tagline": "Next featured site",
-      "header": "Story Number One",
-      "description": "This is the first of two stories. I hope you like it!",
-      "default_zoom": 18,
-      "default_basemap": "sample-wmts",
-      "default_visible_layers": ["demo", "sample-vector"],
-      "order": [
-        {
-          "placeId": 21,
-          "pan_to": [-122.57256740778439, 47.44334015969261],
-          "zoom": 10
-        }
-      ]
+    "tagline": "Next featured site",
+    "header": "Story Number One",
+    "description": "This is the first of two stories. I hope you like it!",
+    "default_zoom": 18,
+    "default_basemap": "sample-wmts",
+    "default_visible_layers": ["demo", "sample-vector"],
+    "order": [
+      {
+        "placeId": 21,
+        "pan_to": [-122.57256740778439, 47.44334015969261],
+        "zoom": 10
+      }
+    ]
   }
 }

--- a/src/flavors/firewise-demo/config.json
+++ b/src/flavors/firewise-demo/config.json
@@ -50,10 +50,10 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "geocoding_engine": "Mapbox",
-    "geocode_hint": [-117.59821, 46.472103],
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEngine": "Mapbox",
+    "geocodeHint": [-117.59821, 46.472103],
     "offlineBoundingBox": {
       "southWest": {
         "lat": 46.709206,
@@ -64,17 +64,17 @@
         "lng": -119.891353
       }
     },
-    "options": {
-      "scrollZoomAroundCenter": true,
-      "mapViewport": {
-        "latitude": 47.18554,
-        "longitude": -120.72226,
-        "zoom": 6.5,
-        "pitch": 15,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "scrollZoomAroundCenter": true,
+    "mapViewport": {
+      "latitude": 47.18554,
+      "longitude": -120.72226,
+      "zoom": 6.5,
+      "pitch": 15,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm": {
         "type": "raster",

--- a/src/flavors/garfield/config.json
+++ b/src/flavors/garfield/config.json
@@ -50,31 +50,31 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "geocoding_engine": "Mapbox",
-    "geocode_hint": [-117.598210, 46.472103],
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEngine": "Mapbox",
+    "geocodeHint": [-117.59821, 46.472103],
     "offlineBoundingBox": {
       "southWest": {
         "lat": 45.971808,
-        "lng": -117.882710
+        "lng": -117.88271
       },
       "northEast": {
         "lat": 46.714002,
         "lng": -117.207024
       }
     },
-    "options": {
-      "scrollZoomAroundCenter": true,
-      "mapViewport": {
-        "latitude": 46.38856,
-        "longitude": -117.55455,
-        "zoom": 8.3,
-        "pitch": 15,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "scrollZoomAroundCenter": true,
+    "mapViewport": {
+      "latitude": 46.38856,
+      "longitude": -117.55455,
+      "zoom": 8.3,
+      "pitch": 15,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm": {
         "type": "raster",

--- a/src/flavors/kittitas-firewise/config.json
+++ b/src/flavors/kittitas-firewise/config.json
@@ -54,10 +54,10 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "geocoding_engine": "Mapbox",
-    "geocode_hint": [-120.541803, 46.99644],
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEngine": "Mapbox",
+    "geocodeHint": [-120.541803, 46.99644],
     "offlineBoundingBox": {
       "southWest": {
         "lat": 46.709206,
@@ -68,15 +68,13 @@
         "lng": -119.891353
       }
     },
-    "options": {
-      "mapViewport": {
-        "latitude": 47.18554,
-        "longitude": -120.72226,
-        "zoom": 6.5,
-        "pitch": 15,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
+    "mapViewport": {
+      "latitude": 47.18554,
+      "longitude": -120.72226,
+      "zoom": 6.5,
+      "pitch": 15,
+      "minZoom": 1,
+      "maxZoom": 18
     }
   },
   "mapStyle": {

--- a/src/flavors/kittitas-firewise/config.json
+++ b/src/flavors/kittitas-firewise/config.json
@@ -77,7 +77,9 @@
         "minZoom": 1,
         "maxZoom": 18
       }
-    },
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm": {
         "type": "raster",
@@ -4097,7 +4099,7 @@
         ]
       },
       {
-        "id": "wa-state-wildfire-start-sites-2008",
+        "id": "wa-state-wildfire-start-sites-2008-group",
         "visibleDefault": false,
         "interactive": true,
         "popupContent": "<p><strong>Year: </strong><em>{{START_DT}}</em></p><p><strong>Acres burned: </strong><em>{{ACRES_BURNED}}</em></p><p><strong>Cause: </strong><em>{{FIREGCAUSE_LABEL_NM}}</em></p>",
@@ -4577,7 +4579,7 @@
                 "title": "Land Ownership"
               },
               {
-                "id": "wa-state-wildfire-start-sites-2008",
+                "id": "wa-state-wildfire-start-sites-2008-group",
                 "title": "Wildfire Start Sites"
               },
               {
@@ -4716,7 +4718,7 @@
             "end_field_index": 4,
             "visibleLayerGroupIds": [
               "light-satellite",
-              "wa-state-wildfire-start-sites-2008",
+              "wa-state-wildfire-start-sites-2008-group",
               "kittitas-burn-risk",
               "kittitas-county-outline"
             ],

--- a/src/flavors/kittitas-vsp/config.json
+++ b/src/flavors/kittitas-vsp/config.json
@@ -50,10 +50,10 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "geocoding_engine": "Mapbox",
-    "geocode_hint": [-120.549183, 46.9999019],
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEngine": "Mapbox",
+    "geocodeHint": [-120.549183, 46.9999019],
     "offlineBoundingBox": {
       "southWest": {
         "lat": 46.709206,
@@ -64,17 +64,17 @@
         "lng": -119.891353
       }
     },
-    "options": {
-      "scrollZoomAroundCenter": true,
-      "mapViewport": {
-        "latitude": 47.18554,
-        "longitude": -120.72226,
-        "zoom": 7.95,
-        "pitch": 15,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "scrollZoomAroundCenter": true,
+    "mapViewport": {
+      "latitude": 47.18554,
+      "longitude": -120.72226,
+      "zoom": 7.95,
+      "pitch": 15,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm": {
         "type": "raster",

--- a/src/flavors/mississippi/config.json
+++ b/src/flavors/mississippi/config.json
@@ -59,7 +59,9 @@
         "minZoom": 1,
         "maxZoom": 18.4
       }
-    },
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "streets": {
         "type": "raster",

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -50,10 +50,10 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "geocoding_engine": "Mapbox",
-    "geocode_hint": [-117.1889785, 46.7298657],
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEngine": "Mapbox",
+    "geocodeHint": [-117.1889785, 46.7298657],
     "offlineBoundingBox": {
       "southWest": {
         "lat": 46.375191,
@@ -64,17 +64,17 @@
         "lng": -118.79526
       }
     },
-    "options": {
-      "scrollZoomAroundCenter": true,
-      "mapViewport": {
-        "latitude": 46.855999488224484,
-        "longitude": -117.51842014278026,
-        "zoom": 8,
-        "pitch": 15,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "scrollZoomAroundCenter": true,
+    "mapViewport": {
+      "latitude": 46.855999488224484,
+      "longitude": -117.51842014278026,
+      "zoom": 8,
+      "pitch": 15,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm": {
         "type": "raster",

--- a/src/flavors/pbdemo/config.json
+++ b/src/flavors/pbdemo/config.json
@@ -131,22 +131,22 @@
     }
   ],
   "map": {
-    "geolocation_enabled": true,
-    "geocoding_bar_enabled": true,
-    "geocoding_engine": "Mapbox",
-    "geocode_field_label": "Enter an address...",
-    "geocode_hint": [-78.906412, 35.9954801],
-    "geocode_bounding_box": [-79.09479, 35.865179, -78.78392, 36.119792],
-    "options": {
-      "mapViewport": {
-        "latitude": 35.976899833978976,
-        "longitude": -78.88370073534878,
-        "zoom": 10.2,
-        "pitch": 30,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "geolocationEnabled": true,
+    "geocodingBarEnabled": true,
+    "geocodingEngine": "Mapbox",
+    "geocodeFieldLabel": "Enter an address...",
+    "geocodeHint": [-78.906412, 35.9954801],
+    "geocodeBoundingBox": [-79.09479, 35.865179, -78.78392, 36.119792],
+    "mapViewport": {
+      "latitude": 35.976899833978976,
+      "longitude": -78.88370073534878,
+      "zoom": 10.2,
+      "pitch": 30,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "satellite": {
         "type": "raster",

--- a/src/flavors/pbdurham/config.json
+++ b/src/flavors/pbdurham/config.json
@@ -89,22 +89,22 @@
     }
   ],
   "map": {
-    "geolocation_enabled": true,
-    "geocoding_bar_enabled": true,
-    "geocoding_engine": "Mapbox",
-    "geocode_field_label": "Enter an address...",
-    "geocode_hint": [-78.906412, 35.9954801],
-    "geocode_bounding_box": [-79.09479, 35.865179, -78.78392, 36.119792],
-    "options": {
-      "mapViewport": {
-        "latitude": 35.976899833978976,
-        "longitude": -78.88370073534878,
-        "zoom": 10.2,
-        "pitch": 30,
-        "minZoom": 1,
-        "maxZoom": 18
-      }
-    },
+    "geolocationEnabled": true,
+    "geocodingBarEnabled": true,
+    "geocodingEngine": "Mapbox",
+    "geocodeFieldLabel": "Enter an address...",
+    "geocodeHint": [-78.906412, 35.9954801],
+    "geocodeBoundingBox": [-79.09479, 35.865179, -78.78392, 36.119792],
+    "mapViewport": {
+      "latitude": 35.976899833978976,
+      "longitude": -78.88370073534878,
+      "zoom": 10.2,
+      "pitch": 30,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "satellite": {
         "type": "raster",

--- a/src/flavors/snohomish/config.json
+++ b/src/flavors/snohomish/config.json
@@ -65,24 +65,20 @@
     }
   ],
   "map": {
-    "geolocation_enabled": true,
-    "geocoding_engine": "Mapbox",
-    "geocoding_bar_enabled": false,
-    "geocode_hint": [-121.9859019, 48.0381909],
-    "options": {
-      "mapViewport": {
-        "latitude": 48.01287153396305,
-        "longitude": -121.9524299235677,
-        "zoom": 9,
-        "pitch": 45,
-        "minZoom": 1,
-        "maxZoom": 18
-      },
-      "control": {
-        "showCompass": true,
-        "position": "top-left"
-      }
-    },
+    "geolocationEnabled": true,
+    "geocodingEngine": "Mapbox",
+    "geocodingBarEnabled": false,
+    "geocodeHint": [-121.9859019, 48.0381909],
+    "mapViewport": {
+      "latitude": 48.01287153396305,
+      "longitude": -121.9524299235677,
+      "zoom": 9,
+      "pitch": 45,
+      "minZoom": 1,
+      "maxZoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm-hot": {
         "type": "raster",

--- a/src/flavors/spokane/config.json
+++ b/src/flavors/spokane/config.json
@@ -50,10 +50,10 @@
     }
   },
   "map": {
-    "geolocation_enabled": true,
-    "geolocation_onload": false,
-    "geocoding_engine": "Mapbox",
-    "geocode_hint": [-117.406929, 47.646225],
+    "geolocationEnabled": true,
+    "geolocationOnload": false,
+    "geocodingEngine": "Mapbox",
+    "geocodeHint": [-117.406929, 47.646225],
     "offlineBoundingBox": {
       "southWest": {
         "lat": 47.15606,
@@ -64,17 +64,17 @@
         "lng": -116.927791
       }
     },
-    "options": {
-      "scrollZoomAroundCenter": false,
-      "mapViewport": {
-        "latitude": 47.646225,
-        "longitude": -117.406929,
-        "zoom": 7.95,
-        "pitch": 25,
-        "minzoom": 1,
-        "maxzoom": 18
-      }
-    },
+    "scrollZoomAroundCenter": false,
+    "mapViewport": {
+      "latitude": 47.646225,
+      "longitude": -117.406929,
+      "zoom": 7.95,
+      "pitch": 25,
+      "minzoom": 1,
+      "maxzoom": 18
+    }
+  },
+  "mapStyle": {
     "mapboxSources": {
       "osm": {
         "type": "raster",


### PR DESCRIPTION
Up on staging for Kittitas-firewise and mississippi flavors

 - renames `layerGroupsMetadata` to `layerGroups` 
 - removes all style state from MapConfig duck
 - moves `state.map.style.layers` into `state.map.layers`
 - updates our layer models with a `groupId` so that we can reference the LayerGroup from the Layer model.
    - this requires us to use a `styleSelector` that restructures `map.style` into the mapbox compatible version.
 - remove `visibility` flag from `layer.layout` models - this value is now being auto-filled from the LayerGroup's `isVisible` attribute.
 - The "home" button resets the map layer visibilities to their defaults

TODO's:
 - [x] test performance in prod, especially with the new style selector
  - [x] if perf looks good - especially with reselect - consider moving the "visibility" flag from the layer into the selector
 - [x] refactor style selector to use reselect
 - [x] refactor all configs to use the new `mapStyle` object
 - [x] update map style layers to default visibility when "reset" button is clicked