### PR TITLE
Goldpbear/spokane

### DIFF
--- a/src/base/static/components/atoms/typography.js
+++ b/src/base/static/components/atoms/typography.js
@@ -309,5 +309,5 @@ export {
   SmallText,
   MicroText,
   DashboardText,
-  Badge,
+  Badge
 };

--- a/src/base/static/components/atoms/typography.js
+++ b/src/base/static/components/atoms/typography.js
@@ -309,5 +309,5 @@ export {
   SmallText,
   MicroText,
   DashboardText,
-  Badge
+  Badge,
 };

--- a/src/base/static/components/form-fields/types/textarea-field-response.js
+++ b/src/base/static/components/form-fields/types/textarea-field-response.js
@@ -7,14 +7,24 @@ import { withTheme } from "emotion-theming";
 import { RegularText } from "../../atoms/typography";
 
 const TextareaFieldResponse = props => {
+  const value = props.value && props.value.split("\n");
+
   return (
-    <RegularText
-      css={css`
-        margin: 8px 0 16px 0;
-      `}
-    >
-      {props.value}
-    </RegularText>
+    <React.Fragment>
+      {value &&
+        value.map((p, idx) => (
+          <RegularText
+            css={css`
+              display: block;
+              margin-top: ${idx === 0 ? "16px" : 0};
+              margin-bottom: ${idx === value.length - 1 ? "16px" : "8px"};
+            `}
+            key={idx}
+          >
+            {p}
+          </RegularText>
+        ))}
+    </React.Fragment>
   );
 };
 

--- a/src/base/static/components/molecules/survey-response.tsx
+++ b/src/base/static/components/molecules/survey-response.tsx
@@ -104,7 +104,10 @@ const SurveyResponse = (props: SurveyResponseProps) => {
             css={css`
               display: block;
             `}
-            submitterName={comment.submitter && comment.submitter.name}
+            submitterName={
+              comment.submitter_name ||
+              (comment.submitter && comment.submitter.name)
+            }
             anonymousName={placeConfig.anonymous_name}
           />
           {appConfig.show_timestamps && (

--- a/src/base/static/components/organisms/info-modal.js
+++ b/src/base/static/components/organisms/info-modal.js
@@ -6,35 +6,45 @@ import "./info-modal.scss";
 
 Modal.setAppElement("#site-wrap");
 
-const InfoModal = props => (
-  <Modal
-    className="mapseed-info-modal"
-    overlayClassName="mapseed-info-modal__overlay"
-    isOpen={props.isModalOpen}
-  >
-    <div className="mapseed-info-modal__header-bar">
-      <h3 className="mapseed-info-modal__header-content">{props.header}</h3>
-      <button className="mapseed-info-modal__close-btn" onClick={props.onClose}>
-        &#10005;
-      </button>
-    </div>
-    <div className="mapseed-info-modal__body">
-      {props.body.map((content, i) => {
-        return (
-          <div
-            key={i}
-            dangerouslySetInnerHTML={{
-              __html: content,
-            }}
-          />
-        );
-      })}
-    </div>
-  </Modal>
-);
+const InfoModal = props => {
+  const body = Array.isArray(props.body) ? props.body : [props.body];
+
+  return (
+    <Modal
+      className="mapseed-info-modal"
+      overlayClassName="mapseed-info-modal__overlay"
+      isOpen={props.isModalOpen}
+    >
+      <div className="mapseed-info-modal__header-bar">
+        <h3 className="mapseed-info-modal__header-content">{props.header}</h3>
+        <button
+          className="mapseed-info-modal__close-btn"
+          onClick={props.onClose}
+        >
+          &#10005;
+        </button>
+      </div>
+      <div className="mapseed-info-modal__body">
+        {body.map((content, i) => {
+          return (
+            <div
+              key={i}
+              dangerouslySetInnerHTML={{
+                __html: content,
+              }}
+            />
+          );
+        })}
+      </div>
+    </Modal>
+  );
+};
 
 InfoModal.propTypes = {
-  body: PropTypes.arrayOf(PropTypes.string).isRequired,
+  body: PropTypes.oneOfType(
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ).isRequired,
   header: PropTypes.string.isRequired,
   isModalOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/base/static/components/place-detail/palouse-field-summary.js
+++ b/src/base/static/components/place-detail/palouse-field-summary.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 
 import fieldResponseFilter from "../../utils/field-response-filter";
-import { RegularTitle, RegularText } from "../atoms/typography";
+import { TinyTitle, RegularTitle, RegularText } from "../atoms/typography";
 import { HorizontalRule } from "../atoms/layout";
 import CoverImage from "../molecules/cover-image";
 
@@ -22,12 +22,15 @@ const ActionSummaryItem = styled("li")(props => ({
   padding: "8px 4px 8px 4px",
 }));
 
+const excludedFields = [""];
+
 const SnohomishFieldSummary = props => {
   const fieldConfigs = fieldResponseFilter(props.fields, props.place).filter(
     fieldConfig => props.place[fieldConfig.name] === "yes",
   );
   const numActions = fieldConfigs.length;
   const description = props.place.practices_description;
+  const challenges = props.place.stewardship_difficulties;
 
   return (
     <div>
@@ -39,6 +42,12 @@ const SnohomishFieldSummary = props => {
           <CoverImage key={i} imageUrl={attachment.file} />
         ))}
       {description && <RegularText>{description}</RegularText>}
+      {challenges && (
+        <React.Fragment>
+          <TinyTitle>Challenges:</TinyTitle>
+          <RegularText>{challenges}</RegularText>
+        </React.Fragment>
+      )}
       <ActionSummary>
         {fieldConfigs.map((fieldConfig, idx) => {
           const actionQuantityConfig =

--- a/src/base/static/components/place-detail/palouse-field-summary.js
+++ b/src/base/static/components/place-detail/palouse-field-summary.js
@@ -1,5 +1,7 @@
+/** @jsx jsx */
 import React from "react";
 import PropTypes from "prop-types";
+import { css, jsx } from "@emotion/core";
 import styled from "@emotion/styled";
 
 import fieldResponseFilter from "../../utils/field-response-filter";
@@ -29,8 +31,12 @@ const SnohomishFieldSummary = props => {
     fieldConfig => props.place[fieldConfig.name] === "yes",
   );
   const numActions = fieldConfigs.length;
-  const description = props.place.practices_description;
-  const challenges = props.place.stewardship_difficulties;
+  const description =
+    props.place.practices_description &&
+    props.place.practices_description.split("\n");
+  const challenges =
+    props.place.stewardship_difficulties &&
+    props.place.stewardship_difficulties.split("\n");
 
   return (
     <div>
@@ -41,11 +47,32 @@ const SnohomishFieldSummary = props => {
         .map((attachment, i) => (
           <CoverImage key={i} imageUrl={attachment.file} />
         ))}
-      {description && <RegularText>{description}</RegularText>}
+      {description &&
+        description.map((p, idx) => (
+          <RegularText
+            css={css`
+              display: block;
+              margin-bottom: 8px;
+            `}
+            key={idx}
+          >
+            {p}
+          </RegularText>
+        ))}
       {challenges && (
         <React.Fragment>
           <TinyTitle>Challenges:</TinyTitle>
-          <RegularText>{challenges}</RegularText>
+          {challenges.map((p, idx) => (
+            <RegularText
+              css={css`
+                display: block;
+                margin-bottom: 8px;
+              `}
+              key={idx}
+            >
+              {p}
+            </RegularText>
+          ))}
         </React.Fragment>
       )}
       <ActionSummary>

--- a/src/base/static/components/place-detail/survey.js
+++ b/src/base/static/components/place-detail/survey.js
@@ -127,6 +127,7 @@ class Survey extends Component {
 
       this.setState({
         isFormSubmitting: false,
+        showValidityStatus: false,
       });
 
       if (response) {

--- a/src/base/static/components/place-detail/survey.js
+++ b/src/base/static/components/place-detail/survey.js
@@ -128,6 +128,7 @@ class Survey extends Component {
       this.setState({
         isFormSubmitting: false,
         showValidityStatus: false,
+        formValidationErrors: new Set(),
       });
 
       if (response) {

--- a/src/base/static/models/place.ts
+++ b/src/base/static/models/place.ts
@@ -23,4 +23,5 @@ export type Support = SubmittedThing;
 
 export interface Comment extends SubmittedThing {
   comment: string;
+  submitter_name?: string;
 }

--- a/src/base/static/state/ducks/datasets-config.d.ts
+++ b/src/base/static/state/ducks/datasets-config.d.ts
@@ -29,6 +29,12 @@ export type DatasetConfig = {
     submission_set: string;
   }[];
   report?: DatasetReport;
+  placeConfirmationModal: {
+    [submissionType: string]: {
+      header: string;
+      body: string[];
+    };
+  };
 };
 
 export const hasAnonAbilitiesInAnyDataset: ({

--- a/src/base/static/state/ducks/datasets-config.js
+++ b/src/base/static/state/ducks/datasets-config.js
@@ -15,6 +15,10 @@ export const datasetReportSelector = (state, datasetSlug) =>
   state.datasetsConfig.find(datasetConfig => datasetConfig.slug === datasetSlug)
     .report;
 
+export const datasetPlaceConfirmationModalSelector = (state, datasetSlug) =>
+  state.datasetsConfig.find(datasetConfig => datasetConfig.slug === datasetSlug)
+    .placeConfirmationModal;
+
 export const datasetsConfigPropType = PropTypes.arrayOf(
   PropTypes.shape({
     url: PropTypes.string.isRequired,
@@ -84,8 +88,9 @@ export default (state = INITIAL_STATE, action) =>
       case LOAD:
         action.payload.map(datasetConfig => {
           draft.push({
-            ...datasetConfig,
+            placeConfirmationModal: {},
             url: `${API_ROOT}smartercleanup/datasets/${datasetConfig.slug}`,
+            ...datasetConfig,
           });
         });
     }

--- a/src/flavors/columbia/config.json
+++ b/src/flavors/columbia/config.json
@@ -14,7 +14,15 @@
           "abilities": ["create"],
           "submission_set": "*"
         }
-      ]
+      ],
+      "placeConfirmationModal": {
+        "privateNonAdmin": {
+          "header": "Thanks for reporting your voluntary stewardship!",
+          "body": [
+            "Your information was submitted successfully but will remain private and will not appear on the Columbia County VSP map."
+          ]
+        }
+      }
     }
   ],
   "app": {

--- a/src/flavors/defaultflavor/config.json
+++ b/src/flavors/defaultflavor/config.json
@@ -852,7 +852,7 @@
           {
             "name": "LID_master_score",
             "type": "pointInPolygon",
-            "targetUrl": "https://raw.githubusercontent.com/mapseed/data/master/scorecard.geojson",
+            "analysisTarget": "scorecard.geojson",
             "propertiesToPluck": [
               {
                 "name": "LID_Checklist_Master_score"

--- a/src/flavors/garfield/config.json
+++ b/src/flavors/garfield/config.json
@@ -14,7 +14,15 @@
           "abilities": ["create"],
           "submission_set": "*"
         }
-      ]
+      ],
+      "placeConfirmationModal": {
+        "privateNonAdmin": {
+          "header": "Thanks for reporting your voluntary stewardship!",
+          "body": [
+            "Your information was submitted successfully but will remain private and will not appear on the Garfield County VSP map."
+          ]
+        }
+      }
     }
   ],
   "app": {

--- a/src/flavors/kittitas-firewise/config.json
+++ b/src/flavors/kittitas-firewise/config.json
@@ -16,6 +16,14 @@
           "submission_set": "*"
         }
       ],
+      "placeConfirmationModal": {
+        "privateNonAdmin": {
+          "header": "Thanks for reporting your wildfire preparedness!",
+          "body": [
+            "Your information was submitted successfully but will remain private and will not appear on the Kittitas County Fire Adapted map."
+          ]
+        }
+      },
       "report": {
         "templateName": "kittitasFirewiseReport",
         "filename": "personal-wildfire-report.pdf"

--- a/src/flavors/kittitas-vsp/config.json
+++ b/src/flavors/kittitas-vsp/config.json
@@ -15,7 +15,15 @@
           "abilities": ["create"],
           "submission_set": "*"
         }
-      ]
+      ],
+      "placeConfirmationModal": {
+        "privateNonAdmin": {
+          "header": "Thanks for reporting your voluntary stewardship!",
+          "body": [
+            "Your information was submitted successfully but will remain private and will not appear on the Kittitas County VSP map."
+          ]
+        }
+      }
     }
   ],
   "app": {

--- a/src/flavors/palouse/config.json
+++ b/src/flavors/palouse/config.json
@@ -14,7 +14,15 @@
           "abilities": ["create"],
           "submission_set": "*"
         }
-      ]
+      ],
+      "placeConfirmationModal": {
+        "privateNonAdmin": {
+          "header": "Thanks for reporting your voluntary stewardship!",
+          "body": [
+            "Your information was submitted successfully but will remain private and will not appear on the Whitman County VSP map."
+          ]
+        }
+      }
     }
   ],
   "app": {

--- a/src/flavors/spokane/config.json
+++ b/src/flavors/spokane/config.json
@@ -44,7 +44,25 @@
           "abilities": ["create"],
           "submission_set": "*"
         }
-      ]
+      ],
+      "placeConfirmationModal": {
+        "nonPrivate": {
+          "header": "Thanks for reporting your voluntary stewardship!",
+          "body": [
+            "If you need to make any changes to your submission, contact Doug Phelps:",
+            "Phone: 509-535-7274 x240",
+            "Email: doug-phelps@sccd.org"
+          ]
+        },
+        "privateNonAdmin": {
+          "header": "Thanks for reporting your voluntary stewardship!",
+          "body": [
+            "Your information was submitted successfully but will remain private and will not appear on the map. If you need to make any changes to your submission, contact Doug Phelps:",
+            "Phone: 509-535-7274 x240",
+            "Email: doug-phelps@sccd.org"
+          ]
+        }
+      }
     }
   ],
   "app": {

--- a/src/flavors/spokane/config.json
+++ b/src/flavors/spokane/config.json
@@ -2704,6 +2704,7 @@
             "name": "synthetic_fertilization_yield_map",
             "type": "big_radio",
             "hidden_default": true,
+            "label": "Yield map for synthetic fertilization",
             "prompt": "Do you base your synthetic fertilizing off of a yield map?",
             "optional": true,
             "content": [
@@ -2721,6 +2722,7 @@
             "name": "synthetic_fertilization_zone_map",
             "type": "big_radio",
             "hidden_default": true,
+            "label": "Zone map for synthetic fertilization",
             "prompt": "Have you developed a zone map for synthetic fertilization?",
             "optional": true,
             "content": [
@@ -2738,6 +2740,7 @@
             "name": "organic_fertilization_yield_map",
             "type": "big_radio",
             "hidden_default": true,
+            "label": "Yield map for organic fertilization",
             "prompt": "Do you base your organic fertilizing off of a yield map?",
             "optional": true,
             "content": [
@@ -2755,6 +2758,7 @@
             "name": "organic_fertilization_zone_map",
             "type": "big_radio",
             "hidden_default": true,
+            "label": "Zone map for organic fertilization",
             "prompt": "Have you developed a zone map for organic fertilization?",
             "optional": true,
             "content": [
@@ -4172,8 +4176,7 @@
           "prompt": "Your Name",
           "type": "text",
           "name": "submitter_name",
-          "placeholder": "Name is optional",
-          "optional": true
+          "placeholder": "Name"
         },
         {
           "type": "submit",
@@ -4286,7 +4289,7 @@
       "content": [
         "<h3 id='about-page-header'>Other Projects</h3>",
         "<p>Whether you are an agricultural producer or just interested in conserving the natural resources around your home, feel free to contact us.  We offer technical assistance regardless of current funding opportunities.  Here are some examples of issues we can assist you with:</p>",
-        "<ul>",
+        "<ul style='font-size:1.1rem;line-height:1.7rem;font-style:italic;color:#555;'>",
         "<li>Streambank erosion restoration</li>",
         "<li>Fish and wildlife habitat</li>",
         "<li>Tree and shrub establishment</li>",

--- a/src/flavors/spokane/config.json
+++ b/src/flavors/spokane/config.json
@@ -1659,7 +1659,7 @@
             "type": "symbol",
             "source": "spokane-input",
             "layout": {
-              "icon-size": 0.4,
+              "icon-size": 0.3,
               "icon-anchor": "bottom",
               "icon-image": [
                 "case",
@@ -1903,7 +1903,7 @@
                 "marker-agriculture-livestock-forestry.png",
                 "marker-agriculture.png"
               ],
-              "icon-size": ["step", ["zoom"], 0.2, 11, 0.3, 16, 0.4],
+              "icon-size": ["step", ["zoom"], 0.1, 11, 0.2, 16, 0.3],
               "icon-allow-overlap": true
             }
           }
@@ -2095,7 +2095,7 @@
           },
           {
             "start_field_index": 75,
-            "end_field_index": 91,
+            "end_field_index": 92,
             "visibleLayerGroupIds": [
               "satellite",
               "spokane-input",
@@ -3974,6 +3974,12 @@
             "optional": true
           },
           {
+            "name": "private-general_questions",
+            "type": "textarea",
+            "prompt": "Do you have any questions?",
+            "optional": true
+          },
+          {
             "name": "private-landowner_name",
             "type": "text",
             "placeholder": "Your name will only be shared if you are logged in",
@@ -4035,34 +4041,13 @@
             "optional": true
           },
           {
-            "name": "allow_followup",
-            "type": "big_radio",
-            "optional": true,
-            "prompt": "May we follow up with you if we have any questions?",
-            "triggers": [
-              {
-                "value": "allow-followup",
-                "targets": [
-                  "private-landowner_email",
-                  "private-landowner_phone"
-                ]
-              }
-            ],
-            "content": [
-              {
-                "label": "Yes",
-                "value": "allow-followup"
-              },
-              {
-                "label": "No",
-                "value": "no-allow-followup"
-              }
-            ]
+            "name": "contact_info",
+            "type": "informational_html",
+            "content": "Please provide your contact information so that we may follow up with you to verify your post."
           },
           {
             "name": "private-landowner_email",
             "type": "text",
-            "hidden_default": true,
             "optional": false,
             "placeholder": "Your email address will never be shared",
             "prompt": "What is your email address?"
@@ -4235,6 +4220,11 @@
       "title": "Funding",
       "type": "internal_link",
       "url": "/page/funding"
+    },
+    {
+      "title": "Other Projects",
+      "type": "internal_link",
+      "url": "/page/other-projects"
     }
   ],
   "pages": [
@@ -4267,16 +4257,7 @@
       "slug": "funding",
       "content": [
         "<h3 id='about-page-header'>Stewardship Practices Examples and Funding Opportunities</h3>",
-        "<p>The Spokane Conservation District partners with other agencies such as the NRCS and the WSCC to match landowners with programs that best fit their needs.</p>",
-        "<p>Contact Walt Edelen or Doug Phelps with questions:</p>",
-        "<div style='margin-bottom:4px;'><span style='margin-left:16px;font-family:Raleway-ExtraBold,sans-serif;'>Walt Edelen</span></div>",
-        "<div style='margin-bottom:8px;'><span style='margin-left:16px;color:#666;font-style:italic;'>Water Resources Manager</span></div>",
-        "<div style='margin-left:16px;margin-bottom:8px;'><i style='color:#888;' class='fa fa-globe'></i><span style='margin-left:16px'>walt-edelen@sccd.org</span></div>",
-        "<div style='margin-left:16px;margin-bottom:32px;'><i style='color:#888;' class='fa fa-phone'></i><span style='margin-left:16px'>509-535-7274 x224</span></div>",
-        "<div style='margin-bottom:4px;'><span style='margin-left:16px;font-family:Raleway-ExtraBold,sans-serif;'>Doug Phelps</span></div>",
-        "<div style='margin-bottom:8px;'><span style='margin-left:16px;color:#666;font-style:italic;'>Agricultural Liaison</span></div>",
-        "<div style='margin-left:16px;margin-bottom:8px;'><i style='color:#888;' class='fa fa-globe'></i><span style='margin-left:16px'>doug-phelps@sccd.org</span></div>",
-        "<div style='margin-left:16px;margin-bottom:32px;'><i style='color:#888;' class='fa fa-phone'></i><span style='margin-left:16px'>509-535-7274 x240</span></div>",
+        "<p>The Spokane Conservation District partners with other agencies such as the NRCS and the WSCC to match landowners with programs that best fit their needs. Here are some examples:</p>",
         "<div style='display:flex;padding:8px;border-bottom:1px solid #bbb;margin-bottom:8px;'><span style='flex:1;margin-right:8px;'>Management Type</span><span style='flex:1;margin-right:8px;'>Conservation Practices</span><span style='flex:1'>NRCS Code</span><span style='flex:1'>Potential Funding</span></div>",
         "<div style='display:flex;background-color:#fff8ea;padding:8px;color:#555;'><span style='flex:1;margin-right:8px;'>Tillage</span><span style='flex:1;margin-right:8px;'>Conservation Tillage No-Till</span><span style='flex:1;margin-right:8px;'>329</span><span style='flex:1;'>$35-$50/acre (max 1,500 acres per entity)</span></div>",
         "<div style='display:flex;padding:8px;color:#555;'><span style='flex:1;margin-right:8px;'>Tillage</span><span style='flex:1;margin-right:8px;'>Conservation Tillage Mulch-Till</span><span style='flex:1;margin-right:8px;'>345</span><span style='flex:1;'>Up to $45/acre (max 1,500 acres per entity)</span></div>",
@@ -4288,7 +4269,41 @@
         "<div style='display:flex;padding:8px;color:#555;'><span style='flex:1;margin-right:8px;'>Livestock</span><span style='flex:1;margin-right:8px;'>Waste Storage Facility</span><span style='flex:1;margin-right:8px;'>313</span><span style='flex:1;'>Varies</span></div>",
         "<div style='display:flex;background-color:#fff8ea;padding:8px;color:#555;'><span style='flex:1;margin-right:8px;'>Livestock</span><span style='flex:1;margin-right:8px;'>Off Creek Watering</span><span style='flex:1;margin-right:8px;'>516/533/614/561/642</span><span style='flex:1;'>Varies</span></div>",
         "<div style='display:flex;padding:8px;color:#555;'><span style='flex:1;margin-right:8px;'>Forest</span><span style='flex:1;margin-right:8px;'>Forest Stand Improvement (thinning, pruning and slash treatment)</span><span style='flex:1;margin-right:8px;'>660/666</span><span style='flex:1;'>Typically about $1,000/acre</span></div>",
-        "<div style='display:flex;background-color:#fff8ea;padding:8px;color:#555;'><span style='flex:1;margin-right:8px;'>Forest</span><span style='flex:1;margin-right:8px;'>Tree and Shrub Establishment</span><span style='flex:1;margin-right:8px;'>612</span><span style='flex:1;'>Typically about $400/acre</span></div>"
+        "<div style='display:flex;background-color:#fff8ea;padding:8px;color:#555;'><span style='flex:1;margin-right:8px;'>Forest</span><span style='flex:1;margin-right:8px;'>Tree and Shrub Establishment</span><span style='flex:1;margin-right:8px;'>612</span><span style='flex:1;'>Typically about $400/acre</span></div>",
+        "<p style='margin-top:32px;'>Contact Walt Edelen or Doug Phelps with questions:</p>",
+        "<div style='margin-bottom:4px;'><span style='margin-left:16px;font-family:Raleway-ExtraBold,sans-serif;'>Walt Edelen</span></div>",
+        "<div style='margin-bottom:8px;'><span style='margin-left:16px;color:#666;font-style:italic;'>Water Resources Manager</span></div>",
+        "<div style='margin-left:16px;margin-bottom:8px;'><i style='color:#888;' class='fa fa-globe'></i><span style='margin-left:16px'>walt-edelen@sccd.org</span></div>",
+        "<div style='margin-left:16px;margin-bottom:32px;'><i style='color:#888;' class='fa fa-phone'></i><span style='margin-left:16px'>509-535-7274 x224</span></div>",
+        "<div style='margin-bottom:4px;'><span style='margin-left:16px;font-family:Raleway-ExtraBold,sans-serif;'>Doug Phelps</span></div>",
+        "<div style='margin-bottom:8px;'><span style='margin-left:16px;color:#666;font-style:italic;'>Agricultural Liaison</span></div>",
+        "<div style='margin-left:16px;margin-bottom:8px;'><i style='color:#888;' class='fa fa-globe'></i><span style='margin-left:16px'>doug-phelps@sccd.org</span></div>",
+        "<div style='margin-left:16px;margin-bottom:32px;'><i style='color:#888;' class='fa fa-phone'></i><span style='margin-left:16px'>509-535-7274 x240</span></div>"
+      ]
+    },
+    {
+      "slug": "other-projects",
+      "content": [
+        "<h3 id='about-page-header'>Other Projects</h3>",
+        "<p>Whether you are an agricultural producer or just interested in conserving the natural resources around your home, feel free to contact us.  We offer technical assistance regardless of current funding opportunities.  Here are some examples of issues we can assist you with:</p>",
+        "<ul>",
+        "<li>Streambank erosion restoration</li>",
+        "<li>Fish and wildlife habitat</li>",
+        "<li>Tree and shrub establishment</li>",
+        "<li>Urban/Homesite forestry</li>",
+        "<li>Smartscape</li>",
+        "<li>Septic assistance</li>",
+        "<li>Soil Health</li>",
+        "</ul>",
+        "<p style='margin-top:32px;'>Contact Walt Edelen or Doug Phelps with questions:</p>",
+        "<div style='margin-bottom:4px;'><span style='margin-left:16px;font-family:Raleway-ExtraBold,sans-serif;'>Walt Edelen</span></div>",
+        "<div style='margin-bottom:8px;'><span style='margin-left:16px;color:#666;font-style:italic;'>Water Resources Manager</span></div>",
+        "<div style='margin-left:16px;margin-bottom:8px;'><i style='color:#888;' class='fa fa-globe'></i><span style='margin-left:16px'>walt-edelen@sccd.org</span></div>",
+        "<div style='margin-left:16px;margin-bottom:32px;'><i style='color:#888;' class='fa fa-phone'></i><span style='margin-left:16px'>509-535-7274 x224</span></div>",
+        "<div style='margin-bottom:4px;'><span style='margin-left:16px;font-family:Raleway-ExtraBold,sans-serif;'>Doug Phelps</span></div>",
+        "<div style='margin-bottom:8px;'><span style='margin-left:16px;color:#666;font-style:italic;'>Agricultural Liaison</span></div>",
+        "<div style='margin-left:16px;margin-bottom:8px;'><i style='color:#888;' class='fa fa-globe'></i><span style='margin-left:16px'>doug-phelps@sccd.org</span></div>",
+        "<div style='margin-left:16px;margin-bottom:32px;'><i style='color:#888;' class='fa fa-phone'></i><span style='margin-left:16px'>509-535-7274 x240</span></div>"
       ]
     }
   ],

--- a/src/flavors/spokane/config.json
+++ b/src/flavors/spokane/config.json
@@ -4065,7 +4065,7 @@
           {
             "name": "contact_info",
             "type": "informational_html",
-            "content": "Please provide your contact information so that we may follow up with you to verify your post."
+            "content": "<p style='margin:8px 8px 0 8px;font-size:1.1rem;font-style:italic;'>Please provide your contact information so that we may follow up with you to verify your post.</p>"
           },
           {
             "name": "private-landowner_email",
@@ -4077,7 +4077,6 @@
           {
             "name": "private-landowner_phone",
             "type": "text",
-            "hidden_default": true,
             "prompt": "What is your phone number?",
             "placeholder": "Your phone number will never be shared",
             "optional": true

--- a/src/flavors/spokane/static/css/custom.css
+++ b/src/flavors/spokane/static/css/custom.css
@@ -59,6 +59,8 @@ header {
 [data-field-name="other_practices_description"],
 [data-field-name="title"],
 [data-field-name="practices_description"],
+[data-field-name="private-general_questions"],
+[data-field-name="contact_info"],
 [data-field-name="stewardship_difficulties"],
 [data-field-name="private-landowner_name"],
 [data-field-name="other_buffer_type"],
@@ -79,7 +81,10 @@ header {
 [data-field-name="acres_farmed"],
 [data-field-name="years_farming"],
 [data-field-name="practices_description"],
+[data-field-name="contact_info"],
 [data-field-name="stewardship_difficulties"],
+[data-field-name="private-general_questions"],
+[data-field-name="private"],
 [data-field-name="private-landowner_name"] {
   margin-top: 15px !important;
 }

--- a/src/locales/en/InputForm.json
+++ b/src/locales/en/InputForm.json
@@ -1,6 +1,3 @@
 {
-  "validationHeader": "Your post is looking good, but we need some more information before we can proceed.",
-  "privateSubmissionModalHeader": "Thank you!",
-  "privateSubmissionModalBodyNonAdmin": "Your information was submitted successfully, and will remain private.",
-  "privateSubmissionModalBodyAdmin": "Your information was submitted successfully as a validated administrator of this site. It will be visible to you and other administrators, but will remain hidden for other users."
+  "validationHeader": "Your post is looking good, but we need some more information before we can proceed."
 }


### PR DESCRIPTION
Updates to the `spokane` flavor.

Also a couple of miscellaneous improvements:
* maintain line breaks in detail views (by splitting on `\n` characters and rendering separate blocks of text)
* allow custom text to be injected into the modal that appears after private Places are submitted
  * because we have a couple of use cases for these post-submission modals, I made it possible to configure the language on a flavor-by-flavor basis for three conditions:
    1. private submissions by admins
    2. private submissions by non-admins
    3. public (aka "non-private") submissions
  * this allows us to confirm private submissions, provide general followup information upon submission, etc.