### PR TITLE
Input form updates: multiple visibility triggers and skippable form stages

### DIFF
--- a/src/base/static/components/form-fields/form-field.js
+++ b/src/base/static/components/form-fields/form-field.js
@@ -100,12 +100,8 @@ class FormField extends Component {
         )
         .set(constants.FIELD_VALIDITY_MESSAGE_KEY, this.validator.message)
         .set(
-          constants.FIELD_TRIGGER_VALUE_KEY,
-          this.props.fieldState.get(constants.FIELD_TRIGGER_VALUE_KEY),
-        )
-        .set(
-          constants.FIELD_TRIGGER_TARGETS_KEY,
-          this.props.fieldState.get(constants.FIELD_TRIGGER_TARGETS_KEY),
+          constants.FIELD_TRIGGERS_VALUE_KEY,
+          this.props.fieldState.get(constants.FIELD_TRIGGERS_VALUE_KEY),
         )
         .set(
           constants.FIELD_VISIBILITY_KEY,

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -116,18 +116,30 @@ class InputForm extends Component {
       this.selectedCategoryConfig.multi_stage &&
       this.state.currentStage !== prevState.currentStage
     ) {
-      // Configure layer visibility and set the viewport for this form stage.
       const stageConfig = this.selectedCategoryConfig.multi_stage[
         this.state.currentStage - 1
       ];
+      const stageFields = this.getFieldsFromStage({
+        fields: this.state.fields,
+        stage: stageConfig,
+      });
 
-      stageConfig.visibleLayerGroupIds &&
-        this.updateLayerGroupVisibilities(
-          stageConfig.visibleLayerGroupIds,
-          true,
-        );
-      stageConfig.viewport &&
-        eventEmitter.emit("setMapViewport", stageConfig.viewport);
+      if (!stageFields.some(field => field.get("isVisible"))) {
+        this.setState({
+          currentStage:
+            this.state.currentStage +
+            (this.state.currentStage > prevState.currentStage ? 1 : -1),
+        });
+      } else {
+        // Configure layer visibility and set the viewport for this form stage.
+        stageConfig.visibleLayerGroupIds &&
+          this.updateLayerGroupVisibilities(
+            stageConfig.visibleLayerGroupIds,
+            true,
+          );
+        stageConfig.viewport &&
+          eventEmitter.emit("setMapViewport", stageConfig.viewport);
+      }
     }
   }
 

--- a/src/base/static/components/input-form/index.js
+++ b/src/base/static/components/input-form/index.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Map, OrderedMap, fromJS } from "immutable";
+import { List, Map, OrderedMap, fromJS } from "immutable";
 import { css, jsx } from "@emotion/core";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
