### PR TITLE
fix(RightSidebar): include header height in right sidebar height calculation

### DIFF
--- a/src/base/static/components/organisms/right-sidebar.tsx
+++ b/src/base/static/components/organisms/right-sidebar.tsx
@@ -41,7 +41,7 @@ const RightSidebar: React.FunctionComponent<Props> = props => {
         position: "absolute",
         top: constants.HEADER_HEIGHT,
         right: 0,
-        height: "100%",
+        height: `calc(100% - ${constants.HEADER_HEIGHT}px)`,
         backgroundColor: "#fff",
         width: props.isRightSidebarVisible ? "15%" : 0,
         boxShadow: "-4px 0 3px rgba(0,0,0,0.1)",

--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -41,7 +41,6 @@
         color-adjust: exact;
         width: 100%;
         height: 100%;
-        overflow: hidden;
       }
     </style>
 


### PR DESCRIPTION
Fix an issue where the `RightSidebar` container can overflow the height of the template container.