### PR TITLE
fix(kittitas-firewise): viewport transition crash

### DIFF
--- a/src/flavors/kittitas-firewise/config.json
+++ b/src/flavors/kittitas-firewise/config.json
@@ -1218,7 +1218,6 @@
               "latitude": 47.04829,
               "zoom": 6.65,
               "longitude": -120.60682,
-              "transitionDuration": 1500,
               "bearing": 0,
               "pitch": 40
             }


### PR DESCRIPTION
Addresses: https://github.com/jalMogo/mgmt/issues/331

Fixes this crash on the `kittitas-firewise` flavor, but does not resolve the underlying problem.