### PR TITLE
fix(base.hbs): add missing mapbox css link

### DIFF
--- a/src/base/templates/base.hbs
+++ b/src/base/templates/base.hbs
@@ -19,6 +19,7 @@
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/static/css/images/apple-touch-icon-72x72-precomposed.png">
     <link rel="apple-touch-icon-precomposed" href="/static/css/images/apple-touch-icon-precomposed.png">
     <link rel="stylesheet" href="https://assets.mapseed.org/font-awesome/css/all.min.css">
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
 
     <!-- webfonts -->
     <link href="https://assets.mapseed.org/font-awesome/webfonts/fa-solid-900.woff2" rel="preload" as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
Fixes this warning:
```
This page appears to be missing CSS declarations for Mapbox GL JS, which may cause the map to display incorrectly. Please ensure your page includes mapbox-gl.css
```