### PR TITLE
Goldpbear/mywater

### DIFF
--- a/src/flavors/central-puget-sound/config.json
+++ b/src/flavors/central-puget-sound/config.json
@@ -75,7 +75,7 @@
       "hydrography": {
         "type": "raster",
         "tiles": [
-          "https://geo.mapseed.org/hydrography/?service=wms&request=getmap&format=image/png&version=1.3.0&crs=EPSG:3857&transparent=false&layers=0&bbox={bbox-epsg-3857}&width=256&height=256&styles=default"
+          "https://geo.mapseed.org/hydrography/?service=wms&request=getmap&format=image/png&version=1.3.0&crs=EPSG:3857&transparent=false&layers=0&bbox={bbox-epsg-3857}&width=256&height=256&styles=default&z={z}&x={x}&y={y}"
         ],
         "tileSize": 256
       },

--- a/src/sw.js
+++ b/src/sw.js
@@ -195,14 +195,6 @@ workbox.routing.registerRoute(
   "GET",
 );
 
-// This plugin strips the `bbox` query param from requests.
-// The bbox param tends to have very high decimal precision, so it resuts in
-// numerous cache misses.
-// Since the bbox param is being stripped, it's important that urls supply an
-// alternative query param(s) to distringuish request. One option is to supply
-// the `z`, `x`, and `y` params.
-// For example:
-// https://geo.mapseed.org/hydrography/?service=wms&request=getmap&format=image/png&version=1.3.0&crs=EPSG:3857&transparent=false&layers=0&bbox={bbox-epsg-3857}&width=256&height=256&styles=default&z={z}&x={x}&y={y}
 workbox.routing.registerRoute(
   /^https:\/\/vector-tiles.mapseed.org\//,
   new workbox.strategies.StaleWhileRevalidate({
@@ -216,7 +208,14 @@ workbox.routing.registerRoute(
   "GET",
 );
 
-// This
+// This plugin strips the `bbox` query param from requests.
+// The bbox param tends to have very high decimal precision, so it resuts in
+// numerous cache misses.
+// Since the bbox param is being stripped, it's important that urls supply an
+// alternative query param(s) to distringuish request. One option is to supply
+// the `z`, `x`, and `y` params.
+// For example:
+// https://geo.mapseed.org/hydrography/?service=wms&request=getmap&format=image/png&version=1.3.0&crs=EPSG:3857&transparent=false&layers=0&bbox={bbox-epsg-3857}&width=256&height=256&styles=default&z={z}&x={x}&y={y}
 const cacheKeyWillBeUsed = ({ request, mode }) => {
   const splitUrl = request.url.split("?");
 
@@ -231,7 +230,10 @@ const cacheKeyWillBeUsed = ({ request, mode }) => {
     }, {});
     const { bbox, ...keep } = parsed;
 
-    return `${splitUrl[0]}?${JSON.stringify(keep)}`;
+    return `${splitUrl[0]}?${(Object.entries(keep).reduce(
+      (memo, [key, val]) => `${memo}&${key}=${val}`,
+    ),
+    "")}`;
   }
 
   return request;

--- a/src/sw.js
+++ b/src/sw.js
@@ -195,6 +195,14 @@ workbox.routing.registerRoute(
   "GET",
 );
 
+// This plugin strips the `bbox` query param from requests.
+// The bbox param tends to have very high decimal precision, so it resuts in
+// numerous cache misses.
+// Since the bbox param is being stripped, it's important that urls supply an
+// alternative query param(s) to distringuish request. One option is to supply
+// the `z`, `x`, and `y` params.
+// For example:
+// https://geo.mapseed.org/hydrography/?service=wms&request=getmap&format=image/png&version=1.3.0&crs=EPSG:3857&transparent=false&layers=0&bbox={bbox-epsg-3857}&width=256&height=256&styles=default&z={z}&x={x}&y={y}
 workbox.routing.registerRoute(
   /^https:\/\/vector-tiles.mapseed.org\//,
   new workbox.strategies.StaleWhileRevalidate({
@@ -208,6 +216,7 @@ workbox.routing.registerRoute(
   "GET",
 );
 
+// This
 const cacheKeyWillBeUsed = ({ request, mode }) => {
   const splitUrl = request.url.split("?");
 

--- a/src/sw.js
+++ b/src/sw.js
@@ -208,11 +208,32 @@ workbox.routing.registerRoute(
   "GET",
 );
 
+const cacheKeyWillBeUsed = ({ request, mode }) => {
+  const splitUrl = request.url.split("?");
+
+  if (splitUrl[1]) {
+    const parsed = splitUrl[1].split("&").reduce((memo, param) => {
+      const qsItem = param.split("=");
+
+      return {
+        ...memo,
+        [qsItem[0]]: qsItem[1],
+      };
+    }, {});
+    const { bbox, ...keep } = parsed;
+
+    return `${splitUrl[0]}?${JSON.stringify(keep)}`;
+  }
+
+  return request;
+};
+
 workbox.routing.registerRoute(
   /^https:\/\/geo.mapseed.org\//,
   new workbox.strategies.StaleWhileRevalidate({
     cacheName: TILE_CACHE_NAME,
     plugins: [
+      { cacheKeyWillBeUsed },
       new workbox.expiration.Plugin({
         maxAgeSeconds: TILE_CACHE_EXPIRATION,
       }),

--- a/src/sw.js
+++ b/src/sw.js
@@ -212,8 +212,8 @@ workbox.routing.registerRoute(
 // The bbox param tends to have very high decimal precision, so it resuts in
 // numerous cache misses.
 // Since the bbox param is being stripped, it's important that urls supply an
-// alternative query param(s) to distringuish request. One option is to supply
-// the `z`, `x`, and `y` params.
+// alternative query param(s) to distinguish the request.
+// One option is to supply the `z`, `x`, and `y` params.
 // For example:
 // https://geo.mapseed.org/hydrography/?service=wms&request=getmap&format=image/png&version=1.3.0&crs=EPSG:3857&transparent=false&layers=0&bbox={bbox-epsg-3857}&width=256&height=256&styles=default&z={z}&x={x}&y={y}
 const cacheKeyWillBeUsed = ({ request, mode }) => {

--- a/src/sw.js
+++ b/src/sw.js
@@ -230,10 +230,14 @@ const cacheKeyWillBeUsed = ({ request, mode }) => {
     }, {});
     const { bbox, ...keep } = parsed;
 
-    return `${splitUrl[0]}?${(Object.entries(keep).reduce(
+    const foo = `${splitUrl[0]}?${Object.entries(keep).reduce(
       (memo, [key, val]) => `${memo}&${key}=${val}`,
-    ),
-    "")}`;
+      "",
+    )}`;
+
+    console.log({ foo });
+
+    return foo;
   }
 
   return request;

--- a/src/sw.js
+++ b/src/sw.js
@@ -230,14 +230,10 @@ const cacheKeyWillBeUsed = ({ request, mode }) => {
     }, {});
     const { bbox, ...keep } = parsed;
 
-    const foo = `${splitUrl[0]}?${Object.entries(keep).reduce(
+    return `${splitUrl[0]}?${Object.entries(keep).reduce(
       (memo, [key, val]) => `${memo}&${key}=${val}`,
       "",
     )}`;
-
-    console.log({ foo });
-
-    return foo;
   }
 
   return request;


### PR DESCRIPTION
This PR strips the `bbox` query param from sw cache requests to the `geo.mapseed.org` route, to improve cache hits.