### PR TITLE
feat: dashboard chart exporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,6 +6176,11 @@
         "entities": "^1.1.1"
       }
     },
+    "dom-to-image": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
+      "integrity": "sha1-ilA2CAiMh7HCL5A0rgMuGJiVWGc="
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "classnames": "^2.2.5",
     "compass-importer": "^0.4.1",
     "d3-geo": "^1.11.6",
+    "dom-to-image": "^2.6.0",
     "dotenv": "^8.0.0",
     "downloadjs": "^1.4.7",
     "downshift": "^3.2.10",

--- a/src/base/static/components/app.tsx
+++ b/src/base/static/components/app.tsx
@@ -10,7 +10,6 @@ import {
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import browserUpdate from "browser-update";
-import Spinner from "react-spinner";
 import { Mixpanel } from "../utils/mixpanel";
 import i18next, { ThirdPartyModule } from "i18next";
 import { initReactI18next } from "react-i18next";
@@ -24,6 +23,7 @@ import {
   updateUIVisibility,
 } from "../state/ducks/ui";
 import ShaTemplate from "./templates/sha";
+import { Spinner } from "./atoms/imagery";
 import CookieConsentBanner from "./molecules/cookie-consent-banner";
 const DashboardTemplate = React.lazy(() => import("./templates/dashboard"));
 const ListTemplate = React.lazy(() => import("./templates/place-list"));

--- a/src/base/static/components/atoms/imagery.js
+++ b/src/base/static/components/atoms/imagery.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import mq from "../../../../media-queries";
+import ReactSpinner from "react-spinner";
+import "react-spinner/react-spinner.css";
 
 const Image = props => <img src={props.src} alt={props.alt} {...props} />;
 
@@ -112,6 +114,8 @@ UserAvatar.defaultProps = {
   src: "/static/css/images/user-50.png",
 };
 
+const Spinner = ({ style }) => <ReactSpinner style={style} />;
+
 export default UserAvatar;
 
-export { Image, UserAvatar, SiteLogo, FontAwesomeIcon };
+export { Image, UserAvatar, SiteLogo, FontAwesomeIcon, Spinner };

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -3,7 +3,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Map, OrderedMap, fromJS } from "immutable";
 import { css, jsx } from "@emotion/core";
-import Spinner from "react-spinner";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import eventEmitter from "../../utils/event-emitter";
@@ -13,6 +12,7 @@ import WarningMessagesContainer from "../molecules/warning-messages-container";
 import FormStageHeaderBar from "../molecules/form-stage-header-bar";
 import FormStageControlBar from "../molecules/form-stage-control-bar";
 import InfoModal from "../organisms/info-modal";
+import { Spinner } from "../atoms/imagery";
 
 import { withTranslation } from "react-i18next";
 import { extractEmbeddedImages } from "../../utils/embedded-images";

--- a/src/base/static/components/molecules/form-field-types/geocoding-field.tsx
+++ b/src/base/static/components/molecules/form-field-types/geocoding-field.tsx
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import * as React from "react";
-import Spinner from "react-spinner";
 import { connect } from "react-redux";
 import { withTranslation, WithTranslation } from "react-i18next";
 import { css, jsx } from "@emotion/core";
@@ -16,7 +15,7 @@ import {
 } from "../../../state/ducks/map";
 import { TextInput } from "../../atoms/input";
 import { Button } from "../../atoms/buttons";
-import { FontAwesomeIcon } from "../../atoms/imagery";
+import { FontAwesomeIcon, Spinner } from "../../atoms/imagery";
 
 declare const MAP_PROVIDER_TOKEN: string;
 

--- a/src/base/static/components/molecules/left-sidebar-section.tsx
+++ b/src/base/static/components/molecules/left-sidebar-section.tsx
@@ -1,12 +1,11 @@
 /** @jsx jsx */
 import * as React from "react";
 import { connect } from "react-redux";
-import Spinner from "react-spinner";
 import styled from "@emotion/styled";
 import { withTranslation, WithTranslation } from "react-i18next";
 import { jsx, css } from "@emotion/core";
 
-import { FontAwesomeIcon } from "../atoms/imagery";
+import { FontAwesomeIcon, Spinner } from "../atoms/imagery";
 import { HorizontalRule } from "../atoms/layout";
 import { TinyTitle } from "../atoms/typography";
 

--- a/src/base/static/components/organisms/dashboard/chart-wrapper.tsx
+++ b/src/base/static/components/organisms/dashboard/chart-wrapper.tsx
@@ -162,7 +162,6 @@ class ChartWrapper extends React.Component<ChartWrapperProps> {
         `}
       >
         <div
-          className="mapseed-chart-header"
           css={css`
             height: ${HEADER_HEIGHT};
             max-height: ${HEADER_HEIGHT};

--- a/src/base/static/components/organisms/dashboard/chart-wrapper.tsx
+++ b/src/base/static/components/organisms/dashboard/chart-wrapper.tsx
@@ -1,10 +1,14 @@
 /** @jsx jsx */
 import * as React from "react";
 import { jsx, css } from "@emotion/core";
+import domtoimage from "dom-to-image";
+import download from "downloadjs";
+import "react-spinner/react-spinner.css";
 
 import { SmallText, TinyTitle } from "../../atoms/typography";
 import { RadioInput } from "../../atoms/input";
-import { FontAwesomeIcon } from "../../atoms/imagery";
+import { Button } from "../../atoms/buttons";
+import { FontAwesomeIcon, Spinner } from "../../atoms/imagery";
 import { FreeDonutChart, getFreeDonutChartData } from "./free-donut-chart";
 import { FreeBarChart, getFreeBarChartData } from "./free-bar-chart";
 import { MapseedLineChart, getLineChartData } from "./line-chart";
@@ -53,7 +57,9 @@ const widgetRegistry = {
 class ChartWrapper extends React.Component<ChartWrapperProps> {
   state = {
     widgetState: {},
+    isExporting: false,
   };
+  chartRef = React.createRef<HTMLDivElement>();
 
   componentDidMount() {
     const { widgetStateControls } = this.props.widget;
@@ -98,12 +104,53 @@ class ChartWrapper extends React.Component<ChartWrapperProps> {
     }
   };
 
+  handleChartExport = () => {
+    if (!this.chartRef.current) {
+      // eslint-disable-next-line no-console
+      console.error("Chart exporter: no ref to export");
+
+      return;
+    }
+
+    this.setState({
+      isExporting: true,
+    });
+
+    const { offsetHeight, offsetWidth } = this.chartRef.current;
+
+    domtoimage
+      .toPng(this.chartRef.current, {
+        // Render at 2X size and scale back down, to improve resolution.
+        height: offsetHeight * 2,
+        width: offsetWidth * 2,
+        style: {
+          transform: `scale(2) translate(${offsetWidth / 4}px, ${offsetHeight /
+            4}px)`,
+        },
+      })
+      .then(dataUrl => {
+        download(dataUrl, "mapseed-chart.png");
+        this.setState({
+          isExporting: false,
+        });
+      })
+      .catch(error => {
+        this.setState({
+          isExporting: false,
+        });
+
+        // eslint-disable-next-line no-console
+        console.error(error);
+      });
+  };
+
   render() {
     const { widget } = this.props;
     const WidgetComponent = widgetRegistry[widget.type].component;
 
     return (
       <div
+        ref={this.chartRef}
         css={css`
           grid-column: ${widget.layout.start} / ${widget.layout.end};
           height: ${widget.layout.height + "px" || "auto"};
@@ -116,6 +163,7 @@ class ChartWrapper extends React.Component<ChartWrapperProps> {
         `}
       >
         <div
+          className="mapseed-chart-header"
           css={css`
             height: ${HEADER_HEIGHT};
             max-height: ${HEADER_HEIGHT};
@@ -141,6 +189,49 @@ class ChartWrapper extends React.Component<ChartWrapperProps> {
           >
             {widget.header}
           </TinyTitle>
+          {widget.isExportable && (
+            <div
+              css={css`
+                display: flex;
+                min-width: 20px;
+                min-height: 20px;
+                align-items: center;
+                justify-content: center;
+                float: right;
+                position: relative;
+                margin-left: 16px;
+              `}
+            >
+              {this.state.isExporting ? (
+                <div
+                  css={css`
+                    width: 20px;
+                    height: 20px;
+                  `}
+                >
+                  <Spinner style={{ width: "20px", height: "20px" }} />
+                </div>
+              ) : (
+                <Button
+                  css={css`
+                    background: none;
+                    padding: 0;
+
+                    &:hover {
+                      background: none;
+                    }
+                  `}
+                  onClick={this.handleChartExport}
+                >
+                  <FontAwesomeIcon
+                    color="#777"
+                    hoverColor="#aaa"
+                    faClassname="fas fa-file-download"
+                  />
+                </Button>
+              )}
+            </div>
+          )}
           {widget.widgetStateControls &&
             widget.widgetStateControls.map(control => {
               return (

--- a/src/base/static/components/organisms/dashboard/chart-wrapper.tsx
+++ b/src/base/static/components/organisms/dashboard/chart-wrapper.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { jsx, css } from "@emotion/core";
 import domtoimage from "dom-to-image";
 import download from "downloadjs";
-import "react-spinner/react-spinner.css";
 
 import { SmallText, TinyTitle } from "../../atoms/typography";
 import { RadioInput } from "../../atoms/input";

--- a/src/base/static/components/place-detail/place-detail-editor.js
+++ b/src/base/static/components/place-detail/place-detail-editor.js
@@ -3,13 +3,12 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import classNames from "classnames";
 import { Map, OrderedMap, fromJS } from "immutable";
-import Spinner from "react-spinner";
-import "react-spinner/react-spinner.css";
 import { withRouter } from "react-router";
 
 import FormField from "../form-fields/form-field";
 import WarningMessagesContainer from "../molecules/warning-messages-container";
 import CoverImage from "../molecules/cover-image";
+import { Spinner } from "../atoms/imagery";
 
 import { jumpTo } from "../../utils/scroll-helpers";
 import { extractEmbeddedImages } from "../../utils/embedded-images";

--- a/src/base/static/state/ducks/dashboard-config.d.ts
+++ b/src/base/static/state/ducks/dashboard-config.d.ts
@@ -24,6 +24,7 @@ type Labels = {
 
 export interface Widget {
   header: string;
+  isExportable?: boolean;
   type: string;
   layout: ChartLayout;
   widgetStateControls?: WidgetStateControl[];

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -97,6 +97,7 @@
         },
         {
           "header": "Reporting Activity",
+          "isExportable": true,
           "type": "lineChart",
           "xAxisLabel": "Date",
           "yAxisLabel": "No. VSP reports",
@@ -108,12 +109,13 @@
         },
         {
           "header": "Stewardship Practices Detail",
+          "isExportable": true,
           "type": "fixedTable",
           "stripeColor": "#f8f5f5",
           "layout": {
             "start": 1,
             "end": 13,
-            "height": 500
+            "height": 1560
           },
           "widgetStateControls": [
             {
@@ -2484,6 +2486,7 @@
         {
           "header": "Critical Area Summary",
           "type": "fixedTable",
+          "isExportable": true,
           "stripeColor": "#f8f5f5",
           "layout": {
             "start": 1,


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/360

Add an MVP dashboard chart exporter, using the [`dom-to-image`](https://github.com/tsayen/dom-to-image) library. Charts that are configured to be exportable will render with a download button, which will download the chart to a PNG.

This is an MVP, and there is one significant limitation: The exporter cannot deal with clipped content in a scrollable container. So for now we just have to render charts at fixed heights which accommodate all the chart's content.

I suppose a more sophisticated chart exporter would work with `react-virtualized` to render all virtualized content somehow before exporting to a PNG. I haven't yet looked into how that might work...

