### PR TITLE
fix(LoginMenu): styling tweaks

### DIFF
--- a/src/base/static/components/molecules/left-sidebar-section.tsx
+++ b/src/base/static/components/molecules/left-sidebar-section.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import * as React from "react";
 import { connect } from "react-redux";
-import styled from "@emotion/styled";
+import styled from "../../utils/styled";
 import { withTranslation, WithTranslation } from "react-i18next";
 import { jsx, css } from "@emotion/core";
 

--- a/src/base/static/components/molecules/login-menu.tsx
+++ b/src/base/static/components/molecules/login-menu.tsx
@@ -66,7 +66,7 @@ const LoginMenu: React.FunctionComponent<Props> = props => {
             lineHeight: "3.25",
             display: "block",
             padding: "0 0.5em",
-            marginRight: "16px",
+            marginRight: "8px",
             height: "100%",
             cursor: "pointer",
 

--- a/src/base/static/components/molecules/login-menu.tsx
+++ b/src/base/static/components/molecules/login-menu.tsx
@@ -36,7 +36,7 @@ const LoginMenu: React.FunctionComponent<Props> = props => {
             // NOTE: We are accessing the 'theme' object directly for now, until
             // we can sort out our theming schema.
             backgroundColor: theme.palette.secondary.main,
-            borderRadius: "40px",
+            borderRadius: "8px",
             maxWidth: "180px",
 
             [mq[0]]: {
@@ -66,6 +66,7 @@ const LoginMenu: React.FunctionComponent<Props> = props => {
             lineHeight: "3.25",
             display: "block",
             padding: "0 0.5em",
+            marginRight: "16px",
             height: "100%",
             cursor: "pointer",
 

--- a/src/base/static/components/molecules/login-modal.tsx
+++ b/src/base/static/components/molecules/login-modal.tsx
@@ -58,7 +58,7 @@ const SocialLoginButton: React.FunctionComponent<{
       component="a"
       css={{
         backgroundColor,
-        borderRadius: "40px",
+        borderRadius: "8px",
         margin: "0 auto 16px auto",
         maxWidth: "180px",
         display: "flex",
@@ -113,7 +113,11 @@ const LoginModal: React.FunctionComponent<Props> = ({
         <Typography css={{ textAlign: "center" }} variant="h5">
           {t("signIn", "Sign In")}
         </Typography>
-        <IconButton aria-label="close" onClick={onClose}>
+        <IconButton
+          css={{ color: "#ff5e99", width: "48px", height: "48px" }}
+          aria-label="close"
+          onClick={onClose}
+        >
           {"✕"}
         </IconButton>
       </DialogTitle>

--- a/src/base/static/components/molecules/user-menu.tsx
+++ b/src/base/static/components/molecules/user-menu.tsx
@@ -6,7 +6,7 @@ import { UserAvatar } from "../atoms/imagery";
 import { connect } from "react-redux";
 import { InternalLink, ExternalLink, SmallText } from "../atoms/typography";
 import OfflineDownloadMenu from "../organisms/offline-download-menu";
-import styled from "@emotion/styled";
+import styled from "../../utils/styled";
 
 import { Mixpanel } from "../../utils/mixpanel";
 import {

--- a/src/base/static/components/molecules/user-menu.tsx
+++ b/src/base/static/components/molecules/user-menu.tsx
@@ -25,7 +25,7 @@ type MenuContainerProps = {
 };
 const MenuContainer = styled("nav")<MenuContainerProps>(props => ({
   marginLeft: "auto",
-  marginRight: "10px",
+  marginRight: "16px",
 
   [mq[0]]: {
     display: props.isMobileEnabled ? "block" : "none",

--- a/src/base/static/components/molecules/user-menu.tsx
+++ b/src/base/static/components/molecules/user-menu.tsx
@@ -25,7 +25,7 @@ type MenuContainerProps = {
 };
 const MenuContainer = styled("nav")<MenuContainerProps>(props => ({
   marginLeft: "auto",
-  marginRight: "16px",
+  marginRight: "8px",
 
   [mq[0]]: {
     display: props.isMobileEnabled ? "block" : "none",

--- a/src/base/static/components/organisms/left-sidebar.tsx
+++ b/src/base/static/components/organisms/left-sidebar.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import * as React from "react";
 import { connect } from "react-redux";
-import styled from "@emotion/styled";
+import styled from "../../utils/styled";
 import { jsx } from "@emotion/core";
 import { SmallTitle } from "../atoms/typography";
 import { withTranslation, WithTranslation } from "react-i18next";

--- a/src/base/static/components/organisms/right-sidebar.tsx
+++ b/src/base/static/components/organisms/right-sidebar.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import * as React from "react";
 import { connect } from "react-redux";
-import styled from "@emotion/styled";
+import styled from "../../utils/styled";
 import { jsx } from "@emotion/core";
 import { ChevronRight, ChevronLeft } from "@material-ui/icons";
 

--- a/src/base/static/components/organisms/site-header.tsx
+++ b/src/base/static/components/organisms/site-header.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import * as React from "react";
 import PropTypes from "prop-types";
-import styled from "@emotion/styled";
+import styled from "../../utils/styled";
 import { connect } from "react-redux";
 import { jsx } from "@emotion/core";
 import { withRouter, RouteComponentProps } from "react-router-dom";

--- a/src/base/static/components/templates/map.tsx
+++ b/src/base/static/components/templates/map.tsx
@@ -4,7 +4,7 @@ import { findDOMNode } from "react-dom";
 import { css, jsx } from "@emotion/core";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import styled from "@emotion/styled";
+import styled from "../../utils/styled";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import { withTranslation, WithTranslation } from "react-i18next";
 

--- a/src/base/static/utils/styled.ts
+++ b/src/base/static/utils/styled.ts
@@ -1,0 +1,4 @@
+import { Theme } from "../../../theme";
+import styled, { CreateStyled } from "@emotion/styled";
+
+export default styled as CreateStyled<Theme>;

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -119,7 +119,7 @@ export const globalStyles = theme => css`
 // TODO: We should start using the 'muiTheme' schema, and consolidate 'theme'
 // into 'muiTheme' for our Emotion themes and config themes. Longer-term, we
 // should only use MuiThemes and sunset Emotion as a theme provider.
-const theme = {
+const theme: Theme = {
   brand: {
     accent: "#0af",
     primary: "#007fbf",
@@ -139,6 +139,7 @@ const theme = {
   text: {
     primary: "#36454f",
     secondary: "#fff",
+    tertiary: "#fff",
     highlighted: "#fff",
     headerFontFamily: "Raleway-Regular,sans-serif",
     bodyFontFamily: "Raleway-Light,sans-serif",
@@ -174,6 +175,7 @@ export type Theme = {
   text: {
     primary: string;
     secondary: string;
+    tertiary: string;
     highlighted: string;
     headerFontFamily: string;
     bodyFontFamily: string;

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -154,6 +154,41 @@ const theme = {
   boxShadow: "-0.25em 0.25em 0 rgba(0, 0, 0, 0.1)",
 };
 
+export type Theme = {
+  brand: {
+    accent: string;
+    primary: string;
+    secondary: string;
+  };
+  bg: {
+    default: string;
+    light: string;
+    highlighted: string;
+  };
+  input: {
+    border: string;
+    padding: string;
+    autofillBgColor: string;
+    defaultBgColor: string;
+  };
+  text: {
+    primary: string;
+    secondary: string;
+    highlighted: string;
+    headerFontFamily: string;
+    bodyFontFamily: string;
+    navBarFontFamily: string;
+    textTransform: string;
+    titleColor: string;
+    titleFontFamily: string;
+  };
+  map: {
+    addPlaceButtonBackgroundColor: string;
+    addPlaceButtonHoverBackgroundColor: string;
+  };
+  boxShadow: string;
+};
+
 export const baseMuiTheme = {
   // TODO: Start using this schema in our Config and our Emotion
   // theme provider


### PR DESCRIPTION
Updated login menu:

![login-menu](https://user-images.githubusercontent.com/42042460/62725259-a340aa80-b9c9-11e9-8c69-3a5de0ed88c0.png)

This is also deployed to Mississippi staging

@goldpbear  lmk what you think 👍 
