### PR TITLE
Jalmogo/add discourse button

### DIFF
--- a/src/base/static/components/app.tsx
+++ b/src/base/static/components/app.tsx
@@ -10,7 +10,6 @@ import {
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import browserUpdate from "browser-update";
-import styled from "@emotion/styled";
 import Spinner from "react-spinner";
 import { Mixpanel } from "../utils/mixpanel";
 import i18next, { ThirdPartyModule } from "i18next";
@@ -44,7 +43,7 @@ import {
 } from "../state/ducks/datasets-config";
 import { loadDatasets } from "../state/ducks/datasets";
 import { loadDashboardConfig } from "../state/ducks/dashboard-config";
-import { appConfigPropType, loadAppConfig } from "../state/ducks/app-config";
+import { AppConfig, loadAppConfig } from "../state/ducks/app-config";
 import { loadMapConfig } from "../state/ducks/map";
 import { loadDatasetsConfig } from "../state/ducks/datasets-config";
 import { loadPlaceConfig } from "../state/ducks/place-config";
@@ -90,19 +89,6 @@ const Fallback = () => {
   return <Spinner />;
 };
 
-const statePropTypes = {
-  appConfig: appConfigPropType,
-  currentTemplate: PropTypes.string.isRequired,
-  datasetsConfig: datasetsConfigPropType,
-  datasetSlugs: PropTypes.array.isRequired,
-  hasAnonAbilitiesInAnyDataset: PropTypes.func.isRequired,
-  hasGroupAbilitiesInDatasets: PropTypes.func.isRequired,
-  layout: PropTypes.string.isRequired,
-  featuredPlacesConfig: featuredPlacesConfigPropType,
-  // TODO: shape of this:
-  pageExists: PropTypes.func.isRequired,
-};
-
 const dispatchPropTypes = {
   createFeaturesInGeoJSONSource: PropTypes.func.isRequired,
   loadDatasets: PropTypes.func.isRequired,
@@ -127,7 +113,20 @@ const dispatchPropTypes = {
   updateLayout: PropTypes.func.isRequired,
 };
 
-type StateProps = PropTypes.InferProps<typeof statePropTypes>;
+type StateProps = {
+  appConfig: AppConfig;
+  currentTemplate: string;
+  datasetsConfig: PropTypes.InferProps<typeof datasetsConfigPropType>;
+  datasetSlugs: any[];
+  hasAnonAbilitiesInAnyDataset: Function;
+  hasGroupAbilitiesInDatasets: Function;
+  layout: string;
+  featuredPlacesConfig: PropTypes.InferProps<
+    typeof featuredPlacesConfigPropType
+  >;
+  // TODO: shape of this:
+  pageExists: Function;
+};
 
 type DispatchProps = PropTypes.InferProps<typeof dispatchPropTypes>;
 

--- a/src/base/static/components/molecules/user-menu.tsx
+++ b/src/base/static/components/molecules/user-menu.tsx
@@ -114,6 +114,9 @@ const SocialLoginButton = styled(ExternalLink)(props => {
     case "google":
       backgroundColor = "#e8433a";
       break;
+    case "discourse":
+      backgroundColor = "green";
+      break;
   }
   return {
     display: "block",
@@ -269,6 +272,9 @@ const UserMenu: React.FunctionComponent<Props> = props => {
         )}
         <ul css={menuStyles({ isMenuOpen, isLoggedIn: false })}>
           <SocialMediaMenuItem>
+            {/* TODO: refactor these into the config:
+              { buttonStyle: "google", service: "google-oauth2" }
+               */}
             <SocialLoginButton
               service={"google"}
               href={`${props.apiRoot}users/login/google-oauth2/`}
@@ -297,6 +303,15 @@ const UserMenu: React.FunctionComponent<Props> = props => {
               }
             >
               Facebook
+            </SocialLoginButton>
+            <SocialLoginButton
+              service={"discourse"}
+              href={`${props.apiRoot}users/login/discourse-hdk/`}
+              onClick={() =>
+                Mixpanel.track("Clicked login button", { service: "discourse" })
+              }
+            >
+              Discourse
             </SocialLoginButton>
           </SocialMediaMenuItem>
         </ul>

--- a/src/base/static/components/organisms/site-header.tsx
+++ b/src/base/static/components/organisms/site-header.tsx
@@ -18,10 +18,7 @@ import {
   navBarConfigSelector,
 } from "../../state/ducks/nav-bar-config";
 import FilterMenu from "./filter-menu";
-import {
-  appConfigSelector,
-  appConfigPropType,
-} from "../../state/ducks/app-config";
+import { appConfigSelector, AppConfig } from "../../state/ducks/app-config";
 import { mapConfigSelector, MapConfig } from "../../state/ducks/map";
 import { currentTemplateSelector, resetUi } from "../../state/ducks/ui";
 import {
@@ -175,7 +172,6 @@ const navItemMappings = {
 };
 
 type ComponentPropTypes = {
-  appConfig: PropTypes.InferProps<typeof appConfigPropType>;
   navBarConfig: PropTypes.InferProps<typeof navBarConfigPropType>;
 };
 
@@ -191,6 +187,7 @@ interface Language {
 }
 
 type Props = {
+  appConfig: AppConfig;
   currentLanguageCode: string;
   currentTemplate: string;
   isLeftSidebarExpanded: boolean;
@@ -450,7 +447,7 @@ const SiteHeader: React.FunctionComponent<Props> = props => {
           </nav>
         )}
         <UserMenu
-          apiRoot={props.appConfig.api_root}
+          appConfig={props.appConfig}
           isInMobileMode={isHeaderExpanded}
           isMobileEnabled={!!props.appConfig.isShowingMobileUserMenu}
           pathname={props.history.location.pathname}

--- a/src/base/static/components/templates/dashboard.tsx
+++ b/src/base/static/components/templates/dashboard.tsx
@@ -18,10 +18,7 @@ import {
   dashboardConfigSelector,
   DashboardsConfig,
 } from "../../state/ducks/dashboard-config";
-import {
-  appConfigSelector,
-  appConfigPropType,
-} from "../../state/ducks/app-config";
+import { appConfigSelector, AppConfig } from "../../state/ducks/app-config";
 import {
   placeFormsConfigSelector,
   placeFormsConfigPropType,
@@ -37,7 +34,7 @@ import constants from "../../constants";
 
 type StateProps = {
   dashboardConfig: DashboardsConfig;
-  appConfig: PropTypes.InferProps<typeof appConfigPropType>;
+  appConfig: AppConfig;
   hasAdminAbilities: Function;
   datasetPlacesSelector: Function;
   placeFormsConfig: PropTypes.InferProps<typeof placeFormsConfigPropType>;

--- a/src/base/static/state/ducks/app-config.d.ts
+++ b/src/base/static/state/ducks/app-config.d.ts
@@ -1,0 +1,57 @@
+export type Theme = {
+  brand: {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+    accent: string;
+  };
+  bg: {
+    default: string;
+    light: string;
+    highlighted: string;
+  };
+  text: {
+    primary: string;
+    secondary: string;
+    highlighted: string;
+    headerFontFamily: string;
+    bodyFontFamily: string;
+    textTransform: string;
+    titleColor: string;
+    titleFontFamily: string;
+  };
+  map: {
+    addPlaceButtonHoverBackgroundColor: string;
+    addPlaceButtonBackgroundColor: string;
+  };
+  boxShadow: string;
+};
+
+export type AppConfig = {
+  title: string;
+  meta_description: string;
+  thumbnail?: string;
+  api_root: string;
+  dataset_download: {};
+  name?: string;
+  time_zone: string;
+  theme: Theme;
+  isShowingMobileUserMenu?: boolean;
+  languages: {
+    code: string;
+    label: string;
+  }[];
+  logo: string;
+  show_name_in_header?: boolean;
+};
+
+export const appConfigSelector: (state: any) => AppConfig;
+
+export const themeSelector: (state: any) => Theme;
+
+export const themePropType: any;
+
+export const appConfigPropType: any;
+
+// Action creators:
+export const loadAppConfig: (config: AppConfig) => void;

--- a/src/base/static/state/ducks/app-config.d.ts
+++ b/src/base/static/state/ducks/app-config.d.ts
@@ -27,6 +27,11 @@ export type Theme = {
   boxShadow: string;
 };
 
+export type LoginProvider = {
+  name: "google" | "twitter" | "discourse" | "facebook";
+  provider: string; // eg: "discourse-hdk", "google-oauth2",
+};
+
 export type AppConfig = {
   title: string;
   meta_description: string;
@@ -36,7 +41,9 @@ export type AppConfig = {
   name?: string;
   time_zone: string;
   theme: Theme;
+  loginProviders: LoginProvider[];
   isShowingMobileUserMenu?: boolean;
+  enableCookieConsent: boolean;
   languages: {
     code: string;
     label: string;

--- a/src/base/static/state/ducks/app-config.js
+++ b/src/base/static/state/ducks/app-config.js
@@ -66,12 +66,25 @@ export function loadAppConfig(config) {
 }
 
 // Reducers:
-// TODO(luke): refactor our current implementation in AppView to use
 const INITIAL_STATE = {
   title: "",
   meta_description: "",
   api_root: "",
   time_zone: "",
+  loginProviders: [
+    {
+      name: "google",
+      provider: "google-oauth2",
+    },
+    {
+      name: "twitter",
+      provider: "twitter",
+    },
+    {
+      name: "facebook",
+      provider: "facebook",
+    },
+  ],
 };
 
 export default function reducer(state = INITIAL_STATE, action) {

--- a/src/flavors/mississippi/config.json
+++ b/src/flavors/mississippi/config.json
@@ -67,10 +67,6 @@
     {
       "name": "facebook",
       "provider": "facebook"
-    },
-    {
-      "name": "discourse",
-      "provider": "discourse-hdk"
     }
   ]
   },

--- a/src/flavors/mississippi/config.json
+++ b/src/flavors/mississippi/config.json
@@ -54,7 +54,25 @@
         "headerFontFamily": "Roboto,sans-serif",
         "bodyFontFamily": "Roboto,sans-serif"
       }
+    },
+  "loginProviders": [
+    {
+      "name": "google",
+      "provider": "google-oauth2"
+    },
+    {
+      "name": "twitter",
+      "provider": "twitter"
+    },
+    {
+      "name": "facebook",
+      "provider": "facebook"
+    },
+    {
+      "name": "discourse",
+      "provider": "discourse-hdk"
     }
+  ]
   },
   "map": {
     "geolocationEnabled": true,

--- a/src/flavors/mississippi/config.json
+++ b/src/flavors/mississippi/config.json
@@ -55,20 +55,20 @@
         "bodyFontFamily": "Roboto,sans-serif"
       }
     },
-  "loginProviders": [
-    {
-      "name": "google",
-      "provider": "google-oauth2"
-    },
-    {
-      "name": "twitter",
-      "provider": "twitter"
-    },
-    {
-      "name": "facebook",
-      "provider": "facebook"
-    }
-  ]
+    "loginProviders": [
+      {
+        "name": "google",
+        "provider": "google-oauth2"
+      },
+      {
+        "name": "twitter",
+        "provider": "twitter"
+      },
+      {
+        "name": "facebook",
+        "provider": "facebook"
+      }
+    ]
   },
   "map": {
     "geolocationEnabled": true,


### PR DESCRIPTION
This PR:

 - refactors SiteHeader to use UserAvatar component
   - this fixes issues for broken images when a user's avatar image fails to load

TODO:
 - [x] refactor UserMenu to read social auth buttons from the config. By default, the config buttons will be Google/Facebook/Twitter.

Depends on API / Python Social Auth updates