### PR TITLE
feat(report.tsx): forward jwt token param

### DIFF
--- a/src/base/static/client/mapseed-api-client/place.js
+++ b/src/base/static/client/mapseed-api-client/place.js
@@ -99,8 +99,9 @@ const getPlace = async ({
   placeId,
   datasetSlug,
   clientSlug,
+  jwtToken,
 }) => {
-  placeParams = setPrivateParams(placeParams, includePrivate);
+  placeParams = setPrivateParams(placeParams, includePrivate, jwtToken);
 
   const response = await fetch(
     `${datasetUrl}/places/${placeId}?${qs.stringify(placeParams)}`,

--- a/src/base/static/client/pdf-service-client.js
+++ b/src/base/static/client/pdf-service-client.js
@@ -3,7 +3,13 @@ import download from "downloadjs";
 import { Mixpanel } from "../utils/mixpanel";
 
 export default {
-  getPDF: ({ url, filename }) => {
+  getPDF: ({ url, filename, jwtPublic = null }) => {
+    if (jwtPublic) {
+      // Don't use qs.stringify here, as we don't want to double-URIEncode
+      // this parameter below.
+      url += `?token=${jwtPublic}`;
+    }
+
     fetch(
       `https://jlupes39i0.execute-api.us-west-2.amazonaws.com/v1/generate-pdf?${qs.stringify(
         {

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -394,7 +394,7 @@ class InputForm extends Component {
       );
     }
 
-    // Generate a PDF for the user.
+    // Generate a PDF for the user if configured to do so.
     if (this.props.datasetReportSelector(this.props.datasetSlug)) {
       mapseedPDFServiceClient.getPDF({
         url: `${window.location.protocol}//${
@@ -404,6 +404,7 @@ class InputForm extends Component {
         )}/${placeResponse.id}`,
         filename: this.props.datasetReportSelector(this.props.datasetSlug)
           .filename,
+        jwtPublic: placeResponse.jwt_public,
       });
     }
 

--- a/src/base/static/components/templates/report.tsx
+++ b/src/base/static/components/templates/report.tsx
@@ -4,6 +4,7 @@ import { css, jsx } from "@emotion/core";
 import PropTypes from "prop-types";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import { connect } from "react-redux";
+import qs from "qs";
 
 import mapseedApiClient from "../../client/mapseed-api-client";
 import { placeSelector, placePropType } from "../../state/ducks/places";
@@ -50,6 +51,14 @@ const ReportTemplate = (props: Props) => {
   }
 
   async function fetchPlace() {
+    let includePrivate = false;
+    let jwtToken = null;
+    const params = qs.parse(window.location.search.slice(1));
+    if ("token" in params) {
+      includePrivate = true;
+      jwtToken = params["token"];
+    }
+
     const response = await mapseedApiClient.place.getPlace({
       datasetUrl: datasetConfig.url,
       clientSlug: props.params.datasetClientSlug,
@@ -59,8 +68,8 @@ const ReportTemplate = (props: Props) => {
         include_submissions: true,
         include_tags: true,
       },
-      // TODO: Handle private data?
-      includePrivate: false,
+      includePrivate,
+      jwtToken,
     });
 
     if (response) {

--- a/src/base/static/utils/place-utils.js
+++ b/src/base/static/utils/place-utils.js
@@ -1,13 +1,21 @@
 import constants from "../constants";
 
-const setPrivateParams = (placeParams, includePrivate) =>
-  includePrivate
+const setPrivateParams = (placeParams, includePrivate, jwtToken = null) => {
+  if (jwtToken) {
+    placeParams = {
+      ...placeParams,
+      token: jwtToken,
+    };
+  }
+
+  return includePrivate
     ? {
         ...placeParams,
         include_private_places: true,
         include_private_fields: true,
       }
     : placeParams;
+};
 
 const createGeoJSONFromPlaces = places => {
   const features = places.map(place => {


### PR DESCRIPTION
Depends on: https://github.com/jalMogo/api/pull/10
Closes: https://github.com/jalMogo/mgmt/issues/300

This PR forwards a `token` param found in the querystring on to the request made by the `getPlace` API client method initiated by the `report` template. 

JWT tokens are only forwarded for requests for individual Places (since JWTs are implemented as object permissions on the backend).