### PR TITLE
fix: momentum scrolling

### DIFF
--- a/src/base/static/components/app.tsx
+++ b/src/base/static/components/app.tsx
@@ -104,7 +104,6 @@ const TemplateContainer = styled("div")<{
   layout: string;
   currentTemplate: string;
 }>(props => ({
-  position: "relative",
   overflow:
     // The report template is a special case, and needs `overflow: visible`
     // for PDFs longer than one page to render.

--- a/src/base/static/components/organisms/left-sidebar.tsx
+++ b/src/base/static/components/organisms/left-sidebar.tsx
@@ -46,7 +46,8 @@ const LeftSidebar: React.FunctionComponent<Props> = props => (
   <section
     css={{
       position: "absolute",
-      zIndex: 20,
+      left: 0,
+      zIndex: 1,
       width: "250px",
       height: "100%",
       boxSizing: "border-box",
@@ -60,17 +61,15 @@ const LeftSidebar: React.FunctionComponent<Props> = props => (
         width: "100%",
         height: "100%",
         padding: "1em 1em 4em 1em",
-        overflow: "auto",
+        overflow: "scroll",
         boxSizing: "border-box",
+        "-webkit-overflow-scrolling": "touch",
 
         "&::-webkit-scrollbar": {
           display: "none",
         },
       }}
     >
-      <CloseButton onClick={() => props.setLeftSidebarExpanded(false)}>
-        &#10005;
-      </CloseButton>
       <SmallTitle
         css={{
           marginTop: 0,
@@ -90,6 +89,9 @@ const LeftSidebar: React.FunctionComponent<Props> = props => (
           ),
         )}
     </div>
+    <CloseButton onClick={() => props.setLeftSidebarExpanded(false)}>
+      &#10005;
+    </CloseButton>
   </section>
 );
 


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/325

Up on `kittitas-vsp` staging.

Second attempt to fix momentum scrolling on the `TemplateContainer` and the `LeftSidebar` on touch devices.

Oddly, removing the explicit `position: relative` on the `TemplateContainer` div enables momentum scrolling on the main content area without any other CSS.

But I can't get momentum scrolling to work on the `LeftSidebar` without using the deprecated `-webkit-overflow-scrolling: touch` vendor prefix.

I *think* the reason for this discrepancy might be that the `LeftSidebar` sits inside an absolutely positioned container, but I haven't done thorough testing to confirm that.

Tested on iOS Safari, iOS Chrome, and iOS FF. Haven't tested on Andriod.