@@ -154,13 +154,14 @@ class InputForm extends Component {
         return memo.set(
           field.name,
           Map({
-            // If this fields has a "forced_default_value", then its default
+            // If this field has a "forced_default_value", then its default
             // value will be set and sent on submission even if the field
             // remains invisible and is never rendered.
             value: fieldConfig.get("forced_default_value") || "",
             config: fieldConfig,
-            trigger: field.trigger && field.trigger.trigger_value,
-            triggerTargets: field.trigger && fromJS(field.trigger.targets),
+            triggers: fromJS(field.triggers),
+            //trigger: field.trigger && field.trigger.trigger_value,
+            //triggerTargets: field.trigger && fromJS(field.trigger.targets),
             // A field will be hidden if it is explicitly declared as
             // hidden_default in the config, or if it is restricted to a
             // group and the current user is not in that group or is not in
@@ -199,9 +200,39 @@ class InputForm extends Component {
     );
 
     // Check if this field triggers the visibility of other fields(s)
-    if (fieldStatus.get("trigger") && !isInitializing) {
-      const isVisible = fieldStatus.get("trigger") === fieldStatus.get("value");
-      this.triggerFieldVisibility(fieldStatus.get("triggerTargets"), isVisible);
+    let triggers = fieldStatus.get("triggers");
+    if (triggers && !isInitializing) {
+      const fieldValue = fieldStatus.get("value");
+      const triggeredFields = triggers.reduce((memo, trigger) => {
+        if (
+          // Fields values may be in list form, if the field type is a
+          // checkbox.
+          List.isList(fieldValue) &&
+          fieldValue.includes(trigger.get("value"))
+        ) {
+          trigger.get("targets").forEach(target => {
+            memo = memo.set(target, true);
+          });
+        } else if (fieldValue === trigger.get("value")) {
+          trigger.get("targets").forEach(target => {
+            memo = memo.set(target, true);
+          });
+        } else {
+          trigger.get("targets").forEach(target => {
+            memo = memo.set(target, false);
+          });
+        }
+
+        return memo;
+      }, Map());
+
+      this.setState({
+        fields: this.state.fields.map((field, fieldName) => {
+          return triggeredFields.has(fieldName)
+            ? field.set("isVisible", triggeredFields.get(fieldName))
+            : field;
+        }),
+      });
     }
 
     this.setState(({ fields }) => ({
@@ -229,21 +260,6 @@ class InputForm extends Component {
         });
       });
     }
-  }
-
-  triggerFieldVisibility(targets, isVisible) {
-    this.setState({
-      fields: this.state.fields.map((field, fieldName) => {
-        return targets.includes(fieldName)
-          ? field
-              .set("isVisible", isVisible)
-              .set(
-                "isAutoFocusing",
-                targets.indexOf(fieldName) === 0 && isVisible,
-              )
-          : field;
-      }),
-    });
   }
 
   onAddAttachment(attachment) {

--- a/src/base/static/constants.js
+++ b/src/base/static/constants.js
@@ -56,8 +56,7 @@ export default {
   FIELD_FIELD_TYPE_KEY: "type",
   FIELD_RENDER_KEY: "renderKey",
   FIELD_VISIBILITY_KEY: "isVisible",
-  FIELD_TRIGGER_VALUE_KEY: "trigger",
-  FIELD_TRIGGER_TARGETS_KEY: "triggerTargets",
+  FIELD_TRIGGERS_VALUE_KEY: "triggers",
   FIELD_AUTO_FOCUS_KEY: "isAutoFocusing",
   FIELD_ADVANCE_STAGE_ON_VALUE_KEY: "advanceStage",
 

--- a/src/flavors/columbia/config.json
+++ b/src/flavors/columbia/config.json
@@ -1967,13 +1967,15 @@
             "prompt": "Do you participate in any conservation cover practices (establishing and maintaining long-term, permanent vegetative cover)?",
             "label": "Conservation cover",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "conservation_cover_date",
-                "conservation_cover_amount"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "conservation_cover_date",
+                  "conservation_cover_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2024,13 +2026,15 @@
             "prompt": "Do you participate in integrated pest management practices (a site-specific combination of pest prevention, pest avoidance, pest monitoring, and pest suppression strategies) on cropland?",
             "label": "Integrated pest management on cropland",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "cropland_pest_management_date",
-                "cropland_pest_management_amount"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "cropland_pest_management_date",
+                  "cropland_pest_management_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2081,10 +2085,12 @@
             "prompt": "Do you participate in any cover crop practices (using grasses, legumes, and leafy ground cover plants for seasonal vegetative cover)?",
             "label": "Cover crop",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["cover_crop_date", "cover_crop_amount"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["cover_crop_date", "cover_crop_amount"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2135,13 +2141,15 @@
             "prompt": "Do you participate in having a riparian forest buffer (an area predominantly of suitable trees and/or shrubs planted along a stream, river, lake, or other water body) on cropland?",
             "label": "Riparian forest buffer on cropland",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "crop_riparian_forest_buffer_date",
-                "crop_riparian_forest_buffer_amount"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "crop_riparian_forest_buffer_date",
+                  "crop_riparian_forest_buffer_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2192,13 +2200,15 @@
             "prompt": "Do you participate in residue and tillage management/reduced till (managing the amount, orientation, and distribution of crop and other plant residue on the soil surface year-round)?",
             "label": "Residue and tillage management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "residue_tillage_management_date",
-                "residue_tillage_management_amount"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "residue_tillage_management_date",
+                  "residue_tillage_management_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2249,13 +2259,15 @@
             "prompt": "Do you participate in nutrient management (managing the amount, source, placement, and timing of plant nutrients and soil amendments)?",
             "label": "Residue and tillage management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "nutrient_management_date",
-                "nutrient_management_amount"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "nutrient_management_date",
+                  "nutrient_management_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2306,10 +2318,12 @@
             "prompt": "Do you participate in fencing (a constructed barrier to protect animals or people) on cropland?",
             "label": "Fencing on cropland",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["crop_fencing_date", "crop_fencing_amount"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["crop_fencing_date", "crop_fencing_amount"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2366,13 +2380,15 @@
             "prompt": "Do you participate in having a riparian forest buffer (an area predominantly of suitable trees and/or shrubs planted along a stream, river, lake, or other water body) on ranchland?",
             "label": "Riparian forest buffer on ranchland",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "ranch_riparian_forest_buffer_date",
-                "ranch_riparian_forest_buffer_amount"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "ranch_riparian_forest_buffer_date",
+                  "ranch_riparian_forest_buffer_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2423,10 +2439,12 @@
             "prompt": "Do you participate in fencing (a constructed barrier to protect animals or people) on ranchland?",
             "label": "Fencing on ranchland",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["ranch_fencing_date", "ranch_fencing_amount"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["ranch_fencing_date", "ranch_fencing_amount"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2477,13 +2495,15 @@
             "prompt": "Do you participate in stream habitat improvement and management (maintaining, improving, or restoring physical, chemical and biological functions of a stream and its associated riparian zone)?",
             "label": "Stream habitat improvement and management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "stream_habitat_improvement_date",
-                "stream_habitat_improvement_amount"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "stream_habitat_improvement_date",
+                  "stream_habitat_improvement_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2534,10 +2554,15 @@
             "prompt": "Do you participate in livestock grazing (managing the harvest of vegetation with grazing and/or browsing animals and soil amendments)?",
             "label": "Livestock grazing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["livestock_grazing_date", "livestock_grazing_amount"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "livestock_grazing_date",
+                  "livestock_grazing_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2588,10 +2613,15 @@
             "prompt": "Do you participate in having a watering facility? (a means of providing a controlled water source to livestock or wildlife)?",
             "label": "Watering facility",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["watering_facility_date", "watering_facility_amount"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "watering_facility_date",
+                  "watering_facility_amount"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",

--- a/src/flavors/defaultflavor/config.json
+++ b/src/flavors/defaultflavor/config.json
@@ -498,7 +498,7 @@
         "multi_stage": [
           {
             "start_field_index": 1,
-            "end_field_index": 3,
+            "end_field_index": 4,
             "icon_url": "/static/css/images/markers/marker-observation.png",
             "header": "Stage 1",
             "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
@@ -506,7 +506,7 @@
             "visible_layer_ids": ["sample-json-a", "sample-vector-b"]
           },
           {
-            "start_field_index": 4,
+            "start_field_index": 5,
             "end_field_index": 7,
             "icon_url": "/static/css/images/markers/marker-question.png",
             "header": "Stage 2, With a Longer and More Complex Header than Stage 1",
@@ -515,15 +515,15 @@
           },
           {
             "start_field_index": 8,
-            "end_field_index": 10,
+            "end_field_index": 11,
             "icon_url": "",
             "header": "Stage 3",
             "visible_basemap_id": "sample-wmts",
             "visible_layer_ids": ["sample-json-b"]
           },
           {
-            "start_field_index": 11,
-            "end_field_index": 18,
+            "start_field_index": 12,
+            "end_field_index": 19,
             "icon_url": "",
             "header": "Stage 4"
           }
@@ -556,14 +556,38 @@
             "optional": true
           },
           {
+            "name": "show_stage_2",
+            "type": "big_toggle",
+            "prompt": "Include second stage?",
+            "optional": false,
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["informational", "text_field", "textarea_field"]
+              }
+            ],
+            "content": [
+              {
+                "label": "Yes",
+                "value": "yes"
+              },
+              {
+                "label": "No",
+                "value": "no"
+              }
+            ]
+          },
+          {
             "name": "informational",
             "type": "informational_html",
+            "hidden_default": true,
             "prompt": "Info",
             "content": "<h1>This is some information for you.</h1><p>Hooray.</p>"
           },
           {
             "name": "text_field",
             "type": "text",
+            "hidden_default": true,
             "includeOnListItem": true,
             "autocomplete": true,
             "prompt": "Single line text field input prompt:",
@@ -578,6 +602,7 @@
           {
             "name": "textarea_field",
             "type": "textarea",
+            "hidden_default": true,
             "includeOnListItem": true,
             "autocomplete": true,
             "prompt": "Multiline textarea field input prompt:",

--- a/src/flavors/defaultflavor/config.json
+++ b/src/flavors/defaultflavor/config.json
@@ -419,73 +419,54 @@
     "is_visible_default": true,
     "component": "FeaturedPlacesNavigator"
   },
-  "left_sidebar": {
-    "is_enabled": true,
-    "is_visible_default": false,
-    "panels": [
+  "leftSidebar": {
+    "icon": "fa fa-bars",
+    "title": "Map Layers:",
+    "sections": [
       {
-        "id": "gis-layers",
-        "icon": "fa fa-bars",
-        "component": "MapLayerPanel",
         "title": "Map Layers with an Extra Long Title",
-        "content": [
+        "options": [
           {
-            "id": "basemaps",
-            "title": "Basemaps",
-            "layerGroups": [
-              {
-                "id": "sample-raster-tile",
-                "title": "Sample Raster Tiles with an Extra Long Layer Title",
-                "info": {
-                  "header": "Sample raster tile layer",
-                  "body": ["Some info.)", "_(Some more info."]
-                }
-              },
-              {
-                "id": "sample-wmts",
-                "title": "Sample WMTS A"
-              },
-              {
-                "id": "sample-wms",
-                "title": "Sample WMS"
-              }
-            ]
+            "layerGroupId": "sample-raster-tile",
+            "title": "Sample Raster Tiles with an Extra Long Layer Title"
           },
           {
-            "id": "group-a",
-            "title": "Group A",
-            "layerGroups": [
-              {
-                "id": "sample-vector-a",
-                "title": "Sample vector tile A",
-                "info": {
-                  "header": "Sample vector tile layer",
-                  "body": ["Some info.)", "_(Some more info."]
-                }
-              },
-              {
-                "id": "sample-vector-b",
-                "title": "Sample vector tile B"
-              },
-              {
-                "id": "sample-json-b",
-                "title": "Sample polygonal GeoJSON"
-              }
-            ]
+            "layerGroupId": "sample-wmts",
+            "title": "Sample WMTS A"
           },
           {
-            "id": "group-b",
-            "title": "Group B",
-            "layerGroups": [
-              {
-                "id": "sample-json-a",
-                "title": "Sample point GeoJSON"
-              },
-              {
-                "id": "demo",
-                "title": "Sample Mapseed place layer A"
-              }
-            ]
+            "layerGroupId": "sample-wms",
+            "title": "Sample WMS"
+          }
+        ]
+      },
+      {
+        "title": "Group A",
+        "options": [
+          {
+            "layerGroupId": "sample-vector-a",
+            "title": "Sample vector tile A"
+          },
+          {
+            "layerGroupId": "sample-vector-b",
+            "title": "Sample vector tile B"
+          },
+          {
+            "layerGroupId": "sample-json-b",
+            "title": "Sample polygonal GeoJSON"
+          }
+        ]
+      },
+      {
+        "title": "Group B",
+        "options": [
+          {
+            "layerGroupId": "sample-json-a",
+            "title": "Sample point GeoJSON"
+          },
+          {
+            "layerGroupId": "demo",
+            "title": "Sample Mapseed place layer A"
           }
         ]
       }
@@ -556,7 +537,7 @@
             "prompt": "Title:",
             "display_prompt": "Ttile:",
             "placeholder": "Enter title...",
-            "optional": false
+            "optional": true
           },
           {
             "name": "location",
@@ -572,7 +553,7 @@
             "prompt": "Number:",
             "display_prompt": "Number:",
             "placeholder": "Enter a number...",
-            "optional": false
+            "optional": true
           },
           {
             "name": "informational",
@@ -588,7 +569,7 @@
             "prompt": "Single line text field input prompt:",
             "display_prompt": "Rendered text field:",
             "placeholder": "Enter text...",
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -602,7 +583,7 @@
             "prompt": "Multiline textarea field input prompt:",
             "display_prompt": "Rendered textarea field:",
             "placeholder": "Enter text...",
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -616,7 +597,7 @@
             "prompt": "Multiline rich textarea field input prompt:",
             "display_prompt": "Rendered rich text:",
             "placeholder": "Enter text...",
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -664,7 +645,7 @@
                 "value": "choice_e"
               }
             ],
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -698,7 +679,7 @@
                 "value": "choice_e"
               }
             ],
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -732,7 +713,7 @@
                 "value": "choice_e"
               }
             ],
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -767,7 +748,7 @@
                 "value": "choice_e"
               }
             ],
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -778,7 +759,7 @@
             "type": "datetime",
             "prompt": "Datetime field prompt:",
             "display_prompt": "Rendered datetime:",
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -811,7 +792,7 @@
                 "value": "off"
               }
             ],
-            "optional": false,
+            "optional": true,
             "modal": {
               "header": "Modal header",
               "body": ["Modal body"]
@@ -869,7 +850,7 @@
             "prompt": "Title of your observation:",
             "display_prompt": "Title:",
             "placeholder": "Enter title...",
-            "optional": false
+            "optional": true
           },
           {
             "name": "big_checkbox_field",
@@ -908,7 +889,7 @@
             "prompt": "Description:",
             "display_prompt": " ",
             "placeholder": "Enter description...",
-            "optional": false
+            "optional": true
           },
           {
             "name": "submitter_name",
@@ -974,7 +955,7 @@
             "prompt": "Title of your question:",
             "display_prompt": "Title:",
             "placeholder": "Enter title...",
-            "optional": false
+            "optional": true
           },
           {
             "name": "description",
@@ -1020,7 +1001,7 @@
             "prompt": "Title of your idea:",
             "placeholder": "Enter title...",
             "display_prompt": "Title:",
-            "optional": false
+            "optional": true
           },
           {
             "name": "description",
@@ -1029,17 +1010,19 @@
             "prompt": "Describe your idea below:",
             "display_prompt": " ",
             "placeholder": "Description...",
-            "optional": false
+            "optional": true
           },
           {
             "name": "toggle_a",
             "type": "big_toggle",
             "prompt": "On or off?",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "on",
-              "targets": ["toggle_a_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "on",
+                "targets": ["toggle_a_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "On",
@@ -1050,7 +1033,7 @@
                 "value": "off"
               }
             ],
-            "optional": false
+            "optional": true
           },
           {
             "name": "toggle_a_datetime",
@@ -1086,16 +1069,64 @@
             "hidden_default": true
           },
           {
+            "name": "checkbox_trigger",
+            "type": "big_checkbox",
+            "prompt": "Select all that apply:",
+            "optional": true,
+            "triggers": [
+              {
+                "value": "a",
+                "targets": ["submitter_name"]
+              },
+              {
+                "value": "b",
+                "targets": ["my_image", "private-submitter_email"]
+              }
+            ],
+            "content": [
+              {
+                "label": "Toggle submitter name",
+                "value": "a"
+              },
+              {
+                "label": "Toggle image and email",
+                "value": "b"
+              },
+              {
+                "label": "C",
+                "value": "c"
+              },
+              {
+                "label": "D",
+                "value": "d"
+              }
+            ]
+          },
+          {
             "name": "submitter_name",
-            "type": "common_form_element"
+            "type": "text",
+            "hidden_default": true,
+            "prompt": "Your name",
+            "placeholder": "Name",
+            "optional": true
           },
           {
             "name": "private-submitter_email",
-            "type": "common_form_element"
+            "type": "text",
+            "hidden_default": true,
+            "prompt": "Your Email",
+            "placeholder": "Receive email updates on your report",
+            "optional": true,
+            "sticky": true
           },
           {
             "name": "my_image",
-            "type": "common_form_element"
+            "type": "file",
+            "hidden_default": true,
+            "includeOnListItem": true,
+            "prompt": "Image",
+            "label": "Add an Image",
+            "optional": true
           },
           {
             "name": "submit",

--- a/src/flavors/garfield/config.json
+++ b/src/flavors/garfield/config.json
@@ -5844,6 +5844,17 @@
           },
           {
             "start_field_index": 71,
+            "end_field_index": 79,
+            "header": "Garfield County",
+            "description": "Voluntary Stewardship Program",
+            "visibleLayerGroupIds": [
+              "satellite",
+              "garfield-input",
+              "garfield-county-outline"
+            ]
+          },
+          {
+            "start_field_index": 80,
             "end_field_index": 109,
             "header": "Garfield County",
             "description": "Voluntary Stewardship Program",
@@ -6130,13 +6141,15 @@
             "prompt": "Conventional tillage system",
             "label": "Conventional till",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "conventional_till_quantity",
-                "conventional_till_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "conventional_till_quantity",
+                  "conventional_till_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6176,10 +6189,12 @@
             "prompt": "Residue and tillage management: no till, strip till, direct seed, 2-pass, 1-pass, or mulch till",
             "label": "No till/direct seed",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["no_till_quantity", "no_till_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["no_till_quantity", "no_till_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6252,13 +6267,15 @@
             "prompt": "Pest management practices: combination of weed and pest prevention, monitoring and suppression",
             "label": "Pest management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "pest_management_quantity",
-                "pest_management_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "pest_management_quantity",
+                  "pest_management_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6331,13 +6348,15 @@
             "prompt": "Nutrient management practices: soil and/or plant tissue tests",
             "label": "Nutrient management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "nutrient_management_quantity",
-                "nutrient_management_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "nutrient_management_quantity",
+                  "nutrient_management_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6410,10 +6429,12 @@
             "prompt": "Irrigation practices:",
             "label": "Irrigation",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["irrigation_quantity", "irrigation_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["irrigation_quantity", "irrigation_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6486,13 +6507,15 @@
             "prompt": "Prescribed grazing: managing the harvest of vegetation with rotation of grazing and/or browsing animals",
             "label": "Prescribed grazing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "prescribed_grazing_quantity",
-                "prescribed_grazing_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "prescribed_grazing_quantity",
+                  "prescribed_grazing_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6536,13 +6559,15 @@
             "prompt": "Range plantings: establishment of adapted perennial or self-sustaining vegetation",
             "label": "Range plantings",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "range_plantings_quantity",
-                "range_plantings_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "range_plantings_quantity",
+                  "range_plantings_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6585,13 +6610,15 @@
             "prompt": "Watering facilities: means of providing drinking water to livestock or wildlife",
             "label": "Watering facilities",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "watering_facility_quantity",
-                "watering_facility_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "watering_facility_quantity",
+                  "watering_facility_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6634,10 +6661,12 @@
             "prompt": "Water wells: for domestic animals, wildlife or fire control",
             "label": "Water wells",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["water_wells_quantity", "water_wells_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["water_wells_quantity", "water_wells_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6680,10 +6709,12 @@
             "prompt": "Fencing: of springs, wetlands, or frequently flooded areas to control movement of livestock/vehicles or people",
             "label": "Fencing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["fencing_quantity", "fencing_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["fencing_quantity", "fencing_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6756,13 +6787,15 @@
             "prompt": "Pasture and hayland planting:",
             "label": "Pasture and hayland planting",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "pasture_hayland_planting_quantity",
-                "pasture_hayland_planting_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "pasture_hayland_planting_quantity",
+                  "pasture_hayland_planting_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6806,10 +6839,12 @@
             "prompt": "Cover crops: seasonal cover to reduce erosion and increase soil organic matter",
             "label": "Cover crops",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["cover_crop_quantity", "cover_crop_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["cover_crop_quantity", "cover_crop_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6850,7 +6885,7 @@
             "//": "---------------SECTION: FISH & WILDLIFE MGMT------------------",
             "name": "fish_wildlife_management",
             "type": "informational_html",
-            "content": "<h2 style='padding-bottom:8px;border-bottom:1px solid #ccc;margin:0;color:rgba(0,0,0,0.7)'>14. Fish & Wildlife Management</h2>"
+            "content": "<h2 style='padding-bottom:8px;border-bottom:1px solid #ccc;margin:0;color:rgba(0,0,0,0.7)'>15. Fish & Wildlife Management</h2>"
           },
           {
             "name": "fish_wildlife_management_information",
@@ -6882,13 +6917,15 @@
             "prompt": "Conservation cover: consists of establishment of permanent vegetative cover including CRP",
             "label": "Conservation cover",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "conservation_cover_quantity",
-                "conservation_cover_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "conservation_cover_quantity",
+                  "conservation_cover_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6932,13 +6969,15 @@
             "prompt": "Critical area planting: planting vegetation to stabilize critically eroding land",
             "label": "Critical area planting",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "critical_area_planting_quantity",
-                "critical_area_planting_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "critical_area_planting_quantity",
+                  "critical_area_planting_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -6982,10 +7021,12 @@
             "prompt": "Weed control on rangeland: can include chemical, mechanical, cultural or biological",
             "label": "Weed control",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["weed_control_quantity", "weed_control_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["weed_control_quantity", "weed_control_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -7029,10 +7070,12 @@
             "prompt": "Tree and shrub establishment: establishing woody plants by planting seedlings or cuttings",
             "label": "Tree/shrub establishment",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["tree_shrub_quantity", "tree_shrub_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["tree_shrub_quantity", "tree_shrub_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -7076,13 +7119,15 @@
             "prompt": "Wetland wildlife habitats management: creating, maintaining, or enhancing wetland habitats",
             "label": "Wetland wildlife management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "wetland_wildlife_management_quantity",
-                "wetland_wildlife_management_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "wetland_wildlife_management_quantity",
+                  "wetland_wildlife_management_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -7126,10 +7171,15 @@
             "prompt": "Upland wildlife habitats management: creating, maintaining, or enhancing areas to provide food, cover and habitat connectivity",
             "label": "Upland habitat management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["upland_habitat_quantity", "upland_habitat_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "upland_habitat_quantity",
+                  "upland_habitat_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -7173,10 +7223,15 @@
             "prompt": "Access control: the temporary or permanent exclusion of animals, people, vehicles, and/or equipment from an area",
             "label": "Access control",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["access_control_quantity", "access_control_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "access_control_quantity",
+                  "access_control_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -7220,13 +7275,15 @@
             "prompt": "Stream habitat improvements: structures placed instream for adult and juvenile salmonoids, such as post-assisted log structures and beaver dam analogs",
             "label": "Instream habitat projects",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "stream_habitat_improvements_quantity",
-                "stream_habitat_improvements_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "stream_habitat_improvements_quantity",
+                  "stream_habitat_improvements_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -7270,13 +7327,15 @@
             "prompt": "Streambank protections: soft streambank bioengineering to protect eroding banks",
             "label": "Streambank habitat projects",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "streambank_protections_quantity",
-                "streambank_protections_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "streambank_protections_quantity",
+                  "streambank_protections_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -7317,7 +7376,7 @@
             "//": "---------------SECTION: ADDITIONAL INFO-------------------",
             "name": "additional_info_header",
             "type": "informational_html",
-            "content": "<h2 style='padding-bottom:8px;border-bottom:1px solid #ccc;margin:0;color:rgba(0,0,0,0.7)'>15. Almost completed!</h2>"
+            "content": "<h2 style='padding-bottom:8px;border-bottom:1px solid #ccc;margin:0;color:rgba(0,0,0,0.7)'>17. Almost completed!</h2>"
           },
           {
             "name": "additional_info",

--- a/src/flavors/garfield/static/css/custom.css
+++ b/src/flavors/garfield/static/css/custom.css
@@ -89,6 +89,7 @@ label[for="input-form-pest-management_no-pest-management"],
 label[for="input-form-nutrient-management_no-nutrient-management"],
 label[for="input-form-water-management_no-water-management"],
 label[for="input-form-livestock-management_no-livestock-management"],
+label[for="input-form-fish-wildlife-management_no-fish-wildlife-management"],
 label[for="input-form-soil-management_no-soil-management"] {
   padding: 0 !important;
   font-family: "Font Awesome 5 Free", sans-serif;

--- a/src/flavors/kittitas-firewise/config.json
+++ b/src/flavors/kittitas-firewise/config.json
@@ -2086,22 +2086,24 @@
         "prompt": "I have an emergency kit",
         "label": "Evacuation plan",
         "optional": true,
-        "trigger": {
-          "trigger_value": "yes",
-          "targets": [
-            "food_and_water",
-            "medications",
-            "clothing",
-            "eyeglasses",
-            "car_keys_money",
-            "first_aid_kit",
-            "flashlight",
-            "radio",
-            "sanitation_supplies",
-            "documents",
-            "pet_food"
-          ]
-        },
+        "triggers": [
+          {
+            "value": "yes",
+            "targets": [
+              "food_and_water",
+              "medications",
+              "clothing",
+              "eyeglasses",
+              "car_keys_money",
+              "first_aid_kit",
+              "flashlight",
+              "radio",
+              "sanitation_supplies",
+              "documents",
+              "pet_food"
+            ]
+          }
+        ],
         "content": [
           {
             "label": "Yes",

--- a/src/flavors/kittitas-vsp/config.json
+++ b/src/flavors/kittitas-vsp/config.json
@@ -940,10 +940,12 @@
             "prompt": "Gated pipe irrigation system",
             "label": "Gated pipe",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["gated_pipe_quantity", "gated_pipe_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["gated_pipe_quantity", "gated_pipe_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -987,13 +989,15 @@
             "prompt": "Handline or wheel line sprinklers",
             "label": "Handline/wheel line sprinklers",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "line_sprinklers_quantity",
-                "line_sprinklers_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "line_sprinklers_quantity",
+                  "line_sprinklers_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1037,13 +1041,15 @@
             "prompt": "Center pivot or linear sprinklers",
             "label": "Center pivot/linear sprinklers",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "pivot_sprinklers_quantity",
-                "pivot_sprinklers_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "pivot_sprinklers_quantity",
+                  "pivot_sprinklers_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1087,13 +1093,15 @@
             "prompt": "Micro (drip) irrigation",
             "label": "Micro (drip) irrigation",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "micro_irrigation_quantity",
-                "micro_irrigation_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "micro_irrigation_quantity",
+                  "micro_irrigation_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1137,13 +1145,15 @@
             "prompt": "Converted open ditch to pipeline",
             "label": "Open ditch to pipeline conversion",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "pipeline_irrigation_quantity",
-                "pipeline_irrigation_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "pipeline_irrigation_quantity",
+                  "pipeline_irrigation_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1187,13 +1197,15 @@
             "prompt": "Irrigation scheduling – monitoring soil moisture and adjusting water applications accordingly",
             "label": "Irrigation scheduling",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "irrigation_scheduling_quantity",
-                "irrigation_scheduling_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "irrigation_scheduling_quantity",
+                  "irrigation_scheduling_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1266,10 +1278,15 @@
             "prompt": "Anionic polyacrylamide (PAM) application to reduce irrigation-associated erosion",
             "label": "Anionic polyacrylamide application",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["polyacrylamide_quantity", "polyacrylamide_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "polyacrylamide_quantity",
+                  "polyacrylamide_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1313,10 +1330,12 @@
             "prompt": "Planting cover crops (grasses, legumes, and forbs) for seasonal vegetative cover to reduce wind and water erosion",
             "label": "Cover crop plantings",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["cover_crop_quantity", "cover_crop_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["cover_crop_quantity", "cover_crop_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1360,13 +1379,15 @@
             "prompt": "Planting permanent cover crops to reduce winter and soil erosion and to establish wildlife or pollinator habitat",
             "label": "Permanent cover crop plantings",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "permanent_cover_crop_quantity",
-                "permanent_cover_crop_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "permanent_cover_crop_quantity",
+                  "permanent_cover_crop_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1410,10 +1431,12 @@
             "prompt": "No-tillage to limit soil disturbing activities. Soil disturbance is only during planting operation.",
             "label": "No-tillage",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["no_till_quantity", "no_till_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["no_till_quantity", "no_till_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1457,10 +1480,12 @@
             "prompt": "Reduced tillage to limit soil disturbing activities. Disturbance may include entire soil surface but cannot result in an inversion of the soil profile.",
             "label": "Reduced tillage",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["reduced_till_quantity", "reduced_till_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["reduced_till_quantity", "reduced_till_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1538,10 +1563,12 @@
             "prompt": "Soil testing for use in fertilizer applications or other planet nutrients or soil amendments",
             "label": "Soil testing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["soil_testing_quantity", "soil_testing_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["soil_testing_quantity", "soil_testing_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1585,13 +1612,15 @@
             "prompt": "Plant tissue testing or monitoring",
             "label": "Plant tissue testing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "plant_tissue_testing_quantity",
-                "plant_tissue_testing_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "plant_tissue_testing_quantity",
+                  "plant_tissue_testing_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1664,13 +1693,15 @@
             "prompt": "Grazing management (such as rotating pastures, keeping a pocket schedule of dates in/out, or monitoring grass height)",
             "label": "Grazing management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "grazing_management_quantity",
-                "grazing_management_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "grazing_management_quantity",
+                  "grazing_management_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1714,13 +1745,15 @@
             "prompt": "Fencing for grazing management",
             "label": "Fencing for grazing management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "grazing_management_fencing_quantity",
-                "grazing_management_fencing_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "grazing_management_fencing_quantity",
+                  "grazing_management_fencing_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1764,13 +1797,15 @@
             "prompt": "Range plantings: establishment of adapted perennial or self-sustaining vegetation",
             "label": "Range plantings",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "range_plantings_quantity",
-                "range_plantings_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "range_plantings_quantity",
+                  "range_plantings_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1813,13 +1848,15 @@
             "prompt": "Watering facilities: means of providing drinking water to livestock or wildlife",
             "label": "Watering facilities",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "watering_facility_quantity",
-                "watering_facility_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "watering_facility_quantity",
+                  "watering_facility_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1862,10 +1899,12 @@
             "prompt": "Water wells: for domestic animals or wildlife",
             "label": "Water wells",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["water_wells_quantity", "water_wells_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["water_wells_quantity", "water_wells_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1937,13 +1976,15 @@
             "prompt": "Weed prevention, monitoring, and suppression",
             "label": "Weed prevention",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "weed_prevention_quantity",
-                "weed_prevention_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "weed_prevention_quantity",
+                  "weed_prevention_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -1987,13 +2028,15 @@
             "prompt": "Pest (insect) prevention, monitoring, and suppression",
             "label": "Pest prevention",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "pest_prevention_quantity",
-                "pest_prevention_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "pest_prevention_quantity",
+                  "pest_prevention_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2066,13 +2109,15 @@
             "prompt": "Conservation cover: consists of establishment of permanent vegetative cover including CRP",
             "label": "Conservation cover",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "conservation_cover_quantity",
-                "conservation_cover_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "conservation_cover_quantity",
+                  "conservation_cover_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2116,10 +2161,12 @@
             "prompt": "Tree and shrub establishment: establishing woody plants by planting seedlings or cuttings, especially along waterways",
             "label": "Tree/shrub establishment",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["tree_shrub_quantity", "tree_shrub_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["tree_shrub_quantity", "tree_shrub_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2163,10 +2210,15 @@
             "prompt": "Upland wildlife habitats management: creating, maintain, or enhancing areas to provide food, cover and habitat connectivity not along waterways",
             "label": "Upland habitat management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["upland_habitat_quantity", "upland_habitat_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "upland_habitat_quantity",
+                  "upland_habitat_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2210,13 +2262,15 @@
             "prompt": "Fencing for riparian habitat protection",
             "label": "Fencing for riparian habitat",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "riparian_fencing_quantity",
-                "riparian_fencing_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "riparian_fencing_quantity",
+                  "riparian_fencing_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2260,10 +2314,12 @@
             "prompt": "Fish screens on irrigation diversions",
             "label": "Fish screens",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["fish_screens_quantity", "fish_screens_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["fish_screens_quantity", "fish_screens_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2307,10 +2363,12 @@
             "prompt": "Fish passages at irrigation diversions or culverts",
             "label": "Fish passages",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["fish_passages_quantity", "fish_passages_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["fish_passages_quantity", "fish_passages_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2354,13 +2412,15 @@
             "prompt": "Streambank stabilization using rock or wood structures",
             "label": "Streambank stabilization",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "streambank_stabilization_quantity",
-                "streambank_stabilization_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "streambank_stabilization_quantity",
+                  "streambank_stabilization_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2404,13 +2464,15 @@
             "prompt": "In-stream restoration including wood structures for fish habitat",
             "label": "In-stream restoration",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "in_stream_restoration_quantity",
-                "in_stream_restoration_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "in_stream_restoration_quantity",
+                  "in_stream_restoration_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -4361,13 +4361,15 @@
             "prompt": "Conventional tillage system",
             "label": "Conventional till",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "conventional_till_quantity",
-                "conventional_till_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "conventional_till_quantity",
+                  "conventional_till_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4407,10 +4409,12 @@
             "prompt": "Residue and tillage management: no till, strip till, direct seed, 2-pass, 1-pass, or mulch till",
             "label": "No till/direct seed",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["no_till_quantity", "no_till_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["no_till_quantity", "no_till_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4483,13 +4487,15 @@
             "prompt": "Pest management practices: combination of weed and pest prevention, monitoring and suppression",
             "label": "Pest management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "pest_management_quantity",
-                "pest_management_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "pest_management_quantity",
+                  "pest_management_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4562,13 +4568,15 @@
             "prompt": "Nutrient management practices: soil and/or plant tissue tests",
             "label": "Nutrient management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "nutrient_management_quantity",
-                "nutrient_management_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "nutrient_management_quantity",
+                  "nutrient_management_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4641,13 +4649,15 @@
             "prompt": "Managed grazing: managing the harvest of vegetation with rotation of grazing and/or browsing animals",
             "label": "Managed grazing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "managed_grazing_quantity",
-                "managed_grazing_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "managed_grazing_quantity",
+                  "managed_grazing_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4691,13 +4701,15 @@
             "prompt": "Range plantings: establishment of adapted perennial or self-sustaining vegetation",
             "label": "Range plantings",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "range_plantings_quantity",
-                "range_plantings_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "range_plantings_quantity",
+                  "range_plantings_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4740,13 +4752,15 @@
             "prompt": "Watering facilities: means of providing drinking water to livestock or wildlife",
             "label": "Watering facilities",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "watering_facility_quantity",
-                "watering_facility_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "watering_facility_quantity",
+                  "watering_facility_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4789,10 +4803,12 @@
             "prompt": "Water wells: for domestic animals, wildlife or fire control",
             "label": "Water wells",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["water_wells_quantity", "water_wells_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["water_wells_quantity", "water_wells_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4864,13 +4880,15 @@
             "prompt": "Conservation crop rotation: growing a planned sequence of various crops on the same piece of land for a variety of conservation purposes",
             "label": "Conservation crop rotation",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "conservation_crop_rotation_quantity",
-                "conservation_crop_rotation_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "conservation_crop_rotation_quantity",
+                  "conservation_crop_rotation_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4914,10 +4932,12 @@
             "prompt": "Cover crops: seasonal cover to reduce erosion and increase soil organic matter",
             "label": "Cover crops",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["cover_crop_quantity", "cover_crop_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["cover_crop_quantity", "cover_crop_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -4961,10 +4981,12 @@
             "prompt": "Mulching: applying plant residues or other suitable materials to land surface to improve moisture management ",
             "label": "Mulching",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["mulching_quantity", "mulching_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["mulching_quantity", "mulching_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5037,13 +5059,15 @@
             "prompt": "Conservation cover: consists of establishment of permanent vegetative cover including CRP",
             "label": "Conservation cover",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "conservation_cover_quantity",
-                "conservation_cover_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "conservation_cover_quantity",
+                  "conservation_cover_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5087,13 +5111,15 @@
             "prompt": "Critical area planting: planting vegetation to stabilize critically eroding land",
             "label": "Critical area planting",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "critical_area_planting_quantity",
-                "critical_area_planting_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "critical_area_planting_quantity",
+                  "critical_area_planting_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5137,13 +5163,15 @@
             "prompt": "Grassed waterways: shaped or graded channel with suitable vegetation to carry surface water at non-erosive velocity to a stable outlet",
             "label": "Grassed waterways",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "grassed_waterways_quantity",
-                "grassed_waterways_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "grassed_waterways_quantity",
+                  "grassed_waterways_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5187,10 +5215,12 @@
             "prompt": "Weed control on rangeland: can include chemical, mechanical, cultural or biological",
             "label": "Weed control on rangeland",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["weed_control_quantity", "weed_control_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["weed_control_quantity", "weed_control_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5234,10 +5264,12 @@
             "prompt": "Tree and shrub establishment: establishing woody plants by planting seedlings or cuttings",
             "label": "Tree/shrub establishment",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["tree_shrub_quantity", "tree_shrub_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["tree_shrub_quantity", "tree_shrub_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5281,13 +5313,15 @@
             "prompt": "Wetland wildlife habitats management: creating, maintaining, or enhancing wetland habitats",
             "label": "Wetland wildlife management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "wetland_wildlife_management_quantity",
-                "wetland_wildlife_management_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "wetland_wildlife_management_quantity",
+                  "wetland_wildlife_management_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5331,10 +5365,15 @@
             "prompt": "Upland wildlife habitats management: creating, maintain, or enhancing areas to provide food, cover and habitat connectivity",
             "label": "Upland habitat management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["upland_habitat_quantity", "upland_habitat_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "upland_habitat_quantity",
+                  "upland_habitat_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5378,13 +5417,15 @@
             "prompt": "Hedgerow planting: establishment of dense vegetation in a linear design to achieve conservation purposes",
             "label": "Hedgerow planting",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "hedgerow_planting_quantity",
-                "hedgerow_planting_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "hedgerow_planting_quantity",
+                  "hedgerow_planting_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5428,10 +5469,12 @@
             "prompt": "Open channel: construct, improve or restore to convey water required for flood prevention, drainage,  or wildlife habitat protection or enhancement",
             "label": "Open channel",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["open_channel_quantity", "open_channel_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["open_channel_quantity", "open_channel_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5475,10 +5518,12 @@
             "prompt": "Fencing: of springs, wetlands, or frequently flooded areas to control movement of livestock/vehicles or people",
             "label": "Fencing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["fencing_quantity", "fencing_datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["fencing_quantity", "fencing_datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5522,13 +5567,15 @@
             "prompt": "Instream habitat improvement: the establishment of instream structures for the purpose of enhancing physical aquatic habitat quality and quantity",
             "label": "Instream habitat improvement",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "instream_habitat_quantity",
-                "instream_habitat_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "instream_habitat_quantity",
+                  "instream_habitat_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -5572,13 +5619,15 @@
             "prompt": "Streambank protection: protection of streams and property by reducing bank erosion and enhancing aquatic habitat",
             "label": "Streambank protection",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "streambank_protection_quantity",
-                "streambank_protection_datetime"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "streambank_protection_quantity",
+                  "streambank_protection_datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",

--- a/src/flavors/snohomish/config.json
+++ b/src/flavors/snohomish/config.json
@@ -590,10 +590,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_rotational-grazing-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_rotational-grazing-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Practice rotational grazing, never grazing grass below 3” deep",
@@ -622,10 +624,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_fencing-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_fencing-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Added streamside fencing to keep livestock out of waterway",
@@ -654,10 +658,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_off-stream-watering-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_off-stream-watering-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Installed an off-stream watering system",
@@ -686,10 +692,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_livestock-heavy-use-areas-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_livestock-heavy-use-areas-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Installed a heavy use or sacrifice area for livestock",
@@ -724,10 +732,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_gutters-diversion-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_gutters-diversion-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Installed gutters or water diversion to keep roof runoff away from heavily used areas",
@@ -756,10 +766,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_soil-testing-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_soil-testing-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Tested my soils to ensure proper fertilizer, manure, or lime application rates",
@@ -788,10 +800,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_manure-storage-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_manure-storage-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Installed a covered manure storage or composting bin",
@@ -820,10 +834,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_septic-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_septic-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Maintain septic systems and have them inspected regularly to make sure they are functioning properly.",
@@ -852,10 +868,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["farm_other-action", "farm_other-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["farm_other-action", "farm_other-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "OTHER",
@@ -921,10 +939,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_protected-buffers-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_protected-buffers-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Protected forest buffers around wetlands, streams, steep slopes, and bald eagle nests to protect water quality and critical wildlife areas",
@@ -953,10 +973,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_restored-buffers-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_restored-buffers-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Restored forest buffers around wetlands, streams, steep slopes, and bald eagle nests to improve water quality and critical wildlife areas",
@@ -985,10 +1007,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_left-trees-snags-etc-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_left-trees-snags-etc-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Left green trees and/or left or created snags, brush piles, downed logs, or other habitat features to improve wildlife habitat",
@@ -1017,10 +1041,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_maintain-roads-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_maintain-roads-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Maintained forest roads and stream crossings to control erosion",
@@ -1049,10 +1075,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_reduce-harvest-compaction-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_reduce-harvest-compaction-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Took steps to reduce compaction during tree harvest",
@@ -1081,10 +1109,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_fish-passage-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_fish-passage-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Replaced fish-passage barrier culverts with larger culverts or bridges",
@@ -1113,10 +1143,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_logging-slash-etc-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_logging-slash-etc-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Kept logging slash and other materials and equipment away from streams, wetlands, and slopes",
@@ -1145,10 +1177,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_stewardship-plan-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_stewardship-plan-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Created and implemented a Forest Stewardship Plan",
@@ -1177,10 +1211,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["forest_other-datetime", "forest_other-action"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["forest_other-datetime", "forest_other-action"]
+              }
+            ],
             "content": [
               {
                 "label": "OTHER",
@@ -1245,10 +1281,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_left-slope-vegetation-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_left-slope-vegetation-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Left existing native vegetation on a slope or bank",
@@ -1277,10 +1315,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_slope-native-buffer-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_slope-native-buffer-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Planted a buffer of native trees and shrubs along slope or streamside",
@@ -1315,10 +1355,12 @@
                 "Common noxious weeds that compete with our native vegetation include blackberry, knotweed, ivy, and scotch broom."
               ]
             },
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_remove-noxious-weeds-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_remove-noxious-weeds-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Removed noxious weeds to support native plant health",
@@ -1347,10 +1389,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_left-dead-trees-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_left-dead-trees-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Left dead “habitat” trees standing for wildlife",
@@ -1379,10 +1423,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_impervious-surfaces-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_impervious-surfaces-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Minimized impervious surfaces (driveways, roofs)",
@@ -1411,10 +1457,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_relocated-slope-structures-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_relocated-slope-structures-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Re-located structures away from slopes",
@@ -1443,10 +1491,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_grass-clippings-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_grass-clippings-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Refrained from dumping grass clippings and yard debris on slopes",
@@ -1475,10 +1525,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_removed-armoring-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_removed-armoring-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Removed shoreline armoring",
@@ -1513,10 +1565,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_pet-waste-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["shoreline_pet-waste-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Pick up after my pet",
@@ -1545,10 +1599,15 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["shoreline_other-action", "shoreline_other-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "shoreline_other-action",
+                  "shoreline_other-datetime"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "OTHER",
@@ -1619,10 +1678,12 @@
                 "A rain garden is an area that is dug out, lined with a special soil mix, and planted with the intent of infiltrating runoff from your house, driveway, or other hardened surfaces."
               ]
             },
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_rain-gardens-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_rain-gardens-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Installed a rain garden",
@@ -1651,10 +1712,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_rain-barrels-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_rain-barrels-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Installed rain barrels or cisterns",
@@ -1689,10 +1752,12 @@
                 "A rain bed combines a rain barrel system with a raised garden bed. A special gutter in the raised bed spreads water from the barrels over the garden for easy watering. Excess water from the barrels infiltrates through the bed and is dispersed over the surrounding yard where it is filtered and infiltrated."
               ]
             },
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_rain-beds-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_rain-beds-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Installed rain beds",
@@ -1727,10 +1792,12 @@
                 "Natural Yard Care can include: building healthy soil, practicing smart watering, using organic products, avoiding chemical use, mulching/composting and supporting pollinators."
               ]
             },
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_natural-yard-care-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_natural-yard-care-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Used natural yard care",
@@ -1759,10 +1826,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["general_wildlife-backyard-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["general_wildlife-backyard-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Certified my property as a Backyard Wildlife Habitat",
@@ -1791,10 +1860,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_pollinator-habitat-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_pollinator-habitat-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Created pollinator habitat by planting flowering native plants",
@@ -1823,10 +1894,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_water-conservation-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_water-conservation-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Practice water conservation",
@@ -1855,10 +1928,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_compost-mulch-soil-amendments-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_compost-mulch-soil-amendments-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Use compost/mulch/soil amendments",
@@ -1887,10 +1962,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_food-garden-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_food-garden-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Started a food garden",
@@ -1919,10 +1996,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_drainage-concerns-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_drainage-concerns-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Addressed stormwater and/or drainage concerns",
@@ -1951,10 +2030,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_pet-waste-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_pet-waste-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Pick up after my pet",
@@ -1983,10 +2064,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_septic-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_septic-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "Maintain septic systems and have them inspected regularly to make sure they are functioning properly.",
@@ -2015,10 +2098,12 @@
             "type": "big_toggle",
             "prompt": " ",
             "display_prompt": " ",
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["urban_other-action", "urban_other-datetime"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["urban_other-action", "urban_other-datetime"]
+              }
+            ],
             "content": [
               {
                 "label": "OTHER",

--- a/src/flavors/spokane/config.json
+++ b/src/flavors/spokane/config.json
@@ -2156,10 +2156,12 @@
             "prompt": "No till",
             "label": "No till",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["no_till_quantity", "no_till_duration"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["no_till_quantity", "no_till_duration"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2232,14 +2234,16 @@
             "prompt": "Mulch till",
             "label": "Mulch till",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "mulch_till_quantity",
-                "mulch_till_type",
-                "mulch_till_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "mulch_till_quantity",
+                  "mulch_till_type",
+                  "mulch_till_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2361,14 +2365,16 @@
             "prompt": "Basic soil tests",
             "label": "Basic soil tests",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "basic_soil_tests_quantity",
-                "basic_soil_tests_type",
-                "basic_soil_tests_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "basic_soil_tests_quantity",
+                  "basic_soil_tests_type",
+                  "basic_soil_tests_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2462,10 +2468,12 @@
             "prompt": "Biosolids management",
             "label": "Control biosolids",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["biosolids_quantity", "biosolids_duration"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["biosolids_quantity", "biosolids_duration"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2538,14 +2546,16 @@
             "prompt": "Precision soil tests or mapping",
             "label": "Precision soil tests / mapping",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "precision_soil_tests_quantity",
-                "precision_soil_tests_type",
-                "precision_soil_tests_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "precision_soil_tests_quantity",
+                  "precision_soil_tests_type",
+                  "precision_soil_tests_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2660,14 +2670,16 @@
             "prompt": "Grassed waterways",
             "label": "Grassed waterways",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "grassed_waterways_quantity",
-                "grassed_waterways_type",
-                "grassed_waterways_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "grassed_waterways_quantity",
+                  "grassed_waterways_type",
+                  "grassed_waterways_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2761,10 +2773,12 @@
             "prompt": "I participate in the commodity buffer program",
             "label": "Commodity buffer program",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": ["commodity_buffer_duration"]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": ["commodity_buffer_duration"]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2819,14 +2833,16 @@
             "prompt": "Riparian tree and shrub planting",
             "label": "Riparian forest planting",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "riparian_forest_quantity",
-                "riparian_forest_type",
-                "riparian_forest_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "riparian_forest_quantity",
+                  "riparian_forest_type",
+                  "riparian_forest_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -2944,14 +2960,16 @@
             "prompt": "Stream crossings",
             "label": "Stream crossings",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "stream_crossing_quantity",
-                "stream_crossing_type",
-                "stream_crossing_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "stream_crossing_quantity",
+                  "stream_crossing_type",
+                  "stream_crossing_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -3045,13 +3063,15 @@
             "prompt": "My operation has a designated heavy use area",
             "label": "Heavy use area protection",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "heavy_use_area_duration",
-                "heavy_use_area_description"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "heavy_use_area_duration",
+                  "heavy_use_area_description"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -3120,14 +3140,16 @@
             "prompt": "Fencing",
             "label": "Fencing",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "fencing_quantity",
-                "fencing_type",
-                "fencing_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "fencing_quantity",
+                  "fencing_type",
+                  "fencing_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -3221,14 +3243,16 @@
             "prompt": "Nutrient management",
             "label": "Nutrient management",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "nutrient_management_quantity",
-                "nutrient_management_type",
-                "nutrient_management_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "nutrient_management_quantity",
+                  "nutrient_management_type",
+                  "nutrient_management_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",
@@ -3322,14 +3346,16 @@
             "prompt": "Pipelines",
             "label": "Pipelines",
             "optional": true,
-            "trigger": {
-              "trigger_value": "yes",
-              "targets": [
-                "pipeline_quantity",
-                "pipeline_type",
-                "pipeline_duration"
-              ]
-            },
+            "triggers": [
+              {
+                "value": "yes",
+                "targets": [
+                  "pipeline_quantity",
+                  "pipeline_type",
+                  "pipeline_duration"
+                ]
+              }
+            ],
             "content": [
               {
                 "label": "Yes",


### PR DESCRIPTION
**WIP**

Closes: https://github.com/jalMogo/mgmt/issues/362

This PR updates the form field visibility feature in two ways:
* allow fields to trigger different sets of fields based on different response values (including multiple values in the case of checkboxes)
* automatically skip form stages with no visible fields on them

The combination of these two features will allow us to build a form for spokane where the responses to one field question configures which remaining form stages a user will see.

@jalMogo -- note that this PR changes the schema of the `trigger` section of a field config (renamed here to `triggers`). See the diff for what the schema looks like now-- hopefully this isn't too bad to deal with on the backend, or lmk what you think.

TODO
 - [x] refactor remaining flavor configs