### PR TITLE
feat(FilterSliders): enable multiple filter sliders

### DIFF
--- a/src/base/static/components/molecules/map-filter-slider.tsx
+++ b/src/base/static/components/molecules/map-filter-slider.tsx
@@ -56,6 +56,7 @@ const MapFilterSlider: React.FunctionComponent = () => {
         property: config.property,
         updateLayerFilters: filters => dispatch(updateLayerFilters(filters)),
       });
+      setSliderValue(config.initialValue);
     }
   }, [dispatch, layerGroups, config]);
 

--- a/src/base/static/state/ducks/map-style.d.ts
+++ b/src/base/static/state/ducks/map-style.d.ts
@@ -5,21 +5,6 @@ type MapseedGeometry = Point | LineString | Polygon;
 
 export const mapViewportPropType: any;
 
-export type FilterSlider = {
-  initialValue?: number;
-  min: number;
-  max: number;
-  step?: number;
-  label?: string;
-  property: string;
-  comparator: string;
-};
-
-export type FilterableLayerGroup = {
-  layerIds: string[];
-  filterSlider: FilterSlider;
-};
-
 export type MapContainerDimensions = {
   width: number;
   height: number;
@@ -51,8 +36,6 @@ export type LegendItem = {
 export type LayerGroup = {
   id: string;
   popupContent: string;
-  // TODO: move this into it's own MapWidget config
-  filterSlider?: FilterSlider;
   isBasemap: boolean;
   isVisible: boolean;
   isVisibleDefault: boolean;

--- a/src/base/static/state/ducks/map.d.ts
+++ b/src/base/static/state/ducks/map.d.ts
@@ -63,7 +63,7 @@ export type RadioMenuConfig = {
 };
 
 export type MapWidgetsConfig = {
-  filterSlider?: MapFilterSliderConfig;
+  filterSlider?: MapFilterSliderConfig[];
   radioMenu?: RadioMenuConfig;
 };
 
@@ -106,7 +106,7 @@ export const mapWidgetsSelector: any;
 export const isWithMapFilterSliderSelector: (state: any) => boolean;
 export const mapFilterSliderConfigSelector: (
   state: any,
-) => MapFilterSliderConfig;
+) => MapFilterSliderConfig[];
 export const mapRadioMenuConfigSelector: (state: any) => RadioMenuConfig;
 export const isWithMapRadioMenuSelector: (state: any) => boolean;
 export const measurementToolEnabledSelector: any;

--- a/src/base/static/state/ducks/map.js
+++ b/src/base/static/state/ducks/map.js
@@ -44,9 +44,10 @@ export const mapWidgetsSelector = state => {
   return state.map.mapWidgets;
 };
 export const mapFilterSliderConfigSelector = state =>
-  state.map.mapWidgets.filterSlider;
+  state.map.mapWidgets.filterSliders;
 export const isWithMapFilterSliderSelector = state =>
-  !!state.map.mapWidgets.filterSlider;
+  state.map.mapWidgets.filterSliders &&
+  state.map.mapWidgets.filterSliders.length > 0;
 export const mapRadioMenuConfigSelector = state =>
   state.map.mapWidgets.radioMenu;
 export const isWithMapRadioMenuSelector = state =>

--- a/src/flavors/kittitas-firewise/config.json
+++ b/src/flavors/kittitas-firewise/config.json
@@ -458,16 +458,18 @@
       "maxZoom": 18
     },
     "mapWidgets": {
-      "filterSlider": {
-        "layerGroupId": "wa-state-large-fires-1973-2018-100-acres-plus",
-        "initialValue": 2018,
-        "min": 1973,
-        "max": 2018,
-        "step": 1,
-        "label": "Large wildfires to date:",
-        "property": "YEAR",
-        "comparator": "<="
-      }
+      "filterSlider": [
+        {
+          "layerGroupId": "wa-state-large-fires-1973-2018-100-acres-plus",
+          "initialValue": 2018,
+          "min": 1973,
+          "max": 2018,
+          "step": 1,
+          "label": "Large wildfires to date:",
+          "property": "YEAR",
+          "comparator": "<="
+        }
+      ]
     }
   },
   "mapStyle": {

--- a/src/flavors/kittitas-firewise/config.json
+++ b/src/flavors/kittitas-firewise/config.json
@@ -458,7 +458,7 @@
       "maxZoom": 18
     },
     "mapWidgets": {
-      "filterSlider": [
+      "filterSliders": [
         {
           "layerGroupId": "wa-state-large-fires-1973-2018-100-acres-plus",
           "initialValue": 2018,

--- a/src/flavors/mississippi/config.json
+++ b/src/flavors/mississippi/config.json
@@ -203,27 +203,29 @@
           }
         ]
       },
-      "filterSlider": {
-        "layerGroupId": "nuclear-plants-timeslider-group",
-        "initialValue": 1944,
-        "min": 1941,
-        "max": 2019,
-        "step": 1,
-        "label": "The nuclear complex in",
-        "property": "date",
-        "comparator": "<="
-      },
+      "filterSliders": [
+        {
+          "layerGroupId": "nuclear-plants-timeslider-group",
+          "initialValue": 1944,
+          "min": 1941,
+          "max": 2019,
+          "step": 1,
+          "label": "The nuclear complex in",
+          "property": "date",
+          "comparator": "<="
+        },
 
-      "filterSlider": {
-        "layerGroupId": "platforms-timeslider-group",
-        "initialValue": 1947,
-        "min": 1947,
-        "max": 2019,
-        "step": 1,
-        "label": "Offshore oil rigs:",
-        "property": "Date",
-        "comparator": "<="
-      }
+        {
+          "layerGroupId": "platforms-timeslider-group",
+          "initialValue": 1947,
+          "min": 1947,
+          "max": 2019,
+          "step": 1,
+          "label": "Offshore oil rigs:",
+          "property": "Date",
+          "comparator": "<="
+        }
+      ]
     }
   },
   "mapStyle": {


### PR DESCRIPTION
Allows us to configure multiple filter sliders, which will continue to be displayed depending on which layer group is visible